### PR TITLE
Detailed results displayed for each task on leaderboard

### DIFF
--- a/src/apps/api/serializers/submissions.py
+++ b/src/apps/api/serializers/submissions.py
@@ -98,7 +98,8 @@ class SubmissionLeaderBoardSerializer(serializers.ModelSerializer):
             'scores',
             'display_name',
             'slug_url',
-            'organization'
+            'organization',
+            'detailed_result'
         )
         extra_kwargs = {
             "scores": {"read_only": True},

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -517,6 +517,7 @@ class PhaseViewSet(ModelViewSet):
         }
         columns = [col for col in query['columns']]
         submissions_keys = {}
+        submission_detailed_results = {}
         for submission in query['submissions']:
 
             # count number of entries/number of submissions for the owner of this submission for this phase
@@ -529,12 +530,22 @@ class PhaseViewSet(ModelViewSet):
                 .strftime('%Y-%m-%d')
 
             submission_key = f"{submission['owner']}{submission['parent'] or submission['id']}"
+
+            # gather detailed result from submissions for each task
+            # detailed_results are gathered based on submission key
+            submission_detailed_results.setdefault(submission_key, []).append({
+                'detailed_result': submission['detailed_result'],
+                'task': submission['task'],
+                'id': submission['id']
+            })
+
             if submission_key not in submissions_keys:
                 submissions_keys[submission_key] = len(response['submissions'])
                 response['submissions'].append({
                     'id': submission['id'],
                     'owner': submission['display_name'] or submission['owner'],
                     'scores': [],
+                    'detailed_results': [],
                     'fact_sheet_answers': submission['fact_sheet_answers'],
                     'slug_url': submission['slug_url'],
                     'organization': submission['organization'],
@@ -558,6 +569,11 @@ class PhaseViewSet(ModelViewSet):
                 # round the score to 'precision' decimal points
                 tempScore['score'] = str(round(float(tempScore["score"]), precision))
                 response['submissions'][submissions_keys[submission_key]]['scores'].append(tempScore)
+
+        # put detailed results in its submission
+        for k, v in submissions_keys.items():
+            response['submissions'][v]['detailed_results'] = submission_detailed_results[k]
+        print(f"\n{response['submissions']}\n")
 
         for task in query['tasks']:
             # This can be used to rendered variable columns on each task

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -533,8 +533,10 @@ class PhaseViewSet(ModelViewSet):
 
             # gather detailed result from submissions for each task
             # detailed_results are gathered based on submission key
+            # `id` is used to fetch the right detailed result in detailed results page
+            # `detailed_result` url is not needed
             submission_detailed_results.setdefault(submission_key, []).append({
-                'detailed_result': submission['detailed_result'],
+                # 'detailed_result': submission['detailed_result'],
                 'task': submission['task'],
                 'id': submission['id']
             })

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -29,8 +29,7 @@
         <tr class="task-row">
             <th>Task:</th>
             <th colspan=3></th>
-            <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ task.colWidth }">{ task.name }</th>
-            <th if="{enable_detailed_results}"></th>
+            <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ enable_detailed_results ? task.colWidth+1 : task.colWidth}">{ task.name }</th>
         </tr>
         <tr>
             <th class="center aligned">#</th>
@@ -38,7 +37,7 @@
             <th>Entries</th>
             <th>Date of last entry</th>
             <th each="{ column in filtered_columns }" colspan="1">{column.title}</th>
-            <th if="{enable_detailed_results}">Detailed Results</th>
+            
         </tr>
         </thead>
         <tbody>
@@ -60,8 +59,12 @@
             <td>{submission.num_entries}</td>
             <td>{submission.last_entry_date}</td>
             <td if="{submission.organization !== null}"><a href="{submission.organization.url}">{ submission.organization.name }</a></td>
-            <td each="{ column in filtered_columns }">{ get_score(column, submission) } </td>
-            <td if="{enable_detailed_results}"><a href="detailed_results/{submission.id}" target="_blank">Show detailed results</a></td>
+            <td each="{ column in filtered_columns }">
+                <a if="{column.title == 'Detailed Results'}" href="detailed_results/{get_detailed_result_submisison_id(column, submission)}" target="_blank">Show detailed results</a> 
+                <span if="{column.title != 'Detailed Results'}">{get_score(column, submission)}</span>
+            </td>
+           
+           
         </tr>
         </tbody>
     </table>
@@ -147,12 +150,27 @@
                             column.task_id = task.id
                             self.columns.push(column)
                         }
+                        if(self.enable_detailed_results){
+                            self.columns.push({
+                              task_id: task.id,
+                              title: "Detailed Results"
+                            })
+                        }
                     }
                     self.filter_columns()
                     $('#leaderboardTable').tablesort()
                     self.update()
                 })
         }
+
+        self.get_detailed_result_submisison_id = function(column, submisison){
+            for (index in submisison.detailed_results) {
+                if(column.task_id == submisison.detailed_results[index].task){
+                    return submisison.detailed_results[index].id
+                }
+            }
+        }
+
 
         CODALAB.events.on('phase_selected', data => {
             self.phase_id = data.id

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -29,7 +29,7 @@
         <tr class="task-row">
             <th>Task:</th>
             <th colspan=3></th>
-            <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ enable_detailed_results ? task.colWidth+1 : task.colWidth}">{ task.name }</th>
+            <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ task.colWidth }">{ task.name }</th>
         </tr>
         <tr>
             <th class="center aligned">#</th>
@@ -104,6 +104,7 @@
         self.filter_columns = () => {
             let search_key = self.refs.leaderboardFilter.value.toLowerCase()
             self.filtered_tasks = JSON.parse(JSON.stringify(self.selected_leaderboard.tasks))
+            console.log(self.filtered_tasks)
             if(search_key){
                 self.filtered_columns = []
                 for (const column of self.columns){
@@ -146,16 +147,20 @@
                         self.selected_leaderboard.tasks.unshift(fake_metadata_task)
                     }
                     for(task of self.selected_leaderboard.tasks){
+
                         for(column of task.columns){
                             column.task_id = task.id
                             self.columns.push(column)
                         }
-                        if(self.enable_detailed_results){
+                        // -1 id is used for fact sheet answers
+                        if(self.enable_detailed_results & task.id != -1){
                             self.columns.push({
                               task_id: task.id,
                               title: "Detailed Results"
                             })
+                            task.colWidth += 1
                         }
+                        console.log(task)
                     }
                     self.filter_columns()
                     $('#leaderboardTable').tablesort()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can see detailed results for each task in leaderboard
<img width="1188" alt="Screenshot 2023-06-20 at 6 32 19 AM" src="https://github.com/codalab/codabench/assets/13259262/d1fa854a-a931-4b93-97c8-609dd0e6130f">



# Issues this PR resolves

- #907 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

