### PR TITLE
Remove chahub button from the GUI

### DIFF
--- a/src/templates/registration/login.html
+++ b/src/templates/registration/login.html
@@ -9,14 +9,6 @@
     <div class="ui stacked segment">
         <form class="ui form" method="POST">
             {% csrf_token %}
-
-            <div class="field">
-                <a class="ui fluid basic button" href="{% url 'social:begin' 'chahub' %}">Log in with ChaHub</a>
-            </div>
-            <div class="ui horizontal divider form-divider-line">
-                <span class="form-divider-words">or</span>
-            </div>
-
             {% if form.non_field_errors %}
             <div class="ui red message">
                 {{ form.non_field_errors }}

--- a/src/templates/registration/signup.html
+++ b/src/templates/registration/signup.html
@@ -14,17 +14,6 @@
     <div class="ui stacked segment">
         <form class="ui form" method="post">
             {% csrf_token %}
-
-            <div class="field">
-                <a class="ui fluid button" href="{% url 'social:begin' 'chahub' %}">Sign up with ChaHub</a>
-            </div>
-            <div class="field">
-                <a class="ui fluid basic button" href="{{ chahub_signup_url }}" target="_blank">Create a ChaHub
-                    Account</a>
-            </div>
-            <div class="ui horizontal divider form-divider-line">
-                <span class="form-divider-words">Or</span>
-            </div>
             <div class="field">
                 <div class="ui left icon input">
                     <i class="user icon"></i>


### PR DESCRIPTION
Issue in question:

- #781

At some point we may want to make the ChaHub signup and login work, but for now removing the buttons is the quickest way of having a cleaner platform.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

