### PR TITLE
v1 bundle unpacking: use column label as title

### DIFF
--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -149,7 +149,7 @@ V1_LEADERBOARDS = [{
     "label": "RESULTS",
     "columns": [
         {
-            "title": "prediction_score",
+            "title": "Prediction score",
             "key": "prediction_score",
             "index": 0,
             "sorting": "desc",

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -158,7 +158,8 @@ class V15Unpacker(BaseUnpacker):
 
         for index, column in enumerate(columns):
             new_col_data = {
-                'title': column['title'],
+                # get label as title, if not found, use title by default
+                'title': column.get('label', column['title']),
                 'key': column['title'],
                 'index': index,
                 'sorting': column.get('sort') or 'desc',


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
While unpacking V1 bundle, label of column was not used as title in Leaderboard.

Now, with the changes made, the following will happen:

1. V1 bundle has label for column: label is used as title. Example below:
<img width="256" alt="Screenshot 2023-05-09 at 10 21 02 PM" src="https://github.com/codalab/codabench/assets/13259262/eb57676d-f4dc-4bce-aaf2-b32cb81e1660">
<img width="797" alt="Screenshot 2023-05-09 at 10 21 08 PM" src="https://github.com/codalab/codabench/assets/13259262/d4e880a2-016c-4073-9d88-d6fa350d674c">
 

2. V1 bundle has no label for column: key is used as title. Example below:
<img width="257" alt="Screenshot 2023-05-09 at 10 22 31 PM" src="https://github.com/codalab/codabench/assets/13259262/4f92cb1c-8ca2-4f9e-acb3-4d2745af5703">
<img width="772" alt="Screenshot 2023-05-09 at 10 22 16 PM" src="https://github.com/codalab/codabench/assets/13259262/ecaa215e-48cc-4fea-8079-f06e3a1772d1">



# Issues this PR resolves
#375 point 1

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

