### PR TITLE
docker image name in competition page

### DIFF
--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -32,6 +32,7 @@
                     </div>
                     <div class="row">
                         <div class="column">
+                            <!-- Main information -->
                             <div>
                                 <span class="detail-label">Organized by:</span>
                                 <span class="detail-item">{competition.created_by}</span>
@@ -44,17 +45,19 @@
                                 <span class="detail-label">Current server time:</span>
                                 <span class="detail-item" id="server_time">{pretty_date(CURRENT_DATE_TIME)}</span>
                             </div>
-                            <div class="competition-secret-key" if="{ competition.admin }">
-                                <span class="secret-label">Secret url:</span>
-                                <span id="secret-url">https://{ URLS.SECRET_KEY_URL(competition.id, competition.secret_key) }</span>
-                                <span onclick="{copy_secret_url}" class="ui send-pop-secret" data-content="Copied!">
-                                    <i class="ui copy icon"></i>
-                                </span>
-                            </div>
+                            <!-- Docker image -->
                             <div class="competition-secret-key">
                                 <span class="docker-label">Docker image:</span>
                                 <span id="docker-image">{ competition.docker_image }</span>
                                 <span onclick="{copy_docker_url}" class="ui send-pop-docker" data-content="Copied!">
+                                    <i class="ui copy icon"></i>
+                                </span>
+                            </div>
+                            <!-- Secret URL -->
+                            <div class="competition-secret-key" if="{ competition.admin }">
+                                <span class="secret-label">Secret url:</span>
+                                <span id="secret-url">https://{ URLS.SECRET_KEY_URL(competition.id, competition.secret_key) }</span>
+                                <span onclick="{copy_secret_url}" class="ui send-pop-secret" data-content="Copied!">
                                     <i class="ui copy icon"></i>
                                 </span>
                             </div>
@@ -249,6 +252,7 @@
         $blue = #2c3f4c
         $teal = #00bbbb
         $lightblue = #f2faff
+        $red = #DB2828
 
         .detail-label
             font-size 1.25em
@@ -266,10 +270,10 @@
             font-size 13px
 
         .secret-label
-            color #DB2828
+            color $red
 
         .docker-label
-            color #2290E2
+            color $teal
 
         .secret-url
             color $blue

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -47,7 +47,14 @@
                             <div class="competition-secret-key" if="{ competition.admin }">
                                 <span class="secret-label">Secret url:</span>
                                 <span id="secret-url">https://{ URLS.SECRET_KEY_URL(competition.id, competition.secret_key) }</span>
-                                <span onclick="{copy_secret_url}" class="ui send-pop" data-content="Copied!">
+                                <span onclick="{copy_secret_url}" class="ui send-pop-secret" data-content="Copied!">
+                                    <i class="ui copy icon"></i>
+                                </span>
+                            </div>
+                            <div class="competition-secret-key">
+                                <span class="docker-label">Docker image:</span>
+                                <span id="docker-image">{ competition.docker_image }</span>
+                                <span onclick="{copy_docker_url}" class="ui send-pop-docker" data-content="Copied!">
                                     <i class="ui copy icon"></i>
                                 </span>
                             </div>
@@ -207,7 +214,17 @@
             window.getSelection().addRange(range); // to select text
             document.execCommand("copy");
             window.getSelection().removeAllRanges();// to deselect
-            $('.send-pop').popup('toggle')
+            $('.send-pop-secret').popup('toggle')
+        }
+
+        self.copy_docker_url = function () {
+            let range = document.createRange();
+            range.selectNode(document.getElementById("docker-image"));
+            window.getSelection().removeAllRanges(); // clear current selection
+            window.getSelection().addRange(range); // to select text
+            document.execCommand("copy");
+            window.getSelection().removeAllRanges();// to deselect
+            $('.send-pop-docker').popup('toggle')
         }
 
         self.get_end_date = function (competition) {
@@ -250,6 +267,9 @@
 
         .secret-label
             color #DB2828
+
+        .docker-label
+            color #2290E2
 
         .secret-url
             color $blue


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can see docker-image name for a competition


# Screenshots
Admin view
<img width="1010" alt="Screenshot 2023-06-14 at 9 15 34 PM" src="https://github.com/codalab/codabench/assets/13259262/41dd979d-e053-48be-b486-f593b32c9ae0">


Participant view
<img width="1049" alt="Screenshot 2023-06-14 at 9 15 16 PM" src="https://github.com/codalab/codabench/assets/13259262/e6231ccf-bc14-4b4d-b0cc-a08abc04c0c7">



# Issues this PR resolves
#764 -> Point 1

> display docker-image name in competition




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

