### PR TITLE
Submission Panel -  submit as your org or org where you are added

### DIFF
--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -45,7 +45,7 @@ class UserViewSet(mixins.UpdateModelMixin,
 
     @action(detail=False, methods=['get'], permission_classes=[IsAuthenticated])
     def participant_organizations(self, request):
-        memberships = request.user.membership_set.filter(group__in=Membership.PARTICIPANT_GROUP).prefetch_related('organization')
+        memberships = request.user.membership_set.filter(group__in=Membership.ALL_GROUP).prefetch_related('organization')
         data = SimpleOrganizationSerializer([member.organization for member in memberships], many=True).data
         return Response(data)
 

--- a/src/apps/profiles/models.py
+++ b/src/apps/profiles/models.py
@@ -199,6 +199,7 @@ class Membership(models.Model):
     EDITORS_GROUP = [OWNER, MANAGER]
     PARTICIPANT_GROUP = EDITORS_GROUP + [PARTICIPANT]
     SETTABLE_PERMISSIONS = [MANAGER, PARTICIPANT, MEMBER]
+    ALL_GROUP = EDITORS_GROUP + [PARTICIPANT, MEMBER]
 
     group = models.TextField(choices=PERMISSIONS, default=INVITED, null=False, blank=False)
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE)


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
In the submission panel, users were only getting organizations they have created. Now users can submit as an organization which is either theirs or they are added as members to it.


# Issues this PR resolves
- #805 -> Bug # 2



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

