### PR TITLE
Add option to show/hide public submissions/datasets

### DIFF
--- a/src/static/riot/datasets/management.tag
+++ b/src/static/riot/datasets/management.tag
@@ -14,13 +14,17 @@
         <label>Show Auto Created</label>
         <input type="checkbox" ref="auto_created">
     </div>
+    <div class="ui checkbox inline-div" onclick="{ filter.bind(this, undefined) }">
+        <label>Show Public</label>
+        <input type="checkbox" ref="show_public">
+    </div>
     <button class="ui green right floated labeled icon button" onclick="{show_creation_modal}">
         <i selenium="add-dataset" class="plus icon"></i>
         Add Dataset/Program
     </button>
     <button class="ui red right floated labeled icon button {disabled: marked_datasets.length === 0}" onclick="{delete_datasets}">
         <i class="icon delete"></i>
-        Delete Selected Datasets
+        Delete Selected
     </button>
 
     <!-- Data Table -->
@@ -276,14 +280,12 @@
 
         self.update_datasets = function (filters) {
             filters = filters || {}
-            let show_datasets_created_by_comp = $(self.refs.auto_created).prop('checked')
-            if (!show_datasets_created_by_comp) {
-                filters.was_created_by_competition = false
-            }
+            filters.was_created_by_competition = $(self.refs.auto_created).prop('checked')
+            filters.is_public = $(self.refs.show_public).prop('checked')
             CODALAB.api.get_datasets(filters)
                 .done(function (data) {
                     self.datasets = data.results
-                    self.datasets = self.filter_out_submissions(self.datasets)
+                    //self.datasets = self.filter_out_submissions(self.datasets)
                     self.pagination = {
                         "count": data.count,
                         "next": data.next,

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -5,6 +5,10 @@
         <input type="text" placeholder="Search..." ref="search" onkeyup="{ filter.bind(this, undefined) }">
         <i class="search icon"></i>
     </div>
+    <div class="ui checkbox inline-div" onclick="{ filter.bind(this, undefined) }">
+        <label>Show Public</label>
+        <input type="checkbox" ref="show_public">
+    </div>
     <button class="ui green right floated labeled icon button" onclick="{show_creation_modal}">
         <i class="plus icon"></i>
         Add Submission
@@ -220,10 +224,8 @@
         self.pretty_date = date => luxon.DateTime.fromISO(date).toLocaleString(luxon.DateTime.DATE_FULL)
 
         self.filter = function (filters) {
-            let type = $(self.refs.type_filter).val()
             filters = filters || {}
             _.defaults(filters, {
-                type: type === '-' ? '' : type,
                 search: $(self.refs.search).val(),
                 page: 1,
             })
@@ -250,6 +252,7 @@
 
         self.update_submissions = function (filters) {
             filters = filters || {}
+            filters.is_public = $(self.refs.show_public).prop('checked')
             filters.type = "submission"
             CODALAB.api.get_datasets(filters)
                 .done(function (data) {


### PR DESCRIPTION
# @ mention of reviewers
...


# A brief description of the purpose of the changes contained in this PR.
In resource interface, now there is an option to show/hide public submissions/datasets and programs


<img width="436" alt="Screenshot 2023-06-01 at 12 53 17 PM" src="https://github.com/codalab/codabench/assets/13259262/ba812823-52c0-48ec-a894-d3402ad4fceb">
<img width="694" alt="Screenshot 2023-06-01 at 12 53 23 PM" src="https://github.com/codalab/codabench/assets/13259262/2530bedc-edb8-481b-8b3f-92c786dda4be">

# Issues this PR resolves
#713 -> Resource interface -> Points : 10, 11

> Public datasets should have their own tab
> Public datasets should not have delete button if they do not belong to us


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

