### PR TITLE
do not show empty leaderboard table when user is not loggedin

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -218,7 +218,15 @@
                 <loader></loader>
             </div>
             <!-- Tab Content !-->
-            <div show="{!loading}">
+            <div class="row" if="{!CODALAB.state.user.logged_in}">
+                <div class="column">
+                    <div class="ui yellow message">
+                        <a href="{URLS.LOGIN}?next={location.pathname}">Log In</a> or
+                        <a href="{URLS.SIGNUP}" target="_blank">Sign Up</a> to view this competition results.
+                    </div>
+                </div>
+            </div>
+            <div if="{CODALAB.state.user.logged_in}" show="{!loading}">
                 <div class="ui button-container inline">
                     <div class="ui button {active: selected_phase_index == phase.id}"
                          each="{ phase in competition.phases }"
@@ -244,6 +252,7 @@
             <div show="{!loading && _.isEmpty(competition.leaderboards)}">
                 <div class="center aligned"><h2>No Visible Leaderboards for this competition</h2></div>
             </div>
+            
         </div>
     </div>
 


### PR DESCRIPTION

# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users will not see empty leaderboard table when not loggedin. 
A warning message is shown to login with links to login or sign up


<img width="1316" alt="Screenshot 2023-05-17 at 10 06 41 PM" src="https://github.com/codalab/codabench/assets/13259262/af39b1d8-afa4-47e0-8992-28fe79470f6d">




# Issues this PR resolves
#749 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

