### PR TITLE
Score shown in submission panel for user and admin

### DIFF
--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -62,7 +62,8 @@
             <th if="{ opts.admin }">Owner</th>
             <th if="{ opts.admin }">Phase</th>
             <th>Date</th>
-            <th class="right aligned">Status</th>
+            <th>Status</th>
+            <th>Score</th>
             <th class="center aligned {admin-action-column: opts.admin, action-column: !opts.admin}">Actions</th>
         </tr>
         </thead>
@@ -94,6 +95,7 @@
                     <i if="{submission.status === 'Failed'}" class="failed question circle icon"></i>
                 </sup>
             </td>
+            <td>{get_score(submission)}</td>
             <td class="center aligned">
                 <virtual if="{ opts.admin }">
                     <span data-tooltip="Rerun Submission"
@@ -379,6 +381,15 @@
                 return [score.score, score.id]
             } catch {
                 return ['', '']
+            }
+        }
+
+        self.get_score = function (submission) {
+            try{
+                return parseFloat(submission.scores[0].score).toFixed(2)
+                
+            } catch {
+                return ""
             }
         }
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users and admins can see score for finished submissions in submissions panel

For users:
<img width="1172" alt="Screenshot 2023-05-16 at 8 54 40 PM" src="https://github.com/codalab/codabench/assets/13259262/7b60ecd9-eba4-436a-b696-f93bd48f9de2">

For Admins:
<img width="1045" alt="Screenshot 2023-05-16 at 8 54 48 PM" src="https://github.com/codalab/codabench/assets/13259262/8cc85893-ec3f-43f6-a29c-962afa19391b">



# Issues this PR resolves
Solves the first point of #610 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

