### PR TITLE
Resource interface : Orderding/Sorting tables

### DIFF
--- a/src/static/riot/datasets/management.tag
+++ b/src/static/riot/datasets/management.tag
@@ -28,17 +28,17 @@
     </button>
 
     <!-- Data Table -->
-    <table class="ui {selectable: datasets.length > 0} celled compact table">
+    <table id="datasetsTable" class="ui {selectable: datasets.length > 0} celled compact sortable table">
         <thead>
         <tr>
             <th>File Name</th>
             <th width="175px">Type</th>
             <th width="175px">Size</th>
             <th width="125px">Uploaded</th>
-            <th width="60px">In Use</th>
-            <th width="60px">Public</th>
-            <th width="50px">Delete?</th>
-            <th width="25px"></th>
+            <th width="60px" class="no-sort">In Use</th>
+            <th width="60px" class="no-sort">Public</th>
+            <th width="50px" class="no-sort">Delete?</th>
+            <th width="25px" class="no-sort"></th>
         </tr>
         </thead>
         <tbody>
@@ -226,6 +226,7 @@
         self.one("mount", function () {
             $(".ui.dropdown", self.root).dropdown()
             $(".ui.checkbox", self.root).checkbox()
+            $('#datasetsTable').tablesort()
             self.update_datasets()
         })
 

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -19,16 +19,16 @@
     </button>
 
     <!-- Data Table -->
-    <table class="ui {selectable: submissions.length > 0} celled compact table">
+    <table id="submissionsTable" class="ui {selectable: submissions.length > 0} celled compact sortable table">
         <thead>
         <tr>
             <th>File Name</th>
             <th>Competition in</th>
             <th width="175px">Size</th>
             <th width="125px">Uploaded</th>
-            <th width="60px">Public</th>
-            <th width="50px">Delete?</th>
-            <th width="25px"></th>
+            <th width="60px" class="no-sort">Public</th>
+            <th width="50px" class="no-sort">Delete?</th>
+            <th width="25px" class="no-sort"></th>
         </tr>
         </thead>
         <tbody>
@@ -200,6 +200,7 @@
         self.one("mount", function () {
             $(".ui.dropdown", self.root).dropdown()
             $(".ui.checkbox", self.root).checkbox()
+            $('#submissionsTable').tablesort()
             self.update_submissions()
         })
 

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -15,16 +15,16 @@
         Delete Selected Tasks
     </button>
 
-    <table class="ui {selectable: tasks.length > 0} celled compact table">
+    <table id="tasksTable" class="ui {selectable: tasks.length > 0} celled compact sortable table">
         <thead>
         <tr>
             <th>Name</th>
             <th class="benchmark-row">Benchmarks</th>
             <th width="125px">Shared With</th>
             <th width="125px">Uploaded...</th>
-            <th width="50px">Public</th>
-            <th width="50px">Delete?</th>
-            <th width="25px"></th>
+            <th width="50px" class="no-sort">Public</th>
+            <th width="50px" class="no-sort">Delete?</th>
+            <th width="25px" class="no-sort"></th>
         </tr>
         </thead>
         <tbody>
@@ -257,6 +257,7 @@
         self.one("mount", function () {
             self.update_tasks()
             $(".ui.checkbox", self.root).checkbox()
+            $('#tasksTable').tablesort()
             $('.ui.search.dataset', self.root).each(function (i, item) {
                 $(item)
                     .search({


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now resource interface tables in tabs: submissions/datasets/tasks can be sorted/ordered


# Issues this PR resolves
#713 -> Interface -> Point 17
> Being able to order rows by clicking on the column name (e.g. size)



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

