### PR TITLE
Competition Dump - Task with/without keys

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -494,11 +494,16 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
             temp_task_data = {
                 'index': index
             }
+
             for field in TASK_FIELDS:
                 data = getattr(task, field, "")
+                # If keys_instead of files is not true and field is key, then skip this filed
+                if not keys_instead_of_files and field == 'key':
+                    continue
                 if field == 'key':
                     data = str(data)
                 temp_task_data[field] = data
+
             for file_type in PHASE_FILES:
                 if hasattr(task, file_type):
                     temp_dataset = getattr(task, file_type)


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now if you create Dump with keys, then you can see task key in yaml. Dump with files will have no keys


# Issues this PR resolves
- #1108 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

