### PR TITLE
upgrade rabbitmq always to the latest management version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   #   Rabbitmq & Flower monitoring tool
   #-----------------------------------------------
   rabbit:
-    image: rabbitmq:3.6-management
+    image: rabbitmq:management
     # setting hostname here makes data persist properly between
     # containers being destroyed..!
     hostname: rabbit


### PR DESCRIPTION
# Mentions of reviewers

@Didayolo @ihsaan-ullah 
...


# There are some vulnerabilities of RabbitMQ's old versions
https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=amqp

![image](https://github.com/codalab/codabench/assets/7440668/119a97b8-d01a-4f91-b0b8-64e5f0d122f5)

After this PR, the RabbitMQ will be always the latest version which helps to resolve some CVE as soon as possible.
# A checklist for hand testing
- [x] We can create a queue
- [x] Compute worker can connect to a queue and process a submission


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

