### PR TITLE
Remove python-setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8
 
-RUN apt-get update && apt-get install -yy gcc build-essential python-setuptools
+RUN apt-get update && apt-get install -y gcc build-essential && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
 
@@ -8,7 +8,5 @@ ADD requirements.dev.txt .
 ADD requirements.txt .
 RUN pip install -U pip
 RUN pip install -r requirements.dev.txt
-
-# INSTALL CHROMEDRIVER HERE?
 
 WORKDIR /app


### PR DESCRIPTION
The `python-setuptools` package provides `easy_install`, which is a deprecated Python package manager that was heavily used before `pip` came along. Since we're using pip in your Dockerfile, you actually don't need to install python-setuptools.

Also, it's good practice to clean up the apt cache by adding `rm -rf /var/lib/apt/lists/*` at the end of the apt-get install line. This reduces the size of the Docker image.

Lastly, `-y` is prefered to `-yy`which is deprecated and considered a security risk.