### PR TITLE
Organization delete functionality added

### DIFF
--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -229,3 +229,18 @@ class OrganizationViewSet(mixins.CreateModelMixin,
 
         mem_ser = MembershipSerializer(membership)
         return Response(mem_ser.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['delete'])
+    def delete_organization(self, request, pk=None):
+        try:
+            org = Organization.objects.get(id=pk)
+            org.delete()
+            return Response({
+                "success": True,
+                "message": "Organization deleted!"
+            })
+        except Exception as e:
+            return Response({
+                "success": False,
+                "message": f"{e}"
+            })

--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -234,11 +234,18 @@ class OrganizationViewSet(mixins.CreateModelMixin,
     def delete_organization(self, request, pk=None):
         try:
             org = Organization.objects.get(id=pk)
-            org.delete()
-            return Response({
-                "success": True,
-                "message": "Organization deleted!"
-            })
+            member = org.membership_set.get(user=request.user)
+            if member.group == Membership.OWNER:
+                org.delete()
+                return Response({
+                    "success": True,
+                    "message": "Organization deleted!"
+                })
+            else:
+                return Response({
+                    "success": False,
+                    "message": "You do not have delete rights!"
+                })
         except Exception as e:
             return Response({
                 "success": False,

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -276,6 +276,9 @@ CODALAB.api = {
     delete_organization_member: (id, data) => {
         return CODALAB.api.request('DELETE', `${URLS.API}organizations/${id}/delete_member/`, data)
     },
+    delete_organization: (id) => {
+        return CODALAB.api.request('DELETE', `${URLS.API}organizations/${id}/delete_organization/`)
+    },
     /*---------------------------------------------------------------------
          Participants
     ---------------------------------------------------------------------*/

--- a/src/templates/profiles/organization_detail.html
+++ b/src/templates/profiles/organization_detail.html
@@ -41,7 +41,7 @@
                                 <p>{{ organization.description | linebreaks }}</p>
                             </div>
                             <div class="extra">
-                                Participating in Codalab since {{ organization.date_created }}
+                                Participating in Codabench since {{ organization.date_created }}
                             </div>
                         </div>
                     </div>

--- a/src/templates/profiles/organization_detail.html
+++ b/src/templates/profiles/organization_detail.html
@@ -6,6 +6,18 @@
     {% if is_editor %}
         <div class="ui container" style="margin-bottom: 1em">
             <a href="{{ organization.url }}edit/"><button type="button" class="ui left floated button">Edit Organization</button></a>
+            
+            {% if organization.users|length > 1 %}
+                <button class="ui red right floated button disabled">
+                    Delete Organization
+                </button>
+            {% else %}
+                <button class="ui red right floated button" onclick="{self.delete_organization({{ organization.id }})}" >
+                    Delete Organization
+                </button>
+            {% endif %}
+            
+            
         </div>
     {% endif %}
     <div class="ui container">
@@ -76,4 +88,26 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script>
+    
+        self.delete_organization = (organization_id) => {
+            if (confirm(`Are you sure you want to permanently delete this organization?`)) {
+                CODALAB.api.delete_organization(organization_id)
+                    .done((resp) => {
+                        if(resp.success){
+                            toastr.success(resp.message)
+                            setTimeout(function (){window.location.href = '/';}, 1000)
+                        }else{
+                            toastr.error(resp.message)
+                        }
+                    })
+                    .fail((errors) => {
+                        toastr.error('An Error has occurred')
+                    })
+            }
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can delete their organization if organization users are no more than 1
<img width="1245" alt="Screenshot 2023-06-18 at 1 33 27 AM" src="https://github.com/codalab/codabench/assets/13259262/dd3203ad-15b1-416d-81f2-31817c99f1da">

<img width="456" alt="Screenshot 2023-06-18 at 1 35 36 AM" src="https://github.com/codalab/codabench/assets/13259262/377ae235-5732-4179-b79c-bfc8382c7960">


After deletion, user is redirected to home page



# Issues this PR resolves

- #938 
- #961 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

