### PR TITLE
Server status - show/hide child submissions

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -62,13 +62,18 @@ class ServerStatusView(TemplateView):
         if not self.request.user.is_staff:
             raise HttpResponse(status=404)
 
+        show_child_submissions = self.request.GET.get('show_child_submissions', False)
+
         qs = Submission.objects.all()
         qs = qs.filter(created_when__gte=now() - timedelta(days=2))
+        if not show_child_submissions:
+            qs = qs.filter(parent__isnull=True)
         qs = qs.order_by('-created_when')
         qs = qs.select_related('phase__competition', 'owner')
 
         context = super().get_context_data(*args, **kwargs)
         context['submissions'] = qs[:250]
+        context['show_child_submissions'] = show_child_submissions
         return context
 
 

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -11,7 +11,7 @@
             <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show child submissions
         </label>
         <span class="ui mini circular icon button"
-            data-tooltip="Child submissions are created when a competition has multiple tasks. One child for each task"
+            data-tooltip="Child submissions are created when a competition has multiple tasks (one child for each task)."
             data-position="top center">
             <i class="question icon"></i>
         </span>

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -8,12 +8,20 @@
     <div class="ui container">
         <h1>Recent submissions (up to 250 or 2 days old)</h1>
         <label>
-            <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show chilld submissions
+            <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show child submissions
         </label>
+        <span class="ui mini circular icon button"
+            data-tooltip="Child submissions are created when a competition has multiple tasks. One child for each task"
+            data-position="top center">
+            <i class="question icon"></i>
+        </span>
         <table class="ui table">
             <thead>
             <th>Competition</th>
             <th>Submission PK</th>
+            {% if show_child_submissions %}
+                <th>Parent PK</th>
+            {% endif %}
             <th>Submitter</th>
             <th>Hostname</th>
             <th>Submitted at</th>
@@ -29,6 +37,9 @@
                 <tr>
                     <td><a class="link-no-deco" target="_blank" href="./competitions/{{ submission.phase.competition.id }}">{{ submission.phase.competition.title }}</a></td>
                     <td>{{ submission.pk }}</td>
+                    {% if show_child_submissions %}
+                        <td>{{ submission.parent.pk }}</td>
+                    {% endif %}
                     <td>{{ submission.owner.username }}</td>
                     <td>{{ submission.worker_hostname }}</td>
                     <td>{{ submission.created_when|timesince }} ago</td>

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -7,6 +7,9 @@
 {% block content %}
     <div class="ui container">
         <h1>Recent submissions (up to 250 or 2 days old)</h1>
+        <label>
+            <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show chilld submissions
+        </label>
         <table class="ui table">
             <thead>
             <th>Competition</th>
@@ -73,4 +76,22 @@
             </div>
         </div>
     </div>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            const checkbox = document.getElementById("show_child_checkbox");
+        
+            checkbox.addEventListener("change", function() {
+                const isChecked = checkbox.checked;
+                const url = new URL(window.location);
+                if (isChecked) {
+                    url.searchParams.set('show_child_submissions', true);
+                } else {
+                    url.searchParams.delete('show_child_submissions');
+                }
+                console.log(url)
+                window.location.href = url.toString();
+            });
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now in server status page there is an option to show child submissions. By default they are hidden

Default : show only parent (checkbox unchecked)
<img width="1165" alt="Screenshot 2023-08-21 at 3 47 08 PM" src="https://github.com/codalab/codabench/assets/13259262/eff4cde4-5880-4316-86cc-a381b9bdd07d">

show parent and children (checkbox checked)
<img width="1191" alt="Screenshot 2023-08-21 at 3 47 17 PM" src="https://github.com/codalab/codabench/assets/13259262/5df687c6-a2c6-48bc-ae8a-59a3ff9ad811">



# Issues this PR resolves
- #744 -> Have a way to differentiate and show/hide the "secondary submissions", which are hidden submissions made when there are multiple tasks



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

