### PR TITLE
Change default docker image to py37

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -550,7 +550,7 @@ class Run:
             # Input from submission (or submission + ingestion combo)
             engine_cmd += ['-v', f'{self._get_host_path(self.input_dir)}:/app/input']
 
-        # Set the image name (i.e. "codalab/codalab-legacy") for the container
+        # Set the image name (i.e. "codalab/codalab-legacy:py37") for the container
         engine_cmd += [self.container_image]
 
         # Handle Legacy competitions by replacing anything in the run command

--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -42,7 +42,7 @@ class Competition(ChaHubSaveMixin, models.Model):
     terms = models.TextField(null=True, blank=True)
     is_migrating = models.BooleanField(default=False)
     description = models.TextField(null=True, blank=True)
-    docker_image = models.CharField(max_length=128, default="codalab/codalab-legacy:py3")
+    docker_image = models.CharField(max_length=128, default="codalab/codalab-legacy:py37")
     enable_detailed_results = models.BooleanField(default=False)
 
     queue = models.ForeignKey('queues.Queue', on_delete=models.SET_NULL, null=True, blank=True,

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -6,7 +6,7 @@ v15_yaml_data = {
     "title": "Sample time series competition",
     "description": "Sample competition for time series prediction",
     "image": "logo.jpg",
-    "competition_docker_image": "codalab/codalab-legacy:py3",
+    "competition_docker_image": "codalab/codalab-legacy:py37",
     "end_date": None,
     "html": {
         "data": "data.txt",

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -11,7 +11,7 @@ class V15Unpacker(BaseUnpacker):
         # Just in case docker image is blank (""), replace with default value
         docker_image = self.competition_yaml.get('competition_docker_image')
         if not docker_image:
-            docker_image = "codalab/codalab-legacy:py3"
+            docker_image = "codalab/codalab-legacy:py37"
 
         self.competition = {
             "title": self.competition_yaml.get('title'),

--- a/src/apps/competitions/unpackers/v2.py
+++ b/src/apps/competitions/unpackers/v2.py
@@ -13,7 +13,7 @@ class V2Unpacker(BaseUnpacker):
             "title": self.competition_yaml.get('title'),
             "logo": None,
             "registration_auto_approve": self.competition_yaml.get('registration_auto_approve', False),
-            "docker_image": self.competition_yaml.get('docker_image', 'codalab/codalab-legacy:py3'),
+            "docker_image": self.competition_yaml.get('docker_image', 'codalab/codalab-legacy:py37'),
             "enable_detailed_results": self.competition_yaml.get('enable_detailed_results', False),
             "description": self.competition_yaml.get("description", ""),
             "competition_type": self.competition_yaml.get("competition_type", "competition"),


### PR DESCRIPTION
Change the default docker image from `codalab/codalab-legacy:py3` to `codalab/codalab-legacy:py37`.

- This way it is the same as on CodaLab Competitions, so bundles using the default image that work on CodaLab will work on Codabench
- The py37 image is documented on https://github.com/codalab/codalab-dockers
- We should not change this in the future to avoid breaking bundles
- It is using decent libraries