### PR TITLE
Search submissions in resource tab by file name and competition name

### DIFF
--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -21,14 +21,14 @@ class DataViewSet(ModelViewSet):
     queryset = Data.objects.all()
     filter_backends = (DjangoFilterBackend, SearchFilter)
     filter_fields = ('type', 'name', 'key', 'was_created_by_competition', 'is_public')
-    search_fields = ('name', 'description', 'key',)
+    search_fields = ('file_name', 'name', 'description', 'key', 'competition__title',)
     pagination_class = BasicPagination
 
     def get_queryset(self):
 
         if self.request.method == 'GET':
 
-            # new filters
+            # filters
             # -----------
 
             # _public = true if want to show public datasets/submissions


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now, users can search a submission by file name and competition name


# Issues this PR resolves
#713 -> Interface -> Points 10, 11

> The search bar for the tab "submissions" should search by filename 
> We need more filtering options. For instance, in the tab "submissions", we should be able to filter a specific competition.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

