### PR TITLE
Adding CustomBrowsableAPIRenderer for API Rest Framework

### DIFF
--- a/src/apps/api/renderers.py
+++ b/src/apps/api/renderers.py
@@ -1,6 +1,18 @@
 from rest_framework.renderers import BaseRenderer
+from rest_framework.renderers import BrowsableAPIRenderer
 
 
 class ZipRenderer(BaseRenderer):
     media_type = 'application/zip'
     format = 'zip'
+
+
+class CustomBrowsableAPIRenderer(BrowsableAPIRenderer):
+    """Overrides the standard DRF Browsable API renderer."""
+
+    def get_context(self, *args, **kwargs):
+        context = super(CustomBrowsableAPIRenderer, self).get_context(*args, **kwargs)
+        # Remove "HTML" tabs
+        context["post_form"] = None
+        context["put_form"] = None
+        return context

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -263,7 +263,10 @@ REST_FRAMEWORK = {
     'DATETIME_INPUT_FORMATS': (
         'iso-8601',
         '%B %d, %Y',
-    )
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        "rest_framework.renderers.JSONRenderer",
+        "api.renderers.CustomBrowsableAPIRenderer")
 }
 # OAuth Toolkit
 OAUTH2_PROVIDER = {


### PR DESCRIPTION
Removing HTML form which leaks users list

# @ mention of reviewers
@Didayolo @ihsaan-ullah 


# A brief description of the purpose of the changes contained in this PR.
This PR disable HTML form, the user list (and other platforms information) won't be public on API rest framework

**Before**

![image](https://github.com/codalab/codabench/assets/7440668/7ce45152-6ecf-486d-9667-006665f4bccb)

**After**

![image](https://github.com/codalab/codabench/assets/7440668/2dc25d6f-6b56-4c33-a632-d3d20a946b7b)


# Issues this PR resolves

#1067 

# A checklist for hand testing
- [ ] HTML form disabled on /api/*


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

