### PR TITLE
Submission detailed results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ docker-compose.override.yml
 server_config.yaml
 /graphs/
 /codabench/
+
+.DS_Store
+.DS_Store?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,8 @@ services:
           memory: 256M
 
   compute_worker:
-    command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
+    # command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
+    command: bash -c "celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
     working_dir: /app
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,8 +192,7 @@ services:
           memory: 256M
 
   compute_worker:
-    # command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
-    command: bash -c "celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
+    command: bash -c "watchmedo auto-restart -p '*.py' --recursive -- celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"
     working_dir: /app
     build:
       context: .

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -474,6 +474,7 @@ class PhaseViewSet(ModelViewSet):
             if submission_key not in submissions_keys:
                 submissions_keys[submission_key] = len(response['submissions'])
                 response['submissions'].append({
+                    'id' : submission['id'],
                     'owner': submission['display_name'] or submission['owner'],
                     'scores': [],
                     'fact_sheet_answers': submission['fact_sheet_answers'],

--- a/src/apps/competitions/urls.py
+++ b/src/apps/competitions/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('edit/<int:pk>/', views.CompetitionForm.as_view(), name="edit"),
     path('upload/', views.CompetitionUpload.as_view(), name="upload"),
     path('public/', views.CompetitionPublic.as_view(), name="public"),
+    path('<int:pk>/detailed_results/<int:submission_id>/', views.CompetitionDetailedResults.as_view(), name="detailed_results"),
 ]

--- a/src/apps/competitions/views.py
+++ b/src/apps/competitions/views.py
@@ -17,6 +17,7 @@ class CompetitionForm(LoginRequiredMixin, TemplateView):
     template_name = 'competitions/form.html'
 
 
+
 class CompetitionUpload(LoginRequiredMixin, TemplateView):
     template_name = 'competitions/upload.html'
 
@@ -33,3 +34,6 @@ class CompetitionDetail(DetailView):
         if is_creator or is_collaborator or competition.published or valid_secret_key:
             return competition
         raise Http404()
+
+class CompetitionDetailedResults(LoginRequiredMixin, TemplateView):
+    template_name = 'competitions/detailed_results.html'

--- a/src/apps/competitions/views.py
+++ b/src/apps/competitions/views.py
@@ -17,7 +17,6 @@ class CompetitionForm(LoginRequiredMixin, TemplateView):
     template_name = 'competitions/form.html'
 
 
-
 class CompetitionUpload(LoginRequiredMixin, TemplateView):
     template_name = 'competitions/upload.html'
 
@@ -34,6 +33,7 @@ class CompetitionDetail(DetailView):
         if is_creator or is_collaborator or competition.published or valid_secret_key:
             return competition
         raise Http404()
+
 
 class CompetitionDetailedResults(LoginRequiredMixin, TemplateView):
     template_name = 'competitions/detailed_results.html'

--- a/src/static/riot/competitions/detail/_detailed_results.tag
+++ b/src/static/riot/competitions/detail/_detailed_results.tag
@@ -1,0 +1,16 @@
+<competition-detailed-results>
+    <h3>Detailed Results</h3>
+    <iframe src="{detailed_result}" width="100%" height="100%" frameBorder="0"></iframe>
+
+    <script>
+
+        let self = this
+        CODALAB.api.get_submission_details(opts.submission_id)
+            .done(function (data) {
+                self.detailed_result = data.detailed_result
+                self.update()
+            })   
+        
+         
+    </script>
+</competition-detailed-results>

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -30,11 +30,13 @@
             <th>Task:</th>
             <th></th>
             <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ task.colWidth }">{ task.name }</th>
+            <th if="{enable_detailed_results}"></th>
         </tr>
         <tr>
             <th class="center aligned">#</th>
             <th>Participant</th>
             <th class="center aligned" each="{ column in filtered_columns }" colspan="1">{column.title}</th>
+            <th if="{enable_detailed_results}">Detailed Results</th>
         </tr>
         </thead>
         <tbody>
@@ -55,6 +57,7 @@
             <td if="{submission.organization === null}"><a href="{submission.slug_url}">{ submission.owner }</a></td>
             <td if="{submission.organization !== null}"><a href="{submission.organization.url}">{ submission.organization.name }</a></td>
             <td each="{ column in filtered_columns }">{ get_score(column, submission) } </td>
+            <td if="{enable_detailed_results}"><a href="detailed_results/{submission.id}">Show detailed results</a></td>
         </tr>
         </tbody>
     </table>
@@ -67,6 +70,7 @@
         self.filtered_columns = []
         self.phase_id = null
         self.competition_id = null
+        self.enable_detailed_results = false
 
         self.get_score = function(column, submission) {
             if(column.task_id === -1){
@@ -117,6 +121,8 @@
             CODALAB.api.get_leaderboard_for_render(self.phase_id)
                 .done(responseData => {
                     self.selected_leaderboard = responseData
+
+                   
                     self.columns = []
                     // Make fake task and columns for Metadata so it can be filtered like columns
                     if(self.selected_leaderboard.fact_sheet_keys){
@@ -154,6 +160,8 @@
         CODALAB.events.on('competition_loaded', (competition) => {
             self.competition_id = competition.id
             self.opts.is_admin ? self.show_download = "visible": self.show_download = "hidden"
+            self.enable_detailed_results = competition.enable_detailed_results
+            
         })
 
         CODALAB.events.on('submission_changed_on_leaderboard', self.update_leaderboard)

--- a/src/templates/competitions/detailed_results.html
+++ b/src/templates/competitions/detailed_results.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+<competition-detailed-results submission_id="{{ submission_id }}"></competition-detailed-results>
+{% endblock %}


### PR DESCRIPTION
@Didayolo @bbearce 

### Description of changes
Added functionality to view detailed results of a submission

### Steps to check the changes
1.  Go to Edit Competition and check "Enable Visualizations" checkbox
<img width="354" alt="Screenshot 2023-04-04 at 6 10 42 PM" src="https://user-images.githubusercontent.com/13259262/229802126-014af694-8ee3-41fc-a26d-82f40a3bde6d.png">

2. Go to Results tab, A new column in the results table "Detailed Results" is added

3. Click "Show detailed results" to view the detailed results of a submission



### Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [ ] Code review by reviewers
- [ ] Hand tested by reviewer
- [ ] Ready to merge

