### PR TITLE
html is now interpreted in compettion pages

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -328,7 +328,14 @@
             // Need to run update() to build tags to render html in
             self.update()
             _.forEach(self.competition.pages, (page, index) => {
-                $(`#page_${index}`)[0].innerHTML = render_markdown(page.content)
+
+                if (self.isHTML(page.content)){
+                    $(`#page_${index}`)[0].innerHTML = sanitize_HTML(page.content)
+                }else{
+                    $(`#page_${index}`)[0].innerHTML = render_markdown(page.content)
+                }
+                
+                
             })
             _.forEach(self.competition.phases, (phase, index) => {
                 $(`#phase_${index}`)[0].innerHTML = render_markdown(phase.description)
@@ -358,6 +365,12 @@
                 self.update()
                 CODALAB.events.trigger('phase_selected', data)
             }
+        }
+        // To check if page content has HTML
+        // Return true if content is html
+        // Return false if content is not html i.e. MarkDown
+        self.isHTML = function (page_content) {
+            return /<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/i.test(page_content);
         }
 
         self.update()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now codabench can interpret the pages if they have HTML or MarkDown

Markdown:
<img width="384" alt="Screenshot 2023-05-17 at 5 19 52 PM" src="https://github.com/codalab/codabench/assets/13259262/4aea46b3-10fa-4bd4-8d15-ddde007de63a">


HTML:
<img width="468" alt="Screenshot 2023-05-17 at 5 20 05 PM" src="https://github.com/codalab/codabench/assets/13259262/912d9faf-9b61-4449-a0f0-c2a7407cd1d3">



# Issues this PR resolves
#836 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

