### PR TITLE
queue added to competition while unpacking from YAML

### DIFF
--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -201,10 +201,10 @@ class BaseUnpacker:
 
     def _unpack_queue(self):
         # Get Queue by vhost/uuid. If instance not returned, or we don't have access don't set it!
-        queue_name = self.competition_yaml.get('queue')
-        if queue_name:
+        vhost = self.competition_yaml.get('queue')
+        if vhost:
             try:
-                queue = Queue.objects.get(name=queue_name)
+                queue = Queue.objects.get(vhost=vhost)
                 if not queue.is_public:
                     all_queue_organizer_names = queue.organizers.all().values_list('username', flat=True)
                     if queue.owner != self.creator and self.creator.username not in all_queue_organizer_names:

--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -201,15 +201,24 @@ class BaseUnpacker:
 
     def _unpack_queue(self):
         # Get Queue by vhost/uuid. If instance not returned, or we don't have access don't set it!
-        vhost = self.competition_yaml.get('queue')
-        if vhost:
+        queue_name = self.competition_yaml.get('queue')
+        if queue_name:
             try:
-                queue = Queue.objects.get(vhost=vhost)
+                queue = Queue.objects.get(name=queue_name)
                 if not queue.is_public:
                     all_queue_organizer_names = queue.organizers.all().values_list('username', flat=True)
                     if queue.owner != self.creator and self.creator.username not in all_queue_organizer_names:
                         raise CompetitionUnpackingException("You do not have access to the specified queue!")
-                self.competition['queue'] = queue.id
+                self.competition['queue'] = {
+                    'name': queue.name,
+                    'vhost': queue.vhost,
+                    'is_public': queue.is_public,
+                    'owner': queue.owner,
+                    'organizers': queue.organizers,
+                    'broker_url': queue.broker_url,
+                    'created_when': queue.broker_url,
+                    'id': queue.id,
+                }
             except Queue.DoesNotExist:
                 raise CompetitionUnpackingException("The specified Queue does not exist!")
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
While unpacking a competition with `queue` mentioned in the YAML file was failing.

Now a `queue` is attached to a competition while unpacking if the queue name is provided in this field.


# Issues this PR resolves
https://github.com/codalab/codabench/issues/855


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

