### PR TITLE
Compute worker: catch the case where metadata is empty

### DIFF
--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM --platform=linux/amd64 python:3.8
 
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED 1

--- a/Dockerfile.compute_worker_gpu
+++ b/Dockerfile.compute_worker_gpu
@@ -1,4 +1,4 @@
-FROM python:3.8.1-buster
+FROM --platform=linux/amd64 python:3.8.1-buster
 
 # We need curl to get docker/nvidia-docker
 RUN apt-get update &&  apt-get install curl wget -y

--- a/Dockerfile.compute_worker_gpu
+++ b/Dockerfile.compute_worker_gpu
@@ -6,8 +6,8 @@ RUN apt-get update &&  apt-get install curl wget -y
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED 1
 
-# Install a specific version of docker
-RUN curl -sSL https://get.docker.com/ | sed 's/docker-ce/docker-ce=18.03.0~ce-0~debian/' | sh
+# Install Docker
+RUN apt-get update && curl -fsSL https://get.docker.com | sh
 
 # nvidia-docker jazz
 RUN curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -

--- a/docker/compute_worker/compute_worker.py
+++ b/docker/compute_worker/compute_worker.py
@@ -484,7 +484,7 @@ class Run:
         with open(os.path.join(program_dir, metadata_path), 'r') as metadata_file:
             metadata = yaml.load(metadata_file.read(), Loader=yaml.FullLoader)
             logger.info(f"Metadata contains:\n {metadata}")
-            command = metadata.get("command")
+            command = metadata.get("command") if metadata is not None else None # in case the file exists but is empty
             if not command and kind == "ingestion":
                 raise SubmissionException("Program directory missing 'command' in metadata")
             elif not command:


### PR DESCRIPTION
To solve this error:

```python
[2022-11-16 12:04:20,291: INFO/ForkPoolWorker-1] Metadata path is /codabench/tmpvcrq013_/program/metadata
[2022-11-16 12:04:20,291: INFO/ForkPoolWorker-1] Metadata contains:
 None
[2022-11-16 12:04:20,291: INFO/ForkPoolWorker-1] Metadata path is /codabench/tmpvcrq013_/ingestion_program/metadata
[2022-11-16 12:04:20,292: INFO/ForkPoolWorker-1] Metadata contains:
 {'command': 'python $ingestion_program/ingestion.py --input_data_dir=$input --output_dir_ingestion=$output --submission_dir=$submission_program --test_tasks_per_dataset=100 --seed=93 --verbose=True --debug_mode=0 --overwrite_previous_results=True'}
[...]
[2022-11-16 12:04:22,657: ERROR/ForkPoolWorker-1] Task compute_worker_run[47e63c6b-996f-4dde-8652-999fbda64efb] raised unexpected: AttributeError("'NoneType' object has no attribute 'get'")
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 650, in __protected_call__
    return self.run(*args, **kwargs)
  File "/compute_worker.py", line 84, in run_wrapper
    run.start()
  File "/compute_worker.py", line 675, in start
    loop.run_until_complete(gathered_tasks)
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 612, in run_until_complete
    return future.result()
  File "/compute_worker.py", line 487, in _run_program_directory
    command = metadata.get("command")
AttributeError: 'NoneType' object has no attribute 'get'
```