### PR TITLE
Phase status fixed

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -289,40 +289,6 @@
                 })
             })
 
-            // loop over competition phases to mark if phase has started or ended
-            self.competition.phases.forEach(function (phase, index) {
-                
-                phase_ended = false 
-                phase_started = false
-
-                // check if phase has started
-                if((Date.parse(phase["start"]) - Date.parse(new Date())) > 0){
-                    // start date is in the future, phase started = NO
-                    phase_started = false
-                }else{
-                    // start date is not in the future, phase started = YES
-                    phase_started = true
-                }
-
-                if(phase_started){
-                    // check if end data exists for this phase
-                    if(phase["end"]){
-                        if((Date.parse(phase["end"]) - Date.parse(new Date())) < 0){
-                            // Phase cannote accept submissions if end date is in the past
-                            phase_ended = true
-                        }else{
-                            // Phase can accept submissions if end date is in the future
-                            phase_ended = false
-                        }
-                    }else{
-                        // Phase can accept submissions if end date is not given
-                        phase_ended = false
-                    }
-                }
-                self.competition.phases[index]["phase_ended"] = phase_ended
-                self.competition.phases[index]["phase_started"] = phase_started
-            })
-
             self.competition.is_admin = CODALAB.state.user.has_competition_admin_privileges(competition)
             self.selected_phase_index = _.get(_.find(self.competition.phases, {'status': 'Current'}), 'id')
             if (self.selected_phase_index == null) {

--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -1,11 +1,10 @@
 <submission-upload>
-    <div class="ui sixteen wide column submission-container"
-         show="{_.get(selected_phase, 'status') === 'Current' || opts.is_admin}">
+    <div class="ui sixteen wide column submission-container">
 
         <div class="submission-form">
             <h1>Submission upload</h1>
-            <div if="{_.get(selected_phase, 'phase_ended')}" class="ui red message">This phase has ended and no longer accepts submissions!</div>
-            <div if="{!_.get(selected_phase, 'phase_started')}" class="ui yellow message">This phase hasn't started yet!</div>
+            <div if="{_.get(selected_phase, 'status') === 'Previous'}" class="ui red message">This phase has ended and no longer accepts submissions!</div>
+            <div if="{_.get(selected_phase, 'status') === 'Next'}" class="ui yellow message">This phase hasn't started yet!</div>
             <form class="ui form coda-animated {error: errors}" ref="form" enctype="multipart/form-data">
                 <div class="submission-form" ref="fact_sheet_form" if="{ opts.fact_sheet !== null}">
                     <h2>Metadata or Fact Sheet</h2>
@@ -353,7 +352,7 @@
         self.check_can_upload = function () {
             
             // Check if selected phase accepts submissions (within the deadline of the phase)
-            if(self.selected_phase.phase_started && !self.selected_phase.phase_ended){
+            if(self.selected_phase.status === "Current"){
 
                 CODALAB.api.can_make_submissions(self.selected_phase.id)
                     .done(function (data) {
@@ -368,13 +367,12 @@
                     })
             }else{
                 // Error when phase is not accepting submissions
-                if(!self.selected_phase.phase_started){
+                if(self.selected_phase.status === "Next"){
                     toastr.error('This phase has not started yet. Please check the phase start date!')
                    
-                }else {
-                    if(self.selected_phase.phase_ended){
-                        toastr.error('This phase has ended and no longer accepts submissions!')
-                    }
+                }
+                if(self.selected_phase.status === "Previous"){
+                    toastr.error('This phase has ended and no longer accepts submissions!')
                 }
                 self.clear_form()
             }


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Phases api (example: https://www.codabench.org/api/phases/1215/) was giving null status and status was not used in the UI to allow or block user from submiting to a phase which has started/ended etc.

Now this is fixed.




# Issues this PR resolves
#931 

# What is changed?

- [x] Phases api ( https://www.codabench.org/api/phases/) fixed to add a valid status instead of `null`
- [x] Used these 3 statuses  (1. `Previous`, 2. `Current`, 3. `Next`)
- [x] Serializer modified to return correct status
- [x] Phase start/end logic based on start date and end date replaced by status in the UI submission panel   
- [x] Admin as well as participants are allowed to see submission panel 
- [x] error/warning messages are displayed  to both admin and participant for not started and ended phases

# Screenshots
API with valid status:
<img width="509" alt="Screenshot 2023-06-13 at 1 03 28 AM" src="https://github.com/codalab/codabench/assets/13259262/c1b3714c-f697-4973-8f96-406252fccf8f">



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

