### PR TITLE
Search competitions, only show public competitions when not logged in…

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -63,11 +63,30 @@ class CompetitionViewSet(ModelViewSet):
             if participating_in:
                 qs = qs.filter(participants__user=self.request.user, participants__status="approved")
 
+            # new condition for search bar
+            # `mine`` is true when this is called from "Benchmarks I'm Running"
+            # `participating_in` is true when this is called from "Benchmarks I'm in"
+            # `mine` and `participating_in` are none when this is called from Search bar
+            if (not mine) and (not participating_in):
+                # User is logged in
+                # filter his own competitions
+                # or 
+                # filter published competitions by other users
+                qs = qs.filter(
+                    (Q(created_by=self.request.user))
+                    |
+                    (Q(published=True) & ~Q(created_by=self.request.user))
+                )
+
             participant_status_query = CompetitionParticipant.objects.filter(
                 competition=OuterRef('pk'),
                 user=self.request.user
             ).values_list('status')[:1]
             qs = qs.annotate(participant_status=Subquery(participant_status_query))
+
+        else:
+            # if user is not authenticated only filter published/public competitions
+            qs = qs.filter(Q(published=True))
 
         # On GETs lets optimize the query to reduce DB calls
         if self.request.method == 'GET':

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -70,11 +70,10 @@ class CompetitionViewSet(ModelViewSet):
             if (not mine) and (not participating_in):
                 # User is logged in
                 # filter his own competitions
-                # or 
+                # or
                 # filter published competitions by other users
                 qs = qs.filter(
-                    (Q(created_by=self.request.user))
-                    |
+                    (Q(created_by=self.request.user)) |
                     (Q(published=True) & ~Q(created_by=self.request.user))
                 )
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @dtuantran @bbearce 


# A brief description of the purpose of the changes contained in this PR.
Searchbar of Codabench was showing private competitions of other users [Issue 705](https://github.com/codalab/codabench/issues/705)

<img width="426" alt="Screenshot 2023-04-25 at 4 32 48 PM" src="https://user-images.githubusercontent.com/13259262/234263949-82401806-bff5-4ce6-8391-ceb2bcc73c66.png">



# Issues this PR resolves
Now if user is not loggedin, only published competitions will be shown
if user is logged in then only public competitions from other users and all his competitions (public/private) will be shown


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

