### PR TITLE
API Security - Phases

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -511,20 +511,20 @@ class PhaseViewSet(ModelViewSet):
     serializer_class = PhaseSerializer
 
     def get_queryset(self):
-        # You can add your logic here to return the full queryset when needed
         qs = Phase.objects.all()
         return qs
 
     def list(self, request, *args, **kwargs):
         # Check if it's a direct request to /api/phases/
+        # i.e without a pk
         direct_request = 'pk' not in kwargs or kwargs['pk'] == 'list'
 
         if direct_request:
-            # If it's a direct request, return an empty response without any actual phase objects
+            # return empty response in direct request
             return Response([], status=status.HTTP_200_OK)
 
         # Otherwise, allow other functions to use the list functionality as usual
-        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self.get_queryset()
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
@@ -636,7 +636,6 @@ class PhaseViewSet(ModelViewSet):
         # put detailed results in its submission
         for k, v in submissions_keys.items():
             response['submissions'][v]['detailed_results'] = submission_detailed_results[k]
-        print(f"\n{response['submissions']}\n")
 
         for task in query['tasks']:
             # This can be used to rendered variable columns on each task

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -508,8 +508,25 @@ class CompetitionViewSet(ModelViewSet):
 
 
 class PhaseViewSet(ModelViewSet):
-    queryset = Phase.objects.none()
     serializer_class = PhaseSerializer
+
+    def get_queryset(self):
+        # You can add your logic here to return the full queryset when needed
+        qs = Phase.objects.all()
+        return qs
+
+    def list(self, request, *args, **kwargs):
+        # Check if it's a direct request to /api/phases/
+        direct_request = 'pk' not in kwargs or kwargs['pk'] == 'list'
+
+        if direct_request:
+            # If it's a direct request, return an empty response without any actual phase objects
+            return Response([], status=status.HTTP_200_OK)
+
+        # Otherwise, allow other functions to use the list functionality as usual
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
     # TODO! Security, who can access/delete/etc this?
 

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -508,7 +508,7 @@ class CompetitionViewSet(ModelViewSet):
 
 
 class PhaseViewSet(ModelViewSet):
-    queryset = Phase.objects.all()
+    queryset = Phase.objects.none()
     serializer_class = PhaseSerializer
 
     # TODO! Security, who can access/delete/etc this?


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
http://localhost/api/phases/ was showing all the phases. As this link is never used and competitions access phases internally, by default this API link will now show no phases.



# Issues this PR resolves
- #972 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

