### PR TITLE
Revert "leaked users fixed (#929)"

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -337,18 +337,6 @@ class CompetitionCreationTaskStatusSerializer(serializers.ModelSerializer):
 class CompetitionParticipantSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
     is_bot = serializers.BooleanField(source='user.is_bot')
-
-    class Meta:
-        model = CompetitionParticipant
-        fields = (
-            'username',
-            'is_bot',
-        )
-
-
-class CompetitionParticipantWithEmailSerializer(serializers.ModelSerializer):
-    username = serializers.CharField(source='user.username')
-    is_bot = serializers.BooleanField(source='user.is_bot')
     email = serializers.CharField(source='user.email')
 
     class Meta:

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -25,7 +25,6 @@ from api.renderers import ZipRenderer
 from rest_framework.viewsets import ModelViewSet
 from api.serializers.competitions import CompetitionSerializerSimple, PhaseSerializer, \
     CompetitionCreationTaskStatusSerializer, CompetitionDetailSerializer, CompetitionParticipantSerializer, \
-    CompetitionParticipantWithEmailSerializer,\
     FrontPageCompetitionsSerializer, PhaseResultsSerializer, CompetitionUpdateSerializer, CompetitionCreateSerializer
 from api.serializers.leaderboards import LeaderboardPhaseSerializer, LeaderboardSerializer
 from competitions.emails import send_participation_requested_emails, send_participation_accepted_emails, \
@@ -605,6 +604,7 @@ class PhaseViewSet(ModelViewSet):
 
 class CompetitionParticipantViewSet(ModelViewSet):
     queryset = CompetitionParticipant.objects.all()
+    serializer_class = CompetitionParticipantSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter)
     filter_fields = ('user__username', 'user__email', 'status', 'competition')
     search_fields = ('user__username', 'user__email',)
@@ -616,14 +616,6 @@ class CompetitionParticipantViewSet(ModelViewSet):
             qs = qs.filter(competition__in=user.competitions.all() | user.collaborations.all())
         qs = qs.select_related('user').order_by('user__username')
         return qs
-
-    def get_serializer_class(self):
-
-        participants_with_email = self.request.query_params.get('participants_with_email', None)
-        if participants_with_email:
-            return CompetitionParticipantWithEmailSerializer
-        else:
-            return CompetitionParticipantSerializer
 
     def update(self, request, *args, **kwargs):
         if request.method == 'PATCH':

--- a/src/apps/profiles/models.py
+++ b/src/apps/profiles/models.py
@@ -89,7 +89,7 @@ class User(ChaHubSaveMixin, AbstractBaseUser, PermissionsMixin):
         return self.name
 
     def __str__(self):
-        return self.username
+        return f'{self.username} | {self.email}'
 
     @property
     def slug_url(self):

--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -134,7 +134,6 @@
             if (status && status !== '-') {
                 filters.status = status
             }
-            filters.participants_with_email = true
 
             CODALAB.api.get_participants(filters)
                 .done(participants => {


### PR DESCRIPTION
We need to revert #929 because it breaks the organizer interface used to approve / revoke participants.