### PR TITLE
Add checkbox for terms and conditions

### DIFF
--- a/src/templates/registration/signup.html
+++ b/src/templates/registration/signup.html
@@ -87,6 +87,11 @@
             </div>
             {% endif %}
 
+            <div>
+                <input type="checkbox" name="checkbox" id="id_checkbox" required>
+                <label for="id_checkbox">I accept the <a href="https://github.com/codalab/codalab-competitions/wiki/Privacy" target="_blank">terms and conditions</a>.</label>
+            </div>
+
             <button class="ui blue fluid submit button" type="submit">Sign Up</button>
         </form>
         <div class="ui divider"></div>


### PR DESCRIPTION
As mentioned in #759

To test it:

- Click on "signup"
- Confirm that there is a checkbox "I accept the terms and conditions" with a link to the TOS
- Try to signup without checking the box: it should not be allowed
- Try to signup checking the box: it should work

Maybe we'll need to add an action in the tests so it check the box?