### PR TITLE
Api security (competitions and phases)

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -337,18 +337,6 @@ class CompetitionCreationTaskStatusSerializer(serializers.ModelSerializer):
 class CompetitionParticipantSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
     is_bot = serializers.BooleanField(source='user.is_bot')
-
-    class Meta:
-        model = CompetitionParticipant
-        fields = (
-            'username',
-            'is_bot',
-        )
-
-
-class CompetitionParticipantWithEmailSerializer(serializers.ModelSerializer):
-    username = serializers.CharField(source='user.username')
-    is_bot = serializers.BooleanField(source='user.is_bot')
     email = serializers.CharField(source='user.email')
 
     class Meta:

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -25,7 +25,6 @@ from api.renderers import ZipRenderer
 from rest_framework.viewsets import ModelViewSet
 from api.serializers.competitions import CompetitionSerializerSimple, PhaseSerializer, \
     CompetitionCreationTaskStatusSerializer, CompetitionDetailSerializer, CompetitionParticipantSerializer, \
-    CompetitionParticipantWithEmailSerializer,\
     FrontPageCompetitionsSerializer, PhaseResultsSerializer, CompetitionUpdateSerializer, CompetitionCreateSerializer
 from api.serializers.leaderboards import LeaderboardPhaseSerializer, LeaderboardSerializer
 from competitions.emails import send_participation_requested_emails, send_participation_accepted_emails, \
@@ -602,6 +601,7 @@ class PhaseViewSet(ModelViewSet):
 
 class CompetitionParticipantViewSet(ModelViewSet):
     queryset = CompetitionParticipant.objects.all()
+    serializer_class = CompetitionParticipantSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter)
     filter_fields = ('user__username', 'user__email', 'status', 'competition')
     search_fields = ('user__username', 'user__email',)
@@ -613,14 +613,6 @@ class CompetitionParticipantViewSet(ModelViewSet):
             qs = qs.filter(competition__in=user.competitions.all() | user.collaborations.all())
         qs = qs.select_related('user').order_by('user__username')
         return qs
-
-    def get_serializer_class(self):
-
-        participants_with_email = self.request.query_params.get('participants_with_email', None)
-        if participants_with_email:
-            return CompetitionParticipantWithEmailSerializer
-        else:
-            return CompetitionParticipantSerializer
 
     def update(self, request, *args, **kwargs):
         if request.method == 'PATCH':

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -482,6 +482,19 @@ class PhaseViewSet(ModelViewSet):
     serializer_class = PhaseSerializer
 
     # TODO! Security, who can access/delete/etc this?
+    def get_queryset(self):
+        qs = super().get_queryset()
+
+        # Filter phases
+        # show all phases which belongs to competitions created by this user
+        # or
+        # show phases belonging to published competitions
+        qs = qs.filter(
+            Q(competition__created_by=self.request.user) |
+            Q(competition__published=True)
+        )
+
+        return qs
 
     @action(detail=True, methods=('POST',), url_name='manually_migrate')
     def manually_migrate(self, request, pk):

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -91,10 +91,18 @@ class CompetitionViewSet(ModelViewSet):
                     (Q(published=True) & ~Q(created_by=self.request.user)) |
                     (Q(participants__user=self.request.user) & Q(participants__status="approved"))
                 ).distinct()
+
+            # default condition
+            if (not mine) and (not participating_in) and (not search_query):
+                qs = qs.filter(
+                    (Q(created_by=self.request.user)) |
+                    (Q(collaborators__in=[self.request.user])) |
+                    (Q(published=True) & ~Q(created_by=self.request.user)) |
+                    (Q(participants__user=self.request.user) & Q(participants__status="approved"))
+                ).distinct()
         else:
             # if user is not authenticated only show public competitions in the search
-            if (search_query):
-                qs = qs.filter(Q(published=True))
+            qs = qs.filter(Q(published=True))
 
         # On GETs lets optimize the query to reduce DB calls
         if self.request.method == 'GET':

--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -134,7 +134,6 @@
             if (status && status !== '-') {
                 filters.status = status
             }
-            filters.participants_with_email = true
 
             CODALAB.api.get_participants(filters)
                 .done(participants => {
@@ -149,7 +148,12 @@
         self._update_status = (id, status) => {
             CODALAB.api.update_participant_status(id, {status: status})
                 .done(() => {
-                    toastr.success('success')
+                    if(status === 'denied'){
+                        toastr.success('Revoked successfully')
+                    }else{
+                        toastr.success('Approved successfully')
+                    }
+                    
                     self.update_participants()
                 })
         }


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @dtuantran 


# A brief description of the purpose of the changes contained in this PR.
Competitions and Phases apis are fixed. Now the following will happen

### Competitions(http://localhost/api/competitions/)
Show competitions where
- user is owner
- user is a collaborator
- competition is public
- user is an approved participant

### Competitions(http://localhost/api/phases/)
Show phases where
- user is owner of the competition to which this phase belongs
- competition is public to which this phase belongs

**Additional fix:**  
Leaked uses in api/participants fixed to show participants of a competition and fixed the issue of participant approval and revoking

# Issues this PR resolves

- #971
- #972 
- #973
- #885 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

