### PR TITLE
Server status - Queue name displayed

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -70,10 +70,11 @@ class ServerStatusView(TemplateView):
         context = super().get_context_data(*args, **kwargs)
         context['submissions'] = qs[:250]
 
-        # Get queue from each submission's competition
         for submission in context['submissions']:
+            # Get queue from each submission's competition
             queue_name = "Default" if submission.phase.competition.queue is None else submission.phase.competition.queue.name
             submission.competition_queue = queue_name
+
         return context
 
 

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -72,7 +72,7 @@ class ServerStatusView(TemplateView):
 
         for submission in context['submissions']:
             # Get queue from each submission's competition
-            queue_name = "Default" if submission.phase.competition.queue is None else submission.phase.competition.queue.name
+            queue_name = "*" if submission.phase.competition.queue is None else submission.phase.competition.queue.name
             submission.competition_queue = queue_name
 
         return context

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -69,6 +69,11 @@ class ServerStatusView(TemplateView):
 
         context = super().get_context_data(*args, **kwargs)
         context['submissions'] = qs[:250]
+
+        # Get queue from each submission's competition
+        for submission in context['submissions']:
+            queue_name = "Default" if submission.phase.competition.queue is None else submission.phase.competition.queue.name
+            submission.competition_queue = queue_name
         return context
 
 

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -12,6 +12,7 @@
             <th>Competition</th>
             <th>Submission PK</th>
             <th>Submitter</th>
+            <th>Queue</th>
             <th>Hostname</th>
             <th>Submitted at</th>
             <th>Status</th>
@@ -27,6 +28,7 @@
                     <td><a class="link-no-deco" target="_blank" href="./competitions/{{ submission.phase.competition.id }}">{{ submission.phase.competition.title }}</a></td>
                     <td>{{ submission.pk }}</td>
                     <td>{{ submission.owner.username }}</td>
+                    <td>{{ submission.competition_queue }}</td>
                     <td>{{ submission.worker_hostname }}</td>
                     <td>{{ submission.created_when|timesince }} ago</td>
                     <td>{{ submission.status }}</td>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Server status page now shows queue name in the table. For default queue `*` is shown

<img width="338" alt="Screenshot 2023-08-20 at 2 39 38 PM" src="https://github.com/codalab/codabench/assets/13259262/582eaab0-73ba-4375-abf7-3876637d20e3">



# Issues this PR resolves
- #744 -> Queue name


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

