### PR TITLE
Forgot/Reset password styling added

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -146,7 +146,7 @@
                                     Notifications
                                 </a>
                                 <a class="item" href="{% url 'accounts:password_reset' %}">
-                                    <i class="icon sign out"></i>
+                                    <i class="lock icon"></i>
                                     Change Password
                                 </a>
                                 <a class="item" href="{% url 'accounts:logout' %}">

--- a/src/templates/registration/password_reset_complete.html
+++ b/src/templates/registration/password_reset_complete.html
@@ -1,10 +1,14 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="six wide centered column">
-    <h2 class="ui blue header">
+<div class="sixteen wide mobile six wide computer centered column">
+    <h2 class="ui blue centered header">
         Password Reset Complete
     </h2>
-    <p>Your password has been successfully reset.</p>
+    <div class="ui stacked segment">
+        <div class="ui green message">
+            <p>Your password has been successfully reset.</p>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/src/templates/registration/password_reset_confirm.html
+++ b/src/templates/registration/password_reset_confirm.html
@@ -1,14 +1,42 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="six wide centered column">
-    <h2 class="ui blue header">
+<div class="sixteen wide mobile six wide computer centered column">
+    <h2 class="ui blue centered header">
         Change Password
     </h2>
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Reset Password</button>
-    </form>
+    <div class="ui stacked segment">
+        <p>Reset your password by entering a new one.</p>
+        <div class="ui divider"></div>
+        <form class="ui form" method="POST">
+            {% csrf_token %}
+            <div class="field">
+                <div class="ui left icon input">
+                    <i class="lock icon"></i>
+                    <input type="password"
+                           name="new_password1"
+                           placeholder="new password"
+                           id="id_new_password1"
+                           value=""
+                           maxlength=""
+                           required>
+                </div>
+            </div>
+            <div class="field">
+                <div class="ui left icon input">
+                    <i class="lock icon"></i>
+                    <input type="password"
+                           name="new_password2"
+                           placeholder="repeat new password"
+                           id="id_new_password2"
+                           value=""
+                           maxlength=""
+                           required>
+                </div>
+            </div>
+            
+            <button class="ui fluid blue submit button" type="submit">Reset password</button>
+        </form>
+    </div>
 </div>
 {% endblock %}

--- a/src/templates/registration/password_reset_done.html
+++ b/src/templates/registration/password_reset_done.html
@@ -3,14 +3,19 @@
 {% block title %}Password reset{% endblock %}
 
 {% block content %}
-<div class="six wide centered column">
-    <h2 class="ui blue header">
+<div class="sixteen wide mobile six wide computer centered column">
+    <h2 class="ui blue centered header">
         Password Reset Complete
     </h2>
-    <p>
-        We have sent you an email with a link to reset your password. Please check
-        your email and click the link to continue.
-    </p>
+    <div class="ui stacked segment">
+        <div class="ui blue message">
+            <p>
+                We have sent you an email with a link to reset your password. Please check
+                your email and click the link to continue.
+            </p>
+        </div>
+        
+    </div>
 </div>
 {% endblock %}
 

--- a/src/templates/registration/password_reset_form.html
+++ b/src/templates/registration/password_reset_form.html
@@ -4,19 +4,37 @@
 {% block title %}Reset password{% endblock %}
 
 {% block content %}
-<div class="six wide centered column">
-    <h2 class="ui blue header">
+<div class="sixteen wide mobile six wide computer centered column">
+    <h2 class="ui blue centered header">
         Reset password
     </h2>
-    {% if user.is_authenticated %}
-        <p><strong>Note:</strong> you are already logged in as {{ user.username }}.</p>
-    {% endif %}
-    <p>Forgot your password? Enter your email in the form below and we'll send you instructions for creating a new one.</p>
-    <form method="post" action="">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" value="Reset password" />
-    </form>
+    <div class="ui stacked segment">
+        {% if user.is_authenticated %}
+            <div class="ui blue message">
+                <p><strong>Note:</strong> you are already logged in as {{ user.username }}.</p>
+            </div>
+        {% endif %}
+        <h5>Forgot your password?</h5>
+        <p>Enter your email in the form below and we'll send you instructions for creating a new one.</p>
+        <div class="ui divider"></div>
+        <form class="ui form" method="POST">
+            {% csrf_token %}
+            <div class="field">
+                <div class="ui left icon input">
+                    <i class="user icon"></i>
+                    <input type="email"
+                           name="email"
+                           placeholder="email"
+                           id="id_email"
+                           value=""
+                           maxlength=""
+                           required>
+                </div>
+            </div>
+            <button class="ui fluid blue submit button" type="submit">Reset password</button>
+            <div class="ui error message"></div>
+        </form>
+    </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION

# @ mention of reviewers
@bbearce @Didayolo @dtuantran


# A brief description of the purpose of the changes contained in this PR.

1. Added CSS style to the forgot password and reset password to match Codabench theme
2. Change password icon changed in the menu


# Issues this PR resolves
When Forgot password is clicked on login screen, this is shown:
<img width="468" alt="Screenshot 2023-04-20 at 8 05 40 PM" src="https://user-images.githubusercontent.com/13259262/233410067-3b0221b7-5277-4510-a335-17f19daa9cc9.png">


When password reset email is sent, this is show:
<img width="478" alt="Screenshot 2023-04-20 at 8 05 49 PM" src="https://user-images.githubusercontent.com/13259262/233410356-beeb318b-9243-46e1-ba3e-6c476c607eb3.png">


When password reset link is clicked this screen is shown:
<img width="481" alt="Screenshot 2023-04-20 at 8 06 07 PM" src="https://user-images.githubusercontent.com/13259262/233410514-4cc32085-c0e8-4da1-806e-512686d8258a.png">

On password reset success:
<img width="487" alt="Screenshot 2023-04-20 at 8 06 18 PM" src="https://user-images.githubusercontent.com/13259262/233410601-47dc3389-e565-4b02-8c87-e11a2627a83b.png">



Change password icon changed from `logout arrow` to `lock`
 
<img width="185" alt="Screenshot 2023-04-20 at 8 08 58 PM" src="https://user-images.githubusercontent.com/13259262/233410919-879e4348-1a56-4082-a544-20e805f707a3.png">





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

