### PR TITLE
Update the docker-compose configuration to fix building issues

### DIFF
--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -3,8 +3,8 @@ FROM python:3.8
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED 1
 
-# Install a specific version of docker
-RUN apt-get update && curl -sSL https://get.docker.com/ | sed 's/docker-ce/docker-ce=18.03.0~ce-0~debian/' | sh
+# Install Docker
+RUN apt-get update && curl -fsSL https://get.docker.com | sh
 
 ADD docker/compute_worker/compute_worker_requirements.txt .
 RUN pip install -r compute_worker_requirements.txt

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -14,4 +14,4 @@ services:
       - ./artifacts:/artifacts/:z
     ports:
       - 4444:4444
-      - 5900:5900
+      - 5904:5900


### PR DESCRIPTION
# Fix CircleCi containers building

* Change how Docker is installed in `Dockerfile.compute_worker`

* Change the port of selemium in `docker-compose.selenium.yml` from 5900 to 5904 to avoid `bind: address already in use` error 

This fixes the "building containers" part of the workflow.