### PR TITLE
Remove the SNCF bundle e2e test

### DIFF
--- a/src/tests/functional/test_submissions.py
+++ b/src/tests/functional/test_submissions.py
@@ -75,9 +75,6 @@ class TestSubmissions(SeleniumTestCase):
         prediction_score = Submission.objects.get(pk=submission_id).scores.first().score
         assert Decimal(self.find('leaderboards table tbody tr:nth-of-type(1) td:nth-of-type(3)').text) == prediction_score
 
-    def test_v15_submission_end_to_end(self):
-        self._run_submission_and_add_to_leaderboard('competition_15.zip', 'submission_15.zip', '*** prediction_score', has_solutions=False)
-
     def test_v15_iris_result_submission_end_to_end(self):
         self._run_submission_and_add_to_leaderboard('competition_15_iris.zip', 'submission_15_iris_result.zip', '======= Set 1 (Iris_test)', has_solutions=False)
 


### PR DESCRIPTION
The goal is to solve this issue:

- #722

With a previous PR (#828), **I added two v15 e2e tests: Iris code submission and Iris result submission**.

The test removed by this PR is testing in `test_submissions.py` "competition_15.zip" and "submission_15.zip", which is a template of SNCF competition. This bundle is not well rounded and documented, and the test seems to be randomly failing from time to time.

Maybe we want to really understand why this bundle creates problem. Or we can merge this PR and have stable tests from now on.

@dtuantran what do you think?