### PR TITLE
HTML - Markdown - Latex : Rendering Fixed

### DIFF
--- a/src/static/js/ours/latex_markdown_html.js
+++ b/src/static/js/ours/latex_markdown_html.js
@@ -1,34 +1,4 @@
-// // Function to render Markdown and HTML content and return updated content
-// function renderMarkdownAndHTML(content) {
-//     const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html");
-//     return parsedHtml.body.childNodes;
-//   }
-
-
-// // Function to render LaTeX formulas using KaTeX and return updated content
-// function renderLatexInContent(content) {
-//     const parsedHtml = new DOMParser().parseFromString(content, "text/html");
-//     const traverseAndRender = (node) => {
-//       if (node.nodeType === Node.ELEMENT_NODE) {
-//         const latexPattern = /\$\$([\s\S]*?)\$\$|\$([^\$\n]*?)\$/g;
-//         const hasLatex = latexPattern.test(node.textContent);
-//         if (hasLatex) {
-//           const tempDiv = document.createElement('div');
-//           tempDiv.innerHTML = node.innerHTML.replace(latexPattern, (_, formula1, formula2) => {
-//             const formula = formula1 || formula2;
-//             return katex.renderToString(formula, { throwOnError: false });
-//           });
-//           node.innerHTML = tempDiv.innerHTML;
-//         }
-//       }
-//       node.childNodes.forEach(traverseAndRender);
-//     };
-//     traverseAndRender(parsedHtml.body);
-//     return parsedHtml.body.innerHTML;
-//   }
-
-
-
+// Function to render Markdown,  HTML and Latex and return updated content
 function renderMarkdownWithLatex(content) {
     const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html");
   

--- a/src/static/js/ours/latex_markdown_html.js
+++ b/src/static/js/ours/latex_markdown_html.js
@@ -1,25 +1,28 @@
 // Function to render Markdown,  HTML and Latex and return updated content
 function renderMarkdownWithLatex(content) {
-    const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html");
+    if(content === null){
+      return []
+    }
+    const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html")
   
     const traverseAndRenderLatex = (node) => {
       if (node.nodeType === Node.ELEMENT_NODE) {
-        const latexPattern = /\$\$([\s\S]*?)\$\$|\$([^\$\n]*?)\$/g;
-        const hasLatex = latexPattern.test(node.textContent);
+        const latexPattern = /\$\$([\s\S]*?)\$\$|\$([^\$\n]*?)\$/g
+        const hasLatex = latexPattern.test(node.textContent)
         if (hasLatex) {
-          const tempDiv = document.createElement('div');
+          const tempDiv = document.createElement('div')
           tempDiv.innerHTML = node.innerHTML.replace(latexPattern, (_, formula1, formula2) => {
-            const formula = formula1 || formula2;
-            return katex.renderToString(formula, { throwOnError: false });
+            const formula = formula1 || formula2
+            return katex.renderToString(formula, { throwOnError: false })
           });
-          node.innerHTML = tempDiv.innerHTML;
+          node.innerHTML = tempDiv.innerHTML
         }
       }
   
-      node.childNodes.forEach(traverseAndRenderLatex);
+      node.childNodes.forEach(traverseAndRenderLatex)
     };
   
-    traverseAndRenderLatex(parsedHtml.body);
+    traverseAndRenderLatex(parsedHtml.body)
   
-    return parsedHtml.body.childNodes;
+    return parsedHtml.body.childNodes
 }

--- a/src/static/js/ours/latex_markdown_html.js
+++ b/src/static/js/ours/latex_markdown_html.js
@@ -1,0 +1,55 @@
+// // Function to render Markdown and HTML content and return updated content
+// function renderMarkdownAndHTML(content) {
+//     const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html");
+//     return parsedHtml.body.childNodes;
+//   }
+
+
+// // Function to render LaTeX formulas using KaTeX and return updated content
+// function renderLatexInContent(content) {
+//     const parsedHtml = new DOMParser().parseFromString(content, "text/html");
+//     const traverseAndRender = (node) => {
+//       if (node.nodeType === Node.ELEMENT_NODE) {
+//         const latexPattern = /\$\$([\s\S]*?)\$\$|\$([^\$\n]*?)\$/g;
+//         const hasLatex = latexPattern.test(node.textContent);
+//         if (hasLatex) {
+//           const tempDiv = document.createElement('div');
+//           tempDiv.innerHTML = node.innerHTML.replace(latexPattern, (_, formula1, formula2) => {
+//             const formula = formula1 || formula2;
+//             return katex.renderToString(formula, { throwOnError: false });
+//           });
+//           node.innerHTML = tempDiv.innerHTML;
+//         }
+//       }
+//       node.childNodes.forEach(traverseAndRender);
+//     };
+//     traverseAndRender(parsedHtml.body);
+//     return parsedHtml.body.innerHTML;
+//   }
+
+
+
+function renderMarkdownWithLatex(content) {
+    const parsedHtml = new DOMParser().parseFromString(marked(content), "text/html");
+  
+    const traverseAndRenderLatex = (node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const latexPattern = /\$\$([\s\S]*?)\$\$|\$([^\$\n]*?)\$/g;
+        const hasLatex = latexPattern.test(node.textContent);
+        if (hasLatex) {
+          const tempDiv = document.createElement('div');
+          tempDiv.innerHTML = node.innerHTML.replace(latexPattern, (_, formula1, formula2) => {
+            const formula = formula1 || formula2;
+            return katex.renderToString(formula, { throwOnError: false });
+          });
+          node.innerHTML = tempDiv.innerHTML;
+        }
+      }
+  
+      node.childNodes.forEach(traverseAndRenderLatex);
+    };
+  
+    traverseAndRenderLatex(parsedHtml.body);
+  
+    return parsedHtml.body.childNodes;
+}

