### PR TITLE
Repeated rows of submissions solved

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -22,6 +22,9 @@ from competitions.models import Submission, Phase, CompetitionParticipant
 from leaderboards.strategies import put_on_leaderboard_by_submission_rule
 from leaderboards.models import SubmissionScore, Column, Leaderboard
 
+import logging 
+logger = logging.getLogger()
+
 
 class SubmissionViewSet(ModelViewSet):
     queryset = Submission.objects.all().order_by('-pk')
@@ -68,7 +71,7 @@ class SubmissionViewSet(ModelViewSet):
                     Q(owner=self.request.user) |
                     Q(phase__competition__created_by=self.request.user) |
                     Q(phase__competition__collaborators__in=[self.request.user.pk])
-                )
+                ).distinct()
             qs = qs.select_related(
                 'phase',
                 'phase__competition',

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -22,9 +22,6 @@ from competitions.models import Submission, Phase, CompetitionParticipant
 from leaderboards.strategies import put_on_leaderboard_by_submission_rule
 from leaderboards.models import SubmissionScore, Column, Leaderboard
 
-import logging 
-logger = logging.getLogger()
-
 
 class SubmissionViewSet(ModelViewSet):
     queryset = Submission.objects.all().order_by('-pk')


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Repeated rows were shown when more than 1 admins were added to a competition

Before solution:
<img width="534" alt="Screenshot 2023-05-05 at 8 54 49 PM" src="https://user-images.githubusercontent.com/13259262/236532664-78412be0-771e-4619-950f-c636db245e1e.png">


This is solved by showing only distinct rows
After solution:
<img width="665" alt="Screenshot 2023-05-05 at 10 53 48 PM" src="https://user-images.githubusercontent.com/13259262/236532690-208d0990-e0dc-4547-8f85-19cb03de99a9.png">



# Issues this PR resolves

1. [Issue 767](https://github.com/codalab/codabench/issues/767) 
2. [Issue 761](https://github.com/codalab/codabench/issues/761)



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

