### PR TITLE
Fix broker URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     env_file: .env
     environment:
-      - BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//
+      - BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${DOMAIN_NAME}:${RABBITMQ_PORT}//
       # Make the worker leave behind the submission so we can examine it
       - CODALAB_IGNORE_CLEANUP_STEP=1
     logging:

--- a/src/apps/queues/models.py
+++ b/src/apps/queues/models.py
@@ -32,7 +32,7 @@ class Queue(models.Model):
     def broker_url(self):
         # host = Site.objects.get_current().domain
         if self.owner:
-            return f"pyamqp://{self.owner.rabbitmq_username}:{self.owner.rabbitmq_password}@{settings.RABBITMQ_HOST}:{settings.RABBITMQ_PORT}/{self.vhost}"
+            return f"pyamqp://{self.owner.rabbitmq_username}:{self.owner.rabbitmq_password}@{settings.DOMAIN_NAME}:{settings.RABBITMQ_PORT}/{self.vhost}"
 
     def delete(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Fix for https://github.com/codalab/codabench/issues/690

**There are also the following changes, not shown for some reason\*:**

**https://github.com/codalab/codabench/pull/726/files**

_*I have done a merge and revert by mistake, so the history thinks these commits are already merged._

---

Error in production when trying to create a queue, apparently due to the firewall configuration:

```
requests.exceptions.ConnectTimeout: HTTPConnectionPool(host='www.codabench.org', port=15672): Max retries exceeded with url: /api/users/26df2d3e-345e-472b-9d41-6e1ae58c4202 (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7fe68516c4f0>, 'Connection to www.codabench.org timed out. (connect timeout=5)'))
```

---

Summary of changes:

- Added "DOMAIN_NAME" variable in `settings/base.py`
- RABBITMQ_HOST -> DOMAIN_NAME in `queues/models.py`
- RABBITMQ_HOST -> DOMAIN_NAME in `docker-compose.yml` **not sure if needed?**
- RABBITMQ_HOST -> DOMAIN_NAME in `queues/rabbit.py`        **not sure if needed?**