### PR TITLE
Queue - remove queue from competition when queue is made private

### DIFF
--- a/src/static/riot/competitions/editor/_competition_details.tag
+++ b/src/static/riot/competitions/editor/_competition_details.tag
@@ -155,6 +155,7 @@
                 // Note: Passing `public=true` so default behavior is users can search for public queues
                 apiSettings: {
                     url: `${URLS.API}queues/?search={query}&public=true`,
+                    cache: false
                 },
                 clearable: true,
                 minCharacters: 2,

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -69,9 +69,8 @@
         </tr>
         </tbody>
         <tfoot>
-        <!-------------------------------------
-                  Pagination
-        ------------------------------------->
+
+        <!-- Pagination -->
         <tr if="{queues.length > 0 && ( _.get(pagination, 'next') || _.get(pagination, 'previous') ) }">
             <th colspan="5">
                 <div class="ui right floated pagination menu" if="{queues.length > 0}">


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
When a user's public Queue is updated to private, remove it from all competitions which do not belong to this user.


# Issues this PR resolves
- #1014 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

