### PR TITLE
uploading a submission, show asterick with required answers only

### DIFF
--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -11,8 +11,8 @@
                     <h2>Metadata or Fact Sheet</h2>
                     <div class="submission-form-question" each="{ question in opts.fact_sheet }">
                         <span if="{ question.type === 'text' }">
-                            <label if="{question.is_required}" class="required-answer" for="{ question.key }">{ question.title }:</label>
-                            <label if="{!question.is_required}" for="{ question.key }">{ question.title }:</label>
+                            <label if="{question.is_required == 'true'}" class="required-answer" for="{ question.key }">{ question.title }:</label>
+                            <label if="{question.is_required == 'false'}" for="{ question.key }">{ question.title }:</label>
                             <input type="text" name="{ question.key }">
                         </span>
                         <span if="{ question.type === 'checkbox' }">


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now `*` will be shown with required fact sheet answers only

<img width="398" alt="Screenshot 2023-05-25 at 2 38 20 PM" src="https://github.com/codalab/codabench/assets/13259262/e4073b70-662f-4086-8ee6-1a6fb8bc7b03">



# Issues this PR resolves
#755 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

