### PR TITLE
Use domain name in broker URL when creating a queue

### DIFF
--- a/src/apps/queues/models.py
+++ b/src/apps/queues/models.py
@@ -32,7 +32,7 @@ class Queue(models.Model):
     def broker_url(self):
         # host = Site.objects.get_current().domain
         if self.owner:
-            return f"pyamqp://{self.owner.rabbitmq_username}:{self.owner.rabbitmq_password}@{settings.RABBITMQ_HOST}:{settings.RABBITMQ_PORT}/{self.vhost}"
+            return f"pyamqp://{self.owner.rabbitmq_username}:{self.owner.rabbitmq_password}@{settings.DOMAIN_NAME}:{settings.RABBITMQ_PORT}/{self.vhost}"
 
     def delete(self, *args, **kwargs):
         try:

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -17,6 +17,7 @@ USE_X_FORWARDED_HOST = True
 SITE_ID = 1
 
 SITE_DOMAIN = os.environ.get('SITE_DOMAIN', 'http://localhost')
+DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost').split(':')[0]
 
 THIRD_PARTY_APPS = (
     'django_su',  # Must come before django.contrib.admin


### PR DESCRIPTION
Fix for https://github.com/codalab/codabench/issues/690

The right one :-)