### PR TITLE
Private competition with secret key without login

### DIFF
--- a/src/apps/competitions/views.py
+++ b/src/apps/competitions/views.py
@@ -27,13 +27,25 @@ class CompetitionDetail(DetailView):
 
     def get_object(self, *args, **kwargs):
         competition = super().get_object(*args, **kwargs)
-        is_creator = self.request.user.is_superuser or self.request.user == competition.created_by
-        is_collaborator = self.request.user in competition.collaborators.all()
 
-        # get participants from CompetitionParticipant where user=user and competition=competition
-        is_participant = CompetitionParticipant.objects.filter(user=self.request.user, competition=competition).count() > 0
+        is_creator, is_collaborator, is_participant = False, False, False
 
+        # check if user is loggedin
+        if self.request.user.is_authenticated:
+            
+            # check if user is the creator of this competition
+            is_creator = self.request.user.is_superuser or self.request.user == competition.created_by
+            
+            # check if user is collaborator of this competition
+            is_collaborator = self.request.user in competition.collaborators.all()
+
+            # check if user is a participant of this competition
+            # get participants from CompetitionParticipant where user=user and competition=competition
+            is_participant = CompetitionParticipant.objects.filter(user=self.request.user, competition=competition).count() > 0
+
+        # check if secret key provided is valid
         valid_secret_key = self.request.GET.get('secret_key') == str(competition.secret_key)
+
         if is_creator or is_collaborator or competition.published or valid_secret_key or is_participant:
             return competition
         raise Http404()

--- a/src/apps/competitions/views.py
+++ b/src/apps/competitions/views.py
@@ -32,10 +32,10 @@ class CompetitionDetail(DetailView):
 
         # check if user is loggedin
         if self.request.user.is_authenticated:
-            
+
             # check if user is the creator of this competition
             is_creator = self.request.user.is_superuser or self.request.user == competition.created_by
-            
+
             # check if user is collaborator of this competition
             is_collaborator = self.request.user in competition.collaborators.all()
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Previosuly if a user was not loggedin, a competition URL with valid secret key was giving `500` error.
<img width="303" alt="Screenshot 2023-05-05 at 4 55 31 PM" src="https://user-images.githubusercontent.com/13259262/236451383-022909a8-e2d8-4540-bcea-a85bde7a7532.png">


Now user can view the competition if he is not loggedin but the secret key is valid. User still has to login in order to participate in the competition


# Issues this PR resolves
[Issue 842](https://github.com/codalab/codabench/issues/842)



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

