### PR TITLE
repeated competitions in competitions api fixed

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -62,7 +62,8 @@ class CompetitionViewSet(ModelViewSet):
                 qs = Competition.objects.filter(
                     (Q(created_by=self.request.user)) |
                     (Q(collaborators__in=[self.request.user]))
-                )
+                ).distinct()
+
             participating_in = self.request.query_params.get('participating_in', None)
             if participating_in:
                 qs = qs.filter(participants__user=self.request.user, participants__status="approved")


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now competitions will not repeat in `mine` tab


Before fix: (Iris 01 is repeating)
<img width="221" alt="Screenshot 2023-05-25 at 2 20 57 PM" src="https://github.com/codalab/codabench/assets/13259262/8b290893-dca1-4aa3-9e09-d7bc386c8358">

After fix:
<img width="214" alt="Screenshot 2023-05-25 at 2 21 11 PM" src="https://github.com/codalab/codabench/assets/13259262/53385b01-715c-4aba-9acb-6220553cce7f">


# Issues this PR resolves
#884 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

