### PR TITLE
Created By is now a clickable link to user profile

### DIFF
--- a/src/static/riot/datasets/management.tag
+++ b/src/static/riot/datasets/management.tag
@@ -116,7 +116,7 @@
                 <tbody>
                 <tr>
                     <td>{selected_row.key}</td>
-                    <td>{selected_row.created_by}</td>
+                    <td><a href="/profiles/user/{selected_row.created_by}/" target=_blank>{selected_row.created_by}</a></td>
                     <td>{pretty_date(selected_row.created_when)}</td>
                     <td>{_.startCase(selected_row.type)}</td>
                     <td>{_.startCase(selected_row.is_public)}</td>

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -112,7 +112,7 @@
                     <td if="{selected_row.competition}"><a class="link-no-deco" target="_blank" href="../competitions/{ selected_row.competition.id }">{ selected_row.competition.title }</a></td>
                     <!--  show empty td if competition is not available  -->
                     <td if="{!selected_row.competition}"></td>
-                    <td>{selected_row.created_by}</td>
+                    <td><a href="/profiles/user/{selected_row.created_by}/" target=_blank>{selected_row.created_by}</a></td>
                     <td>{pretty_date(selected_row.created_when)}</td>
                     <td>{_.startCase(selected_row.type)}</td>
                     <td>{_.startCase(selected_row.is_public)}</td>

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -96,7 +96,7 @@
         <div class="content">
             <h4>{selected_task.description}</h4>
             <div class="ui divider" show="{selected_task.description}"></div>
-            <div><strong>Created By:</strong> {selected_task.created_by}</div>
+            <div><strong>Created By:</strong> <a href="/profiles/user/{selected_task.created_by}/" target=_blank>{selected_task.created_by}</a></div>
             <div><strong>Key:</strong> {selected_task.key}</div>
             <div><strong>Has Been Validated
                 <span data-tooltip="A task has been validated once one of its solutions has successfully been run against it">


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now in submission/dataset/task detail, Created By is a clickable link to the user profile

<img width="906" alt="Screenshot 2023-06-02 at 1 15 18 PM" src="https://github.com/codalab/codabench/assets/13259262/b88a9a42-a65f-4648-b819-aa6ded36eab3">

<img width="912" alt="Screenshot 2023-06-02 at 1 15 32 PM" src="https://github.com/codalab/codabench/assets/13259262/364d2e9f-e3ff-4d5e-9d83-278b1b3f762e">

<img width="914" alt="Screenshot 2023-06-02 at 1 15 46 PM" src="https://github.com/codalab/codabench/assets/13259262/7b4f3058-2994-48e9-a8ff-6193e66ad4b4">



# Issues this PR resolves
#713 -> Interface -> Point 9

> submission detail, make `created_by` a clickable link to user profile



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

