### PR TITLE
Leaderboard v2 comp fixes

### DIFF
--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -734,7 +734,7 @@ class Run:
         elif os.path.exists(os.path.join(self.output_dir, "scores.txt")):
             scores_file = os.path.join(self.output_dir, "scores.txt")
             with open(scores_file) as f:
-                scores = yaml.load(f)
+                scores = yaml.load(f, yaml.Loader)
         else:
             raise SubmissionException("Could not find scores file, did the scoring program output it?")
 

--- a/src/apps/api/serializers/leaderboards.py
+++ b/src/apps/api/serializers/leaderboards.py
@@ -128,7 +128,7 @@ class LeaderboardPhaseSerializer(serializers.ModelSerializer):
         if len(columns) == 0:
             raise serializers.ValidationError("No columns exist on the leaderboard")
         else:
-            return ColumnSerializer(columns, many=len(columns) > 1).data
+            return ColumnSerializer(columns, many=len(columns) >= 1).data
 
     class Meta:
         model = Phase


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo, @Tthomas63 


# A brief description of the purpose of the changes contained in this PR.
This PR is for getting the leaderboard to show results from submissions


# Issues this PR resolves
When loading the main page for a competition, codabench also loads the leaderboard. There were two issues:
* compute_worker.py: The yaml loader that parses the leaderboard scores needed a "yaml.Loader" argument as well as the file object.
* leaderboards.py: had a column serializer that was only returning leaderboards for competitions with more than one metric. I changed so that it accepts 1 or more metrics. 


# A checklist for hand testing
- [x] upload comp
- [x] make submission
- [x] add results to leaderboard
- [x] check leaderboard for results


# Any relevant files for testing
* Compute Pi: https://github.com/codalab/competition-examples/tree/master/basic-competition-bundles/Compute_pi
* Iris: https://github.com/codalab/competition-examples/tree/master/basic-competition-bundles/Iris

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

