### PR TITLE
Only allow submissions for NOT ENDED phases 

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -280,6 +280,23 @@
                 })
             })
 
+            // loop over competition phases to mark active and inactive phases
+            self.competition.phases.forEach(function (phase, index) {
+                // check if end data exists for this phase
+                if (phase["end"]){
+                    if((Date.parse(phase["end"]) - Date.parse(new Date())) < 0){
+                        // Phase cannote accept submissions if end date is in the past
+                        self.competition.phases[index]["accept_submissions"] = false
+                    }else{
+                        // Phase can accept submissions if end date is in the future
+                        self.competition.phases[index]["accept_submissions"] = true
+                    }
+                }else{
+                    // Phase can accept submissions if end date is not given
+                    self.competition.phases[index]["accept_submissions"] = true
+                }
+            })
+
             self.competition.is_admin = CODALAB.state.user.has_competition_admin_privileges(competition)
             self.selected_phase_index = _.get(_.find(self.competition.phases, {'status': 'Current'}), 'id')
             if (self.selected_phase_index == null) {

--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -4,6 +4,7 @@
 
         <div class="submission-form">
             <h1>Submission upload</h1>
+            <div if="{!_.get(selected_phase, 'accept_submissions')}" class="ui yellow message">Submissions are closed for this phase!</div>
             <form class="ui form coda-animated {error: errors}" ref="form" enctype="multipart/form-data">
                 <div class="submission-form" ref="fact_sheet_form" if="{ opts.fact_sheet !== null}">
                     <h2>Metadata or Fact Sheet</h2>
@@ -349,7 +350,10 @@
         }
 
         self.check_can_upload = function () {
-            CODALAB.api.can_make_submissions(self.selected_phase.id)
+            // Check if selected phase accepts submissions (within the deadline of the phase)
+            if(self.selected_phase.accept_submissions){
+
+                CODALAB.api.can_make_submissions(self.selected_phase.id)
                 .done(function (data) {
                     if (data.can) {
                         self.prepare_upload(self.upload)()
@@ -360,6 +364,12 @@
                 .fail(function (data) {
                     toastr.error('Could not verify your ability to make a submission')
                 })
+            }else{
+                // Error when phase is not accepting submissions
+                toastr.error('This phase no longer accepts submissions!')
+                self.clear_form()
+            }
+            
         }
 
         self.get_fact_sheet_answers = function () {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @bbearce 


# A brief description of the purpose of the changes contained in this PR.
Now users are blocked from submitting to a phase which has ended.

A warning message is shown to users for information
<img width="1155" alt="Screenshot 2023-05-03 at 2 31 49 PM" src="https://user-images.githubusercontent.com/13259262/235881825-e3355a49-e234-434a-9c9a-c0ab01bea115.png">

If still user wants to submit to the phase, an error message is shown:
<img width="1330" alt="Screenshot 2023-05-03 at 2 33 20 PM" src="https://user-images.githubusercontent.com/13259262/235881890-5b5f6e83-5735-4470-8097-573626103dbb.png">



# Issues this PR resolves
blocks user from submitting to ended phases


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

