### PR TITLE
Server status - Show to all users

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -59,15 +59,29 @@ class ServerStatusView(TemplateView):
     template_name = 'pages/server_status.html'
 
     def get_context_data(self, *args, **kwargs):
-        if not self.request.user.is_staff:
-            raise HttpResponse(status=404)
 
         show_child_submissions = self.request.GET.get('show_child_submissions', False)
 
+        # Get all submissions
         qs = Submission.objects.all()
+
+        # If user is not super user then:
+        # filter this user's own submissions
+        # and
+        # submissions running on queue which belongs to this user
+        if not self.request.user.is_superuser:
+            qs = qs.filter(
+                Q(owner=self.request.user) |
+                Q(phase__competition__queue__isnull=False, phase__competition__queue__owner=self.request.user)
+            )
+
+        # filter for fetching last 2 days submissions
         qs = qs.filter(created_when__gte=now() - timedelta(days=2))
+
+        # filter out child submissions i.e. submission has no parent
         if not show_child_submissions:
             qs = qs.filter(parent__isnull=True)
+
         qs = qs.order_by('-created_when')
         qs = qs.select_related('phase__competition', 'owner')
 

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -1,6 +1,4 @@
 from datetime import timedelta
-
-from django.http import HttpResponse
 from django.utils.timezone import now
 from django.views.generic import TemplateView
 from django.db.models import Count, Q

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -89,6 +89,11 @@
         </tfoot>
     </table>
 
+    <!--  Server status page button  -->
+    <a href="/server_status" target="_blank">
+        <div class="ui blue right floated button">Open Server status page</div>
+    </a>
+
     <div class="ui modal" ref="modal">
         <div class="header">
             Queue Form

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -123,10 +123,11 @@
                             </div>
                             <i class="dropdown icon"></i>
                             <div class="menu">
-                                {% if request.user.is_staff %}
+                                
                                     <div class="header">Admin management</div>
 {#                                    <a class="item" href="#">Customize Codalab</a>#}
                                     <a class="item" href="{% url "pages:server_status" %}">Server Status</a>
+                                {% if request.user.is_staff %}
                                     <a class="item" href="{% url "admin:index" %}">Django Admin</a>
                                     <a class="item" href="{% url "su_login" %}">Change User</a>
                                     <a class="item" href="{% url "analytics:analytics" %}">Analytics</a>

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -31,8 +31,8 @@
             </thead>
             <tbody>
                 {% if not submissions %}
-                <tr>
-                    <td colspan="5"><i>No submissions, yet!</i></td>
+                <tr class="center aligned">
+                    <td colspan="100%"><em>No submissions, yet!</em></td>
                 </tr>
                 {% endif %}
                 {% for submission in submissions %}
@@ -53,6 +53,8 @@
             </tbody>
         </table>
 
+
+        {% if user.is_superuser %}
         <h1>Monitor queues</h1>
         <div id="external_monitors" class="ui two column grid">
             <div class="column">
@@ -90,6 +92,7 @@
                 </div>
             </div>
         </div>
+        {% endif %}
     </div>
 
     <script>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now all users can see `server_status` page. 
Everything stays the same for super admin but for normal users they can do the following:

- see their own submissions
- see the submissions which are using a queue whose owner is this user.

Note: a user can see past submissions too if you change a queue in a competition from default to this user's queue. And user can lose all submissions showing before but not anymore because queue is changed to another queue. This happens because `queue` is part of a competition and not a submission.


# Screenshots:
status page link in the menu:
<img width="294" alt="Screenshot 2023-08-21 at 6 25 06 PM" src="https://github.com/codalab/codabench/assets/13259262/560f1cd3-9dbe-4933-92fd-0c1a43a3854e">

user `ihsan01` can see his own submissions running on default queue (*) and he can also see some other submissions from other user because they are running on queue: `aaa` whose owner is `ihsan01`
<img width="1215" alt="Screenshot 2023-08-21 at 6 23 36 PM" src="https://github.com/codalab/codabench/assets/13259262/7cf98acb-c519-40a1-81f8-4121859187f8">

Button in queue page to go to
<img width="1191" alt="Screenshot 2023-08-21 at 6 43 09 PM" src="https://github.com/codalab/codabench/assets/13259262/ef460dc9-f9a0-438d-be83-c62ff9c53611">
 server status page



# Issues this PR resolves
- #744 -> users should be able to see status page with their own submissions only
- #744 -> Users should be able to see only the queue they are administrating. This is indeed useful when debugging and monitoring a competition
- #744 -> When this is done, we should add a button in the Queue Management page that redirects to the job status page.




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge


