### PR TITLE
fix createbuckets entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,19 +57,23 @@ services:
     ports:
       - $MINIO_PORT:9000
     env_file: .env
+    healthcheck:
+      test: ["CMD", "nc", "-z", "minio", "9000"]
+      interval: 5s
+      retries: 5
 
   createbuckets:
     image: minio/mc
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     env_file: .env
 #    volumes:
       # This volume is shared with `minio`, so `z` to share it
 #      - ./var/minio:/export
     entrypoint: >
       /bin/sh -c "
-      set -x
-      while ! nc -z minio 9000; echo 'Waiting for minio to startup...' && sleep 5;
+      set -x;
       if [ -n \"$MINIO_ACCESS_KEY\" ] && [ -n \"$MINIO_SECRET_KEY\" ] && [ -n \"$MINIO_PORT\" ]; then
         until /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do echo '...waiting...' && sleep 5; done;
         /usr/bin/mc mb minio_docker/$AWS_STORAGE_BUCKET_NAME;
@@ -77,7 +81,7 @@ services:
         /usr/bin/mc anonymous set download minio_docker/$AWS_STORAGE_BUCKET_NAME;
       else
         echo 'MINIO_ACCESS_KEY, MINIO_SECRET_KEY, or MINIO_PORT are not defined. Skipping buckets creation.';
-      fi
+      fi;
       exit 0;
       "
 


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.

Fix issues with the entrypoint of the createbuckets service when following the "quick installation".

# Issues this PR resolves

1. Add missing semicolons in the createbuckets entrypoint to fix:
```
createbuckets_1   | /bin/sh: -c: line 7: syntax error near unexpected token `exit'
createbuckets_1   | /bin/sh: -c: line 7: `fi exit 0; '
```
```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 19e3880..17f037a 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
 #      - ./var/minio:/export
     entrypoint: >
       /bin/sh -c "
-      set -x
+      set -x;
       while ! nc -z minio 9000; echo 'Waiting for minio to startup...' && sleep 5;
       if [ -n \"$MINIO_ACCESS_KEY\" ] && [ -n \"$MINIO_SECRET_KEY\" ] && [ -n \"$MINIO_PORT\" ]; then
         until /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do echo '...waiting...' && sleep 5; done;
@@ -77,7 +77,7 @@ services:
         /usr/bin/mc anonymous set download minio_docker/$AWS_STORAGE_BUCKET_NAME;
       else
         echo 'MINIO_ACCESS_KEY, MINIO_SECRET_KEY, or MINIO_PORT are not defined. Skipping buckets creation.';
-      fi
+      fi;
       exit 0;
       "
```

2. Once that is done we get another error:
```
createbuckets_1   | /bin/sh: -c: line 8: syntax error: unexpected end of file
```
which is fixed by adding missing `do` and `done` to the while loop :
```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 17f037a..dae281b 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       set -x;
-      while ! nc -z minio 9000; echo 'Waiting for minio to startup...' && sleep 5;
+      while ! nc -z minio 9000; do echo 'Waiting for minio to startup...' && sleep 5; done;
       if [ -n \"$MINIO_ACCESS_KEY\" ] && [ -n \"$MINIO_SECRET_KEY\" ] && [ -n \"$MINIO_PORT\" ]; then
         until /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do echo '...waiting...' && sleep 5; done;
         /usr/bin/mc mb minio_docker/$AWS_STORAGE_BUCKET_NAME;
```
3. We now get an error due to `nc` not being available in minio/mc:
```
createbuckets_1   | /bin/sh: nc: command not found
```
which I propose to fix by using the healthcheck feature of docker-compose on the minio service (the image minio/minio distributes `nc`!):
```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 17f037a..7035681 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,16 @@ services:
     ports:
       - $MINIO_PORT:9000
     env_file: .env
+    healthcheck:
+      test: ["CMD", "nc", "-z", "minio", "9000"]
+      interval: 5s
+      retries: 5
 
   createbuckets:
     image: minio/mc
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     env_file: .env
 #    volumes:
       # This volume is shared with `minio`, so `z` to share it
@@ -69,7 +74,6 @@ services:
     entrypoint: >
       /bin/sh -c "
       set -x;
-      while ! nc -z minio 9000; echo 'Waiting for minio to startup...' && sleep 5;
       if [ -n \"$MINIO_ACCESS_KEY\" ] && [ -n \"$MINIO_SECRET_KEY\" ] && [ -n \"$MINIO_PORT\" ]; then
         until /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do echo '...waiting...' && sleep 5; done;
         /usr/bin/mc mb minio_docker/$AWS_STORAGE_BUCKET_NAME;
```
which fixes everything :smile: :
```
codabench_createbuckets_1    /bin/sh -c  set -x; if [ - ...   Up                                                                                                                                             
```

# A checklist for hand testing
- [x] Check that the change is compatible with a custom MINIO_PORT
-  [ ] The healthcheck configuration (5s interval with 5 retries) seems sensible to me but need to be validated. See https://docs.docker.com/engine/reference/builder/#healthcheck

# Checklist
- [x] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

