### PR TITLE
empty profile page fixed, edit profile github url fixed

### DIFF
--- a/src/static/riot/profiles/profile_detail.tag
+++ b/src/static/riot/profiles/profile_detail.tag
@@ -85,21 +85,46 @@
 
             <!-- Second Column -->
             <div class="eight wide column">
+                <!--  Name  -->
                 <span class="header content">{selected_user.first_name} {selected_user.last_name}</span>
-                <i class="marker alternate icon"></i>
-                <span id="location">{selected_user.location}</span>
-                <div id="job_title">{selected_user.title}</div>
-                <div class="ui justified container">{selected_user.biography}</div>
-                <div id="horiz-margin" class="ui horizontal divider"><i class="user icon"></i>About Me</div>
+                
+                <!--  About  -->
+                <div id="horiz-margin" class="ui horizontal divider">About</div>
+                <div class="about-block">
+                    <i class="marker icon"></i>
+                    <span if="{!selected_user.location}" class="text-placeholder">Location</span>
+                    <span if="{selected_user.location}">{selected_user.location}</span>
+                </div>
+                <div  class="about-block">
+                    <i class="user icon"></i>
+                    <span if="{!selected_user.title}" class="text-placeholder">Job Title</span>
+                    <span if="{selected_user.title}">{selected_user.title}</span>
+                </div>
+
+                <!--  Bio  -->
+                <div id="horiz-margin" class="ui horizontal divider">Bio</div>
+                <span if="{!selected_user.biography}" class="text-placeholder">No bio found! Update your profile to show your bio here.</span>
+                <div if="{selected_user.biography}"  class="ui justified container">{selected_user.biography}</div>
+                
+                <!--  Links  -->
+                <div id="horiz-margin" class="ui horizontal divider">Links</div>
                 <div id="grid-margin" class="ui grid">
-                    <span if="{selected_user.personal_url}" class="three wide column"><i class="world icon"></i>Website:</span>
-                    <a if="{selected_user.personal_url}" href="{selected_user.personal_url}" class="thirteen wide column">{selected_user.personal_url}</a>
-                    <span if="{selected_user.github_url}" class="three wide column"><i class="github icon"></i>GitHub:</span>
-                    <a if="{selected_user.github_url}" href="https://github.com/" class="thirteen wide column">{selected_user.github_url}</a>
-                    <span if="{selected_user.linkedin_url}" class="three wide column"><i class="linkedin icon"></i>LinkedIn:</span>
-                    <a if="{selected_user.linkedin_url}" href="https://linkedin.com/" class="thirteen wide column">{selected_user.linkedin_url}</a>
-                    <span if="{selected_user.twitter_url}" class="three wide column"><i class="twitter icon"></i>Twitter:</span>
-                    <a if="{selected_user.twitter_url}" href="https://twitter.com/" class="thirteen wide column">{selected_user.twitter_url}</a>
+                    <div class="social-block">
+                        <span class="three wide column"><i class="world icon"></i>Website:</span>
+                        <a if="{selected_user.personal_url}" href="{selected_user.personal_url}" class="thirteen wide column">{selected_user.personal_url}</a>
+                    </div>
+                    <div class="social-block">
+                        <span class="three wide column"><i class="github icon"></i>GitHub:</span>
+                        <a if="{selected_user.github_url}" href="https://github.com/" class="thirteen wide column">{selected_user.github_url}</a>
+                    </div>
+                    <div class="social-block">
+                        <span class="three wide column"><i class="linkedin icon"></i>LinkedIn:</span>
+                        <a if="{selected_user.linkedin_url}" href="https://linkedin.com/" class="thirteen wide column">{selected_user.linkedin_url}</a>
+                    </div>
+                    <div class="social-block">
+                        <span class="three wide column"><i class="twitter icon"></i>Twitter:</span>
+                        <a if="{selected_user.twitter_url}" href="https://twitter.com/" class="thirteen wide column">{selected_user.twitter_url}</a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -150,21 +175,6 @@
             font-size 30px
             font-weight bolder
 
-        .marker.alternate.icon
-            margin-left 5px
-            font-size 14px
-            margin-right -5px
-            color #9e9e9e
-
-        #location
-            color #9e9e9e
-
-        #job_title
-            color darkblue
-            font-size 14px
-            font-weight bold
-            margin-top 5px
-
         .ui.justified.container
             margin-top 30px
             font-size 12px
@@ -177,7 +187,7 @@
             margin-bottom -5px
 
         #horiz-margin
-            margin-top 20px
+            margin-top 30px
 
         #grid-margin
             margin-top 20px
@@ -193,5 +203,15 @@
 
         .linkedin.icon
             color #0077B5
+        
+        .social-block
+            margin-bottom 10px
+            margin-top 5px
+
+        .about-block
+            margin-top 10px
+
+        .text-placeholder
+            color #9e9e9e
     </style>
 </profile-detail>

--- a/src/static/riot/profiles/profile_edit.tag
+++ b/src/static/riot/profiles/profile_edit.tag
@@ -91,7 +91,7 @@
                 personal_url:   selected_user.personal_url,
                 twitter_url:    selected_user.twitter_url,
                 linkedin_url:   selected_user.linkedin_url,
-                github_url:     selected_user.linkedin_url,
+                github_url:     selected_user.github_url,
                 title:          selected_user.title,
                 location:       selected_user.location,
                 biography:      selected_user.biography,


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @bbearce 


# A brief description of the purpose of the changes contained in this PR.
Empty profile page when new user account is created looked weird. Edit profile github URL was mixing with Twitter URL as described in [Issue 684](https://github.com/codalab/codabench/issues/684)

Now users can see placeholders when profile is not updated:
<img width="1216" alt="Screenshot 2023-04-26 at 1 32 57 PM" src="https://user-images.githubusercontent.com/13259262/234518244-a4a1e8b1-8b93-48f1-9c0a-9ed36afb75c8.png">



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

