### PR TITLE
API Security - Competitions and Participants

### DIFF
--- a/src/apps/profiles/models.py
+++ b/src/apps/profiles/models.py
@@ -89,7 +89,7 @@ class User(ChaHubSaveMixin, AbstractBaseUser, PermissionsMixin):
         return self.name
 
     def __str__(self):
-        return f'{self.username} | {self.email}'
+        return self.username
 
     @property
     def slug_url(self):

--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -148,7 +148,11 @@
         self._update_status = (id, status) => {
             CODALAB.api.update_participant_status(id, {status: status})
                 .done(() => {
-                    toastr.success('success')
+                    if(status === 'denied'){
+                        toastr.success('Revoked successfully')
+                    }else{
+                        toastr.success('Approved successfully')
+                    }
                     self.update_participants()
                 })
         }


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
This PR solves 2 issues:

1. In http://localhost/api/competitions/ ,  emails of users were leaked. 
2. In http://localhost/api/participants/ ,  no participants will be shown unless this is accessed from the website and not from /api/participants



Competition users emails:
<img width="481" alt="Screenshot 2023-07-30 at 8 16 51 PM" src="https://github.com/codalab/codabench/assets/13259262/2b209fea-3ee9-4c03-89d7-38bf395eeba3">


Tested:

- [x] users emails are not leaked
- [x] participants are now shown in /api/participants
- [x] approve and revoke functionality works
- [x] sending email to participants works


# Issues this PR resolves
- #885 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

