### PR TITLE
Phase dates - do not use same dates for one phase end and next phase start

### DIFF
--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -106,7 +106,7 @@ v2_yaml_data = {
             "execution_time_limit": 500,
             "max_submissions_per_day": 5,
             "start": "2019-01-01",
-            "end": "2019-09-30",
+            "end": "2019-09-29",
             "tasks": [0]
         },
         {

--- a/src/apps/competitions/tests/unpacker_test_data.py
+++ b/src/apps/competitions/tests/unpacker_test_data.py
@@ -204,7 +204,7 @@ PHASES = [
         'max_submissions_per_person': None,
         'auto_migrate_to_this_phase': False,
         'has_max_submissions': True,
-        'end': datetime.datetime(2019, 9, 30, 0, 0, tzinfo=timezone.now().tzinfo),
+        'end': datetime.datetime(2019, 9, 29, 0, 0, tzinfo=timezone.now().tzinfo),
         'public_data': None,
         'starting_kit': None,
         'tasks': [0],

--- a/src/apps/competitions/unpackers/base_unpacker.py
+++ b/src/apps/competitions/unpackers/base_unpacker.py
@@ -127,6 +127,12 @@ class BaseUnpacker:
                     f'Phases must be sequential. Phase: {phase2.get("name", phase2["index"])}'
                     f'starts before Phase: {phase1.get("name", phase1["index"])} has ended'
                 )
+            elif phase1['end'] == phase2['start']:
+                # Current phase start date and previous phase end dates are same, raise error
+                raise CompetitionUnpackingException(
+                    f'Phases dates conflict. Phase: {phase2.get("name", phase2["index"])} '
+                    f'should start after Phase: {phase1.get("name", phase1["index"])} has ended'
+                )
 
     def _unpack_pages(self):
         """

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -4,6 +4,7 @@ from competitions.unpackers.base_unpacker import BaseUnpacker
 from competitions.unpackers.utils import CompetitionUnpackingException, get_datetime
 import logging
 logger = logging.getLogger()
+import datetime
 
 
 class V15Unpacker(BaseUnpacker):
@@ -90,7 +91,11 @@ class V15Unpacker(BaseUnpacker):
                 new_phase['has_max_submissions'] = True
             try:
                 next_phase = phases[index + 1]
-                new_phase['end'] = get_datetime(next_phase['start_date'])
+                # V1 phases have no end dates.
+                # to set an end date of a phase, get the next phase starting date
+                next_phase_start_date = get_datetime(next_phase['start_date'])
+                # subtract one day from it and use it as this phase end date
+                new_phase['end'] = next_phase_start_date - datetime.timedelta(days=1)
             except IndexError:
                 end = self.competition.get('end_date')
                 if end and end != 'null':

--- a/src/apps/competitions/unpackers/v1.py
+++ b/src/apps/competitions/unpackers/v1.py
@@ -1,10 +1,10 @@
 import os
+import datetime
 
 from competitions.unpackers.base_unpacker import BaseUnpacker
 from competitions.unpackers.utils import CompetitionUnpackingException, get_datetime
 import logging
 logger = logging.getLogger()
-import datetime
 
 
 class V15Unpacker(BaseUnpacker):


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now in both V1 and V2 bundles, Phase 1 end and Phase 2 start dates cannot be same

What will happen:

1. `V1` if a phase has no end date and this phase is not the last phase, use the next phase (start date - 1) as its end date
2. `V2`: check if a phase is not the first phase, and its start date and previous phase end date are same, then raise error



### `V2` error screenshot
<img width="574" alt="V2" src="https://github.com/codalab/codabench/assets/13259262/8bca60b7-3647-4097-ad5a-f63581e17302">


# Issues this PR resolves
- #1027 





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

