### PR TITLE
Wait until MinIO is up before proceeding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       /bin/sh -c "
       set -x
       while ! nc -z minio 9000; echo 'Waiting for minio to startup...' && sleep 0.1; sleep 3;
-      /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY;
+      until (/usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc mb minio_docker/$AWS_STORAGE_BUCKET_NAME;
       /usr/bin/mc mb minio_docker/$AWS_STORAGE_PRIVATE_BUCKET_NAME;
       /usr/bin/mc policy set download minio_docker/$AWS_STORAGE_BUCKET_NAME;


### PR DESCRIPTION
Fix bugs mentionned in #771

```python
codabench-createbuckets-1   | Waiting for minio to startup...
codabench-createbuckets-1   | + echo 'Waiting for minio to startup...'
codabench-createbuckets-1   | + sleep 0.1
codabench-createbuckets-1   | + sleep 3
codabench-createbuckets-1   | + /usr/bin/mc config host add minio_docker http://minio:9000 testkey testsecret
codabench-createbuckets-1   | mc: <ERROR> Unable to initialize new alias from the provided credentials. Server not initialized, please try again.
codabench-createbuckets-1   | + /usr/bin/mc mb minio_docker/public
codabench-flower-1          | Traceback (most recent call last):
codabench-createbuckets-1   | Bucket created successfully `minio_docker/public`.
codabench-createbuckets-1   | + /usr/bin/mc mb minio_docker/private
codabench-createbuckets-1   | Bucket created successfully `minio_docker/private`.
codabench-createbuckets-1   | + /usr/bin/mc policy set download minio_docker/public
codabench-createbuckets-1   | mc: Please use 'mc anonymous'
```