### PR TITLE
More robust handling of metadata command in compute worker

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -497,9 +497,16 @@ class Run:
 
         logger.info(f"Metadata path is {os.path.join(program_dir, metadata_path)}")
         with open(os.path.join(program_dir, metadata_path), 'r') as metadata_file:
-            metadata = yaml.load(metadata_file.read(), Loader=yaml.FullLoader)
-            logger.info(f"Metadata contains:\n {metadata}")
-            command = metadata.get("command") if metadata is not None else None # in case the file exists but is empty
+            try: # try to find a command in the metadata, in other cases set metadata to None
+                metadata = yaml.load(metadata_file.read(), Loader=yaml.FullLoader)
+                logger.info(f"Metadata contains:\n {metadata}")
+                if isinstance(metadata, dict): # command found
+                    command = metadata.get("command")
+                else:
+                    command = None
+            except yaml.YAMLError as e:
+                print("Error parsing YAML file: ", e)
+                command = None
             if not command and kind == "ingestion":
                 raise SubmissionException("Program directory missing 'command' in metadata")
             elif not command:


### PR DESCRIPTION
The `metadata` file of a scoring or ingestion program is supposed to contain something like this:

```yaml
command: python3 scoring.py $argument [...]
```

However, organizers may provide empty file, or file simply containing a string. In such case, we simply want the command to be set to `None` instead of having the compute worker crashing. 

---

`codalab/competitions-v2-compute-worker:latest` and `codalab/competitions-v2-compute-worker:nvidia` updated.