### PR TITLE
Create Dump with keys

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -493,9 +493,12 @@ class CompetitionViewSet(ModelViewSet):
         if not competition.user_has_admin_permission(request.user):
             raise PermissionDenied("You don't have access")
 
+        # get keys_instead_of_files from request data
+        keys_instead_of_files = request.data.get('keys_instead_of_files', False)
+
         # arg 1: pk: competition primary key
-        # arg 2: False: keys_instead_of_files (if false: files will be dowloaded in dumps, if true: only keys)
-        create_competition_dump.delay(pk, False)
+        # arg 2: keys_instead_of_files (if false: files will be dowloaded in dumps, if true: only keys)
+        create_competition_dump.delay(pk, keys_instead_of_files)
 
         serializer = CompetitionCreationTaskStatusSerializer({"status": "Success. Competition dump is being created."})
         return Response(serializer.data, status=201)

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -70,8 +70,8 @@ CODALAB.api = {
     get_competition_files: pk => {
         return CODALAB.api.request('GET', `${URLS.API}competitions/${pk}/get_files/`)
     },
-    create_competition_dump: function (pk) {
-        return CODALAB.api.request('POST', `${URLS.API}competitions/${pk}/create_dump/`)
+    create_competition_dump: function (pk, keys_instead_of_files) {
+        return CODALAB.api.request('POST', `${URLS.API}competitions/${pk}/create_dump/`, {keys_instead_of_files: keys_instead_of_files})
     },
     /*---------------------------------------------------------------------
          Submissions

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -99,9 +99,27 @@
     <!-- Manage Competition Modal -->
     <div class="ui manage-competition modal" ref="files_modal">
         <div class="content">
-            <button class="ui icon button" onclick="{create_dump}">
+            <div class="ui dropdown button">
+                <i class="download icon"></i>
+                <div class="text">Create Competition Dump</div>
+                <div class="menu">
+                    <div class="parent-modal item"
+                        onclick="{create_dump.bind(this, true)}"> 
+                        <!--  true for keys  -->
+                        Dump with keys
+                    </div>
+                    <div class="parent-modal item"
+                    
+                        onclick="{create_dump.bind(this, false)}">
+                        <!--  false for files  -->
+                        Dump with files
+                    </div>
+                </div>
+            </div>
+
+            <!--  <button class="ui icon button" onclick="{create_dump}">
                 <i class="download icon"></i> Create Competition Dump
-            </button>
+            </button>  -->
             <button class="ui icon button" onclick="{update_files}">
                 <i class="sync alternate icon"></i> Refresh Table
             </button>
@@ -201,8 +219,8 @@
         self.close_modal = selector => $(selector).modal('hide')
         self.show_modal = selector => $(selector).modal('show')
 
-        self.create_dump = () => {
-            CODALAB.api.create_competition_dump(self.competition.id)
+        self.create_dump = (keys_instead_of_files) => {
+            CODALAB.api.create_competition_dump(self.competition.id, keys_instead_of_files)
                 .done(data => {
                     self.tr_show = true
                     toastr.success("Success! Your competition dump is being created.")


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can create dumps with either keys or files

# Screenshots:

Drop down to select `keys` or `files`
<img width="1007" alt="Screenshot 2023-08-24 at 12 31 47 AM" src="https://github.com/codalab/codabench/assets/13259262/681695fd-a4d6-4049-bd87-d1f95983d368">



Dump with keys yaml and folder:
<img width="791" alt="Screenshot 2023-08-23 at 4 21 24 PM" src="https://github.com/codalab/codabench/assets/13259262/49252356-a208-468c-8f41-2e4c994328ae">
<img width="775" alt="Screenshot 2023-08-23 at 4 21 44 PM" src="https://github.com/codalab/codabench/assets/13259262/44ad2a83-6959-4113-8cd8-92ef64a3c7a7">

Dump with files yaml and folder:
<img width="789" alt="Screenshot 2023-08-23 at 4 22 11 PM" src="https://github.com/codalab/codabench/assets/13259262/b7178b69-7c73-4c8d-b262-e1d5e2128e16">
<img width="800" alt="Screenshot 2023-08-23 at 4 22 22 PM" src="https://github.com/codalab/codabench/assets/13259262/55b101d3-6a64-49c0-a155-b875c897b39d">



# Issues this PR resolves
- #880 -> Key only style dump would dump the dataset keys into the zip



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

