### PR TITLE
Rerun all submissions - allowed for super admin and with restrictions for competition admins

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -59,6 +59,14 @@ AWS_STORAGE_PRIVATE_BUCKET_NAME=private
 AWS_S3_ENDPOINT_URL=http://minio:9000/
 AWS_QUERYSTRING_AUTH=False
 
+# -----------------------------------------------------------------------------
+# Limit for re-running submission
+# This is used to limit users to rerun submissions
+# on default queue when number of submissions are < RERUN_SUBMISSION_LIMIT
+# -----------------------------------------------------------------------------
+RERUN_SUBMISSION_LIMIT=30
+
+
 # # S3 storage example
 # STORAGE_TYPE=s3
 # AWS_ACCESS_KEY_ID=12312312312312312331223

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -585,28 +585,69 @@ class PhaseViewSet(ModelViewSet):
     def rerun_submissions(self, request, pk):
 
         # Limit for rerunning submissions
-        RERUN_SUBMISSION_LIMIT = 200
+        RERUN_SUBMISSION_LIMIT = 30
 
         phase = self.get_object()
         comp = phase.competition
 
-        # error when user is not super user or admin of the competition
-        if request.user not in comp.all_organizers and not request.user.is_superuser:
-            raise PermissionDenied('You do not have permission to re-run submissions')
-
         # Get submissions
         submissions = phase.submissions.all()
+
+        can_re_run_submissions = False
+        error_message = ""
+
+        # Super admin can rerun without any restrictions
+        if request.user.is_superuser:
+            can_re_run_submissions = True
+
+        # competition admin can run only if
+        elif request.user in comp.all_organizers:
+
+            # submissions are in limit
+            if len(submissions) <= RERUN_SUBMISSION_LIMIT:
+                can_re_run_submissions = True
+
+            # submissions are not in limit
+            else:
+                # Codabemch public queue
+                if comp.queue is None:
+                    can_re_run_submissions = False
+                    error_message = f"You cannot rerun more than {RERUN_SUBMISSION_LIMIT} submissions on Codabench public queue! Contact us on `info@codalab.org` to request a rerun."
+
+                # Other queue where user is not owner and not organizer
+                elif request.user != comp.queue.owner and request.user not in comp.queue.organizers.all():
+                    can_re_run_submissions = False
+                    error_message = f"You cannot rerun more than {RERUN_SUBMISSION_LIMIT} submissions on a queue which is not yours! Contact us on `info@codalab.org` to request a rerun."
+
+                # User can rerun submissions where he is owner or organizer
+                else:
+                    can_re_run_submissions = True
+
+        else:
+            can_re_run_submissions = False
+            error_message = 'You do not have permission to re-run submissions'
+
+        # error when user is not super user or admin of the competition
+        if can_re_run_submissions:
+            # rerun all submissions
+            # for submission in submissions:
+            #     submission.re_run()
+            rerun_count = len(submissions)
+            return Response({"count": rerun_count})
+        else:
+            raise PermissionDenied(error_message)
+
+       
+
+        
+
+       
 
         # error when user is not super user and submissions crosses the limit
         if not request.user.is_superuser and len(submissions) >= RERUN_SUBMISSION_LIMIT:
             raise PermissionDenied('You have too many submissions, Contact us on `info@codalab.org` to request a rerun.')
 
-        # rerun all submissions
-        for submission in submissions:
-            submission.re_run()
-
-        rerun_count = len(submissions)
-        return Response({"count": rerun_count})
+       
 
     @swagger_auto_schema(responses={200: PhaseResultsSerializer})
     @action(detail=True, methods=['GET'])

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -630,8 +630,8 @@ class PhaseViewSet(ModelViewSet):
         # error when user is not super user or admin of the competition
         if can_re_run_submissions:
             # rerun all submissions
-            # for submission in submissions:
-            #     submission.re_run()
+            for submission in submissions:
+                submission.re_run()
             rerun_count = len(submissions)
             return Response({"count": rerun_count})
         else:

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -38,6 +38,7 @@ from utils.data import make_url_sassy
 from api.permissions import IsOrganizerOrCollaborator
 from datetime import datetime
 from django.db import transaction
+from django.conf import settings
 
 
 class CompetitionViewSet(ModelViewSet):