--- a/src/static/riot/competitions/detail/_registration.tag
+++ b/src/static/riot/competitions/detail/_registration.tag
@@ -72,7 +72,11 @@
         CODALAB.events.on('competition_loaded', (competition) => {
             self.competition_id = competition.id
             if (self.refs.terms_content) {
-                self.refs.terms_content.innerHTML = render_markdown(competition.terms)
+                const rendered_content = renderMarkdownWithLatex(competition.terms)
+                self.refs.terms_content.innerHTML = ""
+                rendered_content.forEach(node => {
+                    self.refs.terms_content.appendChild(node.cloneNode(true)); // Append each node
+                });
             }
             self.registration_auto_approve = competition.registration_auto_approve
             self.status = competition.participant_status

--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -318,16 +318,21 @@
             self.update()
             _.forEach(self.competition.pages, (page, index) => {
 
-                if (self.isHTML(page.content)){
-                    $(`#page_${index}`)[0].innerHTML = sanitize_HTML(page.content)
-                }else{
-                    $(`#page_${index}`)[0].innerHTML = render_markdown(page.content)
-                }
-                
+                // Render html pages
+                const rendered_content = renderMarkdownWithLatex(page.content)
+                $(`#page_${index}`)[0].innerHTML = ""
+                rendered_content.forEach(node => {
+                    $(`#page_${index}`)[0].appendChild(node.cloneNode(true)); // Append each node
+                });
                 
             })
             _.forEach(self.competition.phases, (phase, index) => {
-                $(`#phase_${index}`)[0].innerHTML = render_markdown(phase.description)
+                // Render phase description
+                const rendered_content = renderMarkdownWithLatex(phase.description)
+                $(`#phase_${index}`)[0].innerHTML = ""
+                rendered_content.forEach(node => {
+                    $(`#phase_${index}`)[0].appendChild(node.cloneNode(true)); // Append each node
+                });
             })
             _.delay(() => {
                 self.loading = false
@@ -354,12 +359,6 @@
                 self.update()
                 CODALAB.events.trigger('phase_selected', data)
             }
-        }
-        // To check if page content has HTML
-        // Return true if content is html
-        // Return false if content is not html i.e. MarkDown
-        self.isHTML = function (page_content) {
-            return /<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/i.test(page_content);
         }
 
         self.update()

--- a/src/static/riot/competitions/editor/_pages.tag
+++ b/src/static/riot/competitions/editor/_pages.tag
@@ -159,7 +159,11 @@
         self.view_page = function (page_index) {
             self.selected_page_index = page_index
             $(self.refs.view_modal).modal('show')
-            self.refs.page_content.innerHTML = render_markdown(self.pages[page_index].content)
+            const rendered_content = renderMarkdownWithLatex(self.pages[page_index].content)
+            self.refs.page_content.innerHTML = ""
+            rendered_content.forEach(node => {
+                self.refs.page_content.appendChild(node.cloneNode(true)); // Append each node
+            });
         }
 
         self.form_updated = function () {

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -242,6 +242,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/filesize/4.2.1/filesize.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.address/1.6/jquery.address.min.js" integrity="sha256-mLCPYHfNREhSETFQGuowilY3zBAZGnDO2cxCnCEm8/I=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.0.1/dist/gsap.min.js"></script>
+    <!-- Markdown-->
+    <script src="https://cdn.jsdelivr.net/npm/marked@3.0.7/marked.min.js"></script>
+    <!-- Latex -->
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js"></script>
     <!-- Ours -->
 
 
@@ -360,9 +364,6 @@
     <script src="{% static "js/Chart.bundle.js" %}"></script>
     <script src="{% static "js/reconnecting-websocket.min.js" %}"></script>
     <script src="{% static "generated/riot.js" %}"></script>
-    <!-- Latex Markdown and HTML -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js"></script>
     <script src="{% static "js/ours/latex_markdown_html.js" %}"></script>
 
     {% block extra_js %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -361,7 +361,7 @@
     <script src="{% static "js/reconnecting-websocket.min.js" %}"></script>
     <script src="{% static "generated/riot.js" %}"></script>
     <!-- Latex Markdown and HTML -->
-    <script src="https://cdn.jsdelivr.net/npm/marked@3.0.4/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js"></script>
     <script src="{% static "js/ours/latex_markdown_html.js" %}"></script>
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -23,6 +23,9 @@
     <!-- Ours -->
     <link rel="stylesheet" href="{% static "generated/output.css" %}">
 
+    <!-- Latex -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css">
+
     {% block extra_head %}
     {% endblock %}
 </head>
@@ -357,6 +360,10 @@
     <script src="{% static "js/Chart.bundle.js" %}"></script>
     <script src="{% static "js/reconnecting-websocket.min.js" %}"></script>
     <script src="{% static "generated/riot.js" %}"></script>
+    <!-- Latex Markdown and HTML -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@3.0.4/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js"></script>
+    <script src="{% static "js/ours/latex_markdown_html.js" %}"></script>
 
     {% block extra_js %}
     {% endblock %}


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
We had the following problems:

1. HTML and markdown were not rendered when mixed
2. Latex was not rendered.

Both of these are solved in this PR

# What is done:
Rendeding of markdown-html-latex is fixed in:

1. Competition pages
<img width="1218" alt="Screenshot 2023-08-19 at 1 37 44 PM" src="https://github.com/codalab/codabench/assets/13259262/13642454-23e9-49c0-a237-842ff748601a">

2. Competition page view in the editor
<img width="978" alt="Screenshot 2023-08-19 at 1 37 25 PM" src="https://github.com/codalab/codabench/assets/13259262/baf59d55-ceb6-422c-a4de-e9177282827e">

3. Phase description
<img width="1171" alt="Screenshot 2023-08-19 at 1 39 11 PM" src="https://github.com/codalab/codabench/assets/13259262/d7f94771-8c3c-4681-98ef-2e0082ae4712">

4. competition registration terms modal
<img width="944" alt="Screenshot 2023-08-19 at 1 37 03 PM" src="https://github.com/codalab/codabench/assets/13259262/33178864-c3c8-4788-aa12-fc61ecdc783f">

# Issues this PR resolves
- #852 
- #879 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

