### PR TITLE
username limit between 5 and 15 characters

### DIFF
--- a/src/apps/profiles/forms.py
+++ b/src/apps/profiles/forms.py
@@ -17,6 +17,10 @@ class SignUpForm(UserCreationForm):
             raise forms.ValidationError(
                 "Usernames should not contain special characters."
             )
+        if (len(data) > 15 or len(data)< 5):
+            raise forms.ValidationError(
+                "Username must have at least 5 characters and at most 15 characters"
+            )
         return data
 
     class Meta:


### PR DESCRIPTION

# @ mention of reviewers
@Didayolo @bbearce @dtuantran 


# A brief description of the purpose of the changes contained in this PR.
Now users can only use a username which has at least 5 characters and at most 15 characters


# Issues this PR resolves
Limits username length



# Screenshots

Less than 5 characters
<img width="443" alt="Screenshot 2023-04-22 at 5 42 49 PM" src="https://user-images.githubusercontent.com/13259262/233785516-a55b5fd9-f4e1-47f4-b665-40e3521a9ab2.png">

More than 15 characters
<img width="452" alt="Screenshot 2023-04-22 at 5 43 25 PM" src="https://user-images.githubusercontent.com/13259262/233785524-84ba9c8a-4ab2-4052-90ba-6a6a1f38b7d4.png">




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

