### PR TITLE
Server status - submission file size added

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -69,7 +69,29 @@ class ServerStatusView(TemplateView):
 
         context = super().get_context_data(*args, **kwargs)
         context['submissions'] = qs[:250]
+
+        for submission in context['submissions']:
+            # Get filesize from each submissions's data
+            submission.file_size = self.format_file_size(submission.data.file_size)
+
         return context
+
+    def format_file_size(self, file_size):
+        """
+        A custom function to convert file size to KB, MB, GB and return with the unit
+        """
+        try:
+            n = float(file_size)
+        except ValueError:
+            return ""
+
+        units = ['KB', 'MB', 'GB']
+        i = 0
+        while n >= 1000 and i < len(units) - 1:
+            n /= 1000
+            i += 1
+
+        return f"{n:.1f} {units[i]}"
 
 
 def page_not_found_view(request, exception):

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -11,6 +11,7 @@
             <thead>
             <th>Competition</th>
             <th>Submission PK</th>
+            <th>Size</th>
             <th>Submitter</th>
             <th>Hostname</th>
             <th>Submitted at</th>
@@ -26,6 +27,7 @@
                 <tr>
                     <td><a class="link-no-deco" target="_blank" href="./competitions/{{ submission.phase.competition.id }}">{{ submission.phase.competition.title }}</a></td>
                     <td>{{ submission.pk }}</td>
+                    <td>{{ submission.file_size }}</td>
                     <td>{{ submission.owner.username }}</td>
                     <td>{{ submission.worker_hostname }}</td>
                     <td>{{ submission.created_when|timesince }} ago</td>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now In server status page, submission size is displayed
<img width="458" alt="Screenshot 2023-08-20 at 1 55 17 PM" src="https://github.com/codalab/codabench/assets/13259262/48cb4fb7-e60d-4ca3-87d1-ad750639c6f1">



# Issues this PR resolves
- #744 -> Submission size



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

