### PR TITLE
text/html content header for detailed_results.html or *.html files

### DIFF
--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -261,7 +261,7 @@ class Run:
 
     async def send_detailed_results(self, file_path):
         logger.info(f"Updating detailed results {file_path} - {self.detailed_results_url}")
-        self._put_file(self.detailed_results_url, file=file_path, content_type='')
+        self._put_file(self.detailed_results_url, file=file_path, content_type='text/html')
         async with websockets.connect(self.websocket_url) as websocket:
             await websocket.send(json.dumps({
                 "kind": 'detailed_result_update',

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -142,7 +142,7 @@ def _send_to_compute_worker(submission, is_scoring):
             run_args['detailed_results_url'] = make_url_sassy(
                 path=submission.detailed_result.name,
                 permission='w',
-                content_type=''
+                content_type='text/html'
             )
         run_args['prediction_result'] = make_url_sassy(
             path=submission.prediction_result.name,


### PR DESCRIPTION
# Content Type Update For Detailed Results HTML Files

# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Detailed results html files weren't showing in the VISUALIZATION tab when viewing a submission's results. 

The content-type of the html file was being saved as "binary/octet-stream". This link will retrieve the detailed_results.html if you search it in the URL search in a browser as this content-type allows for that. The link to the minio location is embedded in the html in an iframe on the VISUALIZATION tab however and this causes the html to not be rendered. 


# A checklist for hand testing
- [ ] Upload IRIS (warning the old IRIS has a yaml bug in the scoring program requiring you to add yaml.Loader as an argument) or Hello World or any challenge that has the scoring program generate *.html detailed results files. 
- [ ] Make submission
- [ ] Check the VISUALIZATION tab for results

![image](https://user-images.githubusercontent.com/7649007/187590871-abff04a2-6378-427e-9cce-fcfb4e7ff610.png)



# Any relevant files for testing

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