@@ -584,9 +585,6 @@ class PhaseViewSet(ModelViewSet):
     @action(detail=True, url_name='rerun_submissions')
     def rerun_submissions(self, request, pk):
 
-        # Limit for rerunning submissions
-        RERUN_SUBMISSION_LIMIT = 30
-
         phase = self.get_object()
         comp = phase.competition
 
@@ -604,7 +602,7 @@ class PhaseViewSet(ModelViewSet):
         elif request.user in comp.all_organizers:
 
             # submissions are in limit
-            if len(submissions) <= RERUN_SUBMISSION_LIMIT:
+            if len(submissions) <= settings.RERUN_SUBMISSION_LIMIT:
                 can_re_run_submissions = True
 
             # submissions are not in limit
@@ -612,12 +610,12 @@ class PhaseViewSet(ModelViewSet):
                 # Codabemch public queue
                 if comp.queue is None:
                     can_re_run_submissions = False
-                    error_message = f"You cannot rerun more than {RERUN_SUBMISSION_LIMIT} submissions on Codabench public queue! Contact us on `info@codalab.org` to request a rerun."
+                    error_message = f"You cannot rerun more than {settings.RERUN_SUBMISSION_LIMIT} submissions on Codabench public queue! Contact us on `info@codalab.org` to request a rerun."
 
                 # Other queue where user is not owner and not organizer
                 elif request.user != comp.queue.owner and request.user not in comp.queue.organizers.all():
                     can_re_run_submissions = False
-                    error_message = f"You cannot rerun more than {RERUN_SUBMISSION_LIMIT} submissions on a queue which is not yours! Contact us on `info@codalab.org` to request a rerun."
+                    error_message = f"You cannot rerun more than {settings.RERUN_SUBMISSION_LIMIT} submissions on a queue which is not yours! Contact us on `info@codalab.org` to request a rerun."
 
                 # User can rerun submissions where he is owner or organizer
                 else:

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -602,7 +602,7 @@ class PhaseViewSet(ModelViewSet):
         elif request.user in comp.all_organizers:
 
             # submissions are in limit
-            if len(submissions) <= settings.RERUN_SUBMISSION_LIMIT:
+            if len(submissions) <= int(settings.RERUN_SUBMISSION_LIMIT):
                 can_re_run_submissions = True
 
             # submissions are not in limit

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -637,18 +637,6 @@ class PhaseViewSet(ModelViewSet):
         else:
             raise PermissionDenied(error_message)
 
-       
-
-        
-
-       
-
-        # error when user is not super user and submissions crosses the limit
-        if not request.user.is_superuser and len(submissions) >= RERUN_SUBMISSION_LIMIT:
-            raise PermissionDenied('You have too many submissions, Contact us on `info@codalab.org` to request a rerun.')
-
-       
-
     @swagger_auto_schema(responses={200: PhaseResultsSerializer})
     @action(detail=True, methods=['GET'])
     def get_leaderboard(self, request, pk):

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -447,3 +447,10 @@ CHAHUB_PRODUCER_ID = os.environ.get('CHAHUB_PRODUCER_ID')
 # Django-Su (User impersonation)
 SU_LOGIN_CALLBACK = 'profiles.admin.su_login_callback'
 AJAX_LOOKUP_CHANNELS = {'django_su': dict(model='profiles.User', search_field='username')}
+
+# =============================================================================
+# Limit for re-running submission
+# This is used to limit users to rerun submissions
+# on default queue when number of submissions are < RERUN_SUBMISSION_LIMIT
+# =============================================================================
+RERUN_SUBMISSION_LIMIT = os.environ.get('RERUN_SUBMISSION_LIMIT', 30)

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -284,6 +284,9 @@
                         toastr.success(`Rerunning ${response.count} submissions`)
                         self.update_submissions()
                     })
+                    .fail(function (response) {
+                        toastr.error(response.responseJSON.detail)
+                    })
             }
         }
         self.filter = function () {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @dtuantran 

# A brief description of the purpose of the changes contained in this PR.
Any admin of a competition was able to rerun all submissions. NOW only super admin can rerun if submissions are more than 30 otherwise competition admin can rerun


# Issues this PR resolves
- #1073 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

