### PR TITLE
change cdn from unpkg to cdn.jsdeliver

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -11,7 +11,7 @@
 
     <!-- Vendor -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
-    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
     <link rel="stylesheet" href="{% static "css/calendar.min.css" %}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
@@ -227,7 +227,7 @@
     <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{% static "js/calendar.min.js" %}"></script>
-    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.10/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/luxon@1.13.1/build/global/luxon.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/filesize/4.2.1/filesize.min.js"></script>


### PR DESCRIPTION
# Template
We are changing the cdn from unpkg to cdn.jsdeliver as the links for the js and CSS source files weren't loading for the js one. We change both the sync them together.

Source for the paths we ended up using: https://github.com/Ionaru/easy-markdown-editor

# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Need easymde source files that load.


# Issues this PR resolves
None - we found this by accident.


# Known issues to be addressed in a separate PR
None


# A checklist for hand testing
- [ ] open inspect in browser from main site UI and check for any errors loading the files:
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">

and

<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>



# Checklist
- [ x] Code review by me 
- [ x] Hand tested by me 
- [ x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge

