### PR TITLE
Server status - username is a link to profile

### DIFF
--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -26,7 +26,7 @@
                 <tr>
                     <td><a class="link-no-deco" target="_blank" href="./competitions/{{ submission.phase.competition.id }}">{{ submission.phase.competition.title }}</a></td>
                     <td>{{ submission.pk }}</td>
-                    <td>{{ submission.owner.username }}</td>
+                    <td><a target="_blank" href="/profiles/user/{{ submission.owner.username }}">{{ submission.owner.username }}</a></td>
                     <td>{{ submission.worker_hostname }}</td>
                     <td>{{ submission.created_when|timesince }} ago</td>
                     <td>{{ submission.status }}</td>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now in job status page, competitions table, submitter is a clickable link
<img width="551" alt="Screenshot 2023-08-20 at 1 39 41 PM" src="https://github.com/codalab/codabench/assets/13259262/0d110609-5e73-447d-a4ca-30b390a3778f">


# Issues this PR resolves
- #744 -> Make usernames as clickable links



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

