### PR TITLE
default value added for rank

### DIFF
--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -143,7 +143,8 @@ class V15Unpacker(BaseUnpacker):
         except KeyError:
             raise CompetitionUnpackingException('Could not find leaderboards declared on the competition leaderboard')
         try:
-            columns = sorted([{'title': k, **v} for k, v in leaderboard['columns'].items()], key=lambda c: c['rank'])
+            # use rank = 1 if rank is not defined in .yaml file
+            columns = sorted([{'title': k, **v} for k, v in leaderboard['columns'].items()], key=lambda c: c.get('rank', 1))
         except KeyError:
             raise CompetitionUnpackingException('Could not find columns declared on the competition leaderboard')
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
rank when not defined in `.yaml` file is set to a default value of 1 in v1.5 unpacker


# Issues this PR resolves
#932 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

