### PR TITLE
Use title and url of benchmark in job status page

### DIFF
--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -24,7 +24,7 @@
                 {% endif %}
                 {% for submission in submissions %}
                 <tr>
-                    <td>{{ submission.phase.competition }}</td>
+                    <td><a class="link-no-deco" target="_blank" href="./competitions/{{ submission.phase.competition.id }}">{{ submission.phase.competition.title }}</a></td>
                     <td>{{ submission.pk }}</td>
                     <td>{{ submission.owner.username }}</td>
                     <td>{{ submission.worker_hostname }}</td>


### PR DESCRIPTION
Make title of competitions a clickable link in the admin job status page:

<img width="818" alt="Capture d’écran 2023-05-27 à 15 20 28" src="https://github.com/codalab/codabench/assets/11784999/3fbdf766-1321-4492-bac0-57b5f124867a">



# Issues this PR resolves

Point 2 of #744

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

