### PR TITLE
Search competitions: loggedin: public+own private, not loggedin: public

### DIFF
--- a/src/factories.py
+++ b/src/factories.py
@@ -58,7 +58,7 @@ class CompetitionFactory(DjangoModelFactory):
     title = factory.Sequence(lambda n: f'Competition {n}')
     created_by = factory.SubFactory(UserFactory)
     logo = factory.django.ImageField()
-    published = factory.LazyAttribute(lambda n: random.choice([True, False]))
+    published = factory.LazyAttribute(lambda n: random.choice([True, True]))
     description = factory.Faker('paragraph')
 
     created_when = factory.Faker('date_time_between', start_date='-5y', end_date='now', tzinfo=UTC)


### PR DESCRIPTION
 # @ mention of reviewers
@Didayolo @bbearce 


# A brief description of the purpose of the changes contained in this PR.
Searchbar of Codabench was showing private competitions of other users 


**Now** if user is not loggedin, only published competitions will be shown
if user is logged in then only public competitions from other users and all his competitions (public/private) will be shown

Unpublished iris is not shown
<img width="411" alt="Screenshot 2023-05-05 at 2 42 35 PM" src="https://user-images.githubusercontent.com/13259262/236429877-c38e2c8c-86bd-459a-abac-4939f69feb58.png">

Published Classify weeds.. is shown
<img width="411" alt="Screenshot 2023-05-05 at 2 58 04 PM" src="https://user-images.githubusercontent.com/13259262/236429926-4e98089f-9940-4f2f-9b3c-7be3db5c7fa8.png">



# Issues this PR resolves
[Issue 705](https://github.com/codalab/codabench/issues/705)



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

