### PR TITLE
manual_comp_create_queue

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -170,6 +170,9 @@ class CompetitionUpdateSerializer(CompetitionSerializer):
     phases = PhaseUpdateSerializer(many=True)
     queue = None
 
+class CompetitionCreateSerializer(CompetitionSerializer):
+    queue = None
+
 
 class CompetitionDetailSerializer(serializers.ModelSerializer):
     created_by = serializers.CharField(source='created_by.username', read_only=True)

--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -170,6 +170,7 @@ class CompetitionUpdateSerializer(CompetitionSerializer):
     phases = PhaseUpdateSerializer(many=True)
     queue = None
 
+
 class CompetitionCreateSerializer(CompetitionSerializer):
     queue = None
 

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -23,7 +23,7 @@ from rest_framework_extensions.key_constructor.constructors import DefaultListKe
 from api.pagination import LargePagination
 from api.renderers import ZipRenderer
 from rest_framework.viewsets import ModelViewSet
-from api.serializers.competitions import CompetitionSerializer, CompetitionSerializerSimple, PhaseSerializer, \
+from api.serializers.competitions import CompetitionSerializerSimple, PhaseSerializer, \
     CompetitionCreationTaskStatusSerializer, CompetitionDetailSerializer, CompetitionParticipantSerializer, \
     FrontPageCompetitionsSerializer, PhaseResultsSerializer, CompetitionUpdateSerializer, CompetitionCreateSerializer
 from api.serializers.leaderboards import LeaderboardPhaseSerializer, LeaderboardSerializer
@@ -146,6 +146,7 @@ class CompetitionViewSet(ModelViewSet):
         elif self.request.method == 'PATCH':
             return CompetitionUpdateSerializer
         else:
+            # Really just CompetitionSerializer with queue = None
             return CompetitionCreateSerializer
 
     def create(self, request, *args, **kwargs):
@@ -172,7 +173,7 @@ class CompetitionViewSet(ModelViewSet):
             for phase in data['phases']:
                 phase['leaderboard'] = leaderboard_id
 
-        serializer = self.get_serializer(data=request.data) # CompetitionSerializer but this is for update...hmmm curious
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -25,7 +25,7 @@ from api.renderers import ZipRenderer
 from rest_framework.viewsets import ModelViewSet
 from api.serializers.competitions import CompetitionSerializer, CompetitionSerializerSimple, PhaseSerializer, \
     CompetitionCreationTaskStatusSerializer, CompetitionDetailSerializer, CompetitionParticipantSerializer, \
-    FrontPageCompetitionsSerializer, PhaseResultsSerializer, CompetitionUpdateSerializer
+    FrontPageCompetitionsSerializer, PhaseResultsSerializer, CompetitionUpdateSerializer, CompetitionCreateSerializer
 from api.serializers.leaderboards import LeaderboardPhaseSerializer, LeaderboardSerializer
 from competitions.emails import send_participation_requested_emails, send_participation_accepted_emails, \
     send_participation_denied_emails, send_direct_participant_email
@@ -146,7 +146,7 @@ class CompetitionViewSet(ModelViewSet):
         elif self.request.method == 'PATCH':
             return CompetitionUpdateSerializer
         else:
-            return CompetitionSerializer
+            return CompetitionCreateSerializer
 
     def create(self, request, *args, **kwargs):
         """Mostly a copy of the underlying base create, however we return some additional data
@@ -158,7 +158,6 @@ class CompetitionViewSet(ModelViewSet):
 
         # TODO - This is Temporary. Need to change Leaderboard to Phase connect to M2M and handle this correctly.
         # save leaderboard individually, then pass pk to each phase
-        print(f"{request.data['leaderboards']}")
         data = request.data
         if 'leaderboards' in data:
             leaderboard_data = data['leaderboards'][0]
@@ -173,7 +172,7 @@ class CompetitionViewSet(ModelViewSet):
             for phase in data['phases']:
                 phase['leaderboard'] = leaderboard_id
 
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(data=request.data) # CompetitionSerializer but this is for update...hmmm curious
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)

--- a/src/static/riot/competitions/editor/_competition_details.tag
+++ b/src/static/riot/competitions/editor/_competition_details.tag
@@ -88,7 +88,7 @@
         </div>
         <div class="field required">
             <label>Competition Docker Image</label>
-            <input type="text" ref="docker_image" onchange="{form_updated}">
+            <input type="text" ref="docker_image" onchange="{form_updated}" value="codalab/codalab-legacy:py37">
         </div>
         <div class="field">
             <label>Competition Type</label>

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -267,8 +267,11 @@
 
                 self.has_initialized_calendars = true
             }
-            $(self.refs.calendar_start).calendar('set date', self.phases[self.selected_phase_index].start)
-            $(self.refs.calendar_end).calendar('set date', self.phases[self.selected_phase_index].end)
+            debugger
+            if(!(self.selected_phase_index === undefined)){
+                $(self.refs.calendar_start).calendar('set date', self.phases[self.selected_phase_index].start)
+                $(self.refs.calendar_end).calendar('set date', self.phases[self.selected_phase_index].end)
+            }
         }
 
         self.close_modal = function () {

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -267,7 +267,6 @@
 
                 self.has_initialized_calendars = true
             }
-            debugger
             if(!(self.selected_phase_index === undefined)){
                 $(self.refs.calendar_start).calendar('set date', self.phases[self.selected_phase_index].start)
                 $(self.refs.calendar_end).calendar('set date', self.phases[self.selected_phase_index].end)


### PR DESCRIPTION
This is code to fix the queue error when adding a competition manually with the editor. 

Manually creating a comp with queue throws wrong datatype error. We need to be able to set queue when creating competiton.


# Issues this PR resolves
- #740 
- #739 
- #909

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

