### PR TITLE
Issue 733 - Manual comp creation now will save leaderboard

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -129,6 +129,23 @@ class CompetitionViewSet(ModelViewSet):
             for index in range(len(phase['tasks'])):
                 phase['tasks'][index] = phase['tasks'][index]['task']
 
+        # TODO - This is Temporary. Need to change Leaderboard to Phase connect to M2M and handle this correctly.
+        # save leaderboard individually, then pass pk to each phase
+        print(f"{request.data['leaderboards']}")
+        data = request.data
+        if 'leaderboards' in data:
+            leaderboard_data = data['leaderboards'][0]
+            if(leaderboard_data['id']):
+                leaderboard_instance = Leaderboard.objects.get(id=leaderboard_data['id'])
+                leaderboard = LeaderboardSerializer(leaderboard_instance, data=data['leaderboards'][0])
+            else:
+                leaderboard = LeaderboardSerializer(data=data['leaderboards'][0])
+            leaderboard.is_valid()
+            leaderboard.save()
+            leaderboard_id = leaderboard["id"].value
+            for phase in data['phases']:
+                phase['leaderboard'] = leaderboard_id
+
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -129,7 +129,6 @@ class CompetitionViewSet(ModelViewSet):
             for index in range(len(phase['tasks'])):
                 phase['tasks'][index] = phase['tasks'][index]['task']
 
-        # TODO - This is Temporary. Need to change Leaderboard to Phase connect to M2M and handle this correctly.
         # save leaderboard individually, then pass pk to each phase
         print(f"{request.data['leaderboards']}")
         data = request.data


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 
@Tthomas63 


# A brief description of the purpose of the changes contained in this PR.
Upon manual UI challenge creation, the leaderboard isn't saved.


# Issues this PR resolves
733 (https://github.com/codalab/codabench/issues/733)


# Known issues to be addressed in a separate PR
N/A


# A checklist for hand testing
- [ ] Make a challenge using the form in the UI and don't forget to create a leaderboard.
- [ ] Next once competition is created, go to edit and make sure the leaderboard you created still exists.
- [ ] Also go to results tab and make sure you can see the leaderboard.


# Any relevant files for testing
N/A


# Misc. comments
I'm worried that this fix and the underlying code I copied or updating a challenge is not what the original creators wanted. See this comment above the code I copied: https://github.com/codalab/codabench/blob/73cacee18a72ffa129938098b9b341d6b807759a/src/apps/api/views/competitions.py#L148.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge

