### PR TITLE
Compute Worker - Scoring program with dir structure

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -366,40 +366,44 @@ class Run:
             # Run for scoring program only
             if destination == "program" and self.is_scoring:
 
-                # Check if scoring program has a parent directory
-                # or the files are zipped without parent directory
+                # Check if scoring program is zipped with or without a parent directory
                 # If parent directory is found i.e. parent_dir is not None
-                # then extract the scoring program and move its content to
-                # destination dir and then delete the parent dir
+                # then do the following:
+                #   - extract the scoring program
+                #   - move its content to destination dir
+                #   - delete the parent dir
 
                 # Get list of files and directories from the zip of scoring program
                 extracted_files = z.namelist()
 
-                # Intiialize parent dir to none
+                # Intiialize parent dir with a None value
                 parent_dir = None
 
-                # loop over all the extracted files
-                # to identify parent directory
-                # the first directory found is considered parent dir
+                # loop over all the extracted files to identify parent directory
                 for extracted_file in extracted_files:
-                    # check if a metadata file is located in the subdirectory
+                    # if a metadata file is located in the subdirectory
                     # that directory is considered the parent dir
+                    # Note:
+                    # `/` shows that there is a directory structure e.g. scoring_program/metadata
                     if '/' in extracted_file and os.path.basename(extracted_file) == 'metadata':
+                        # split the path by `/`, the first item is the directory name
+                        # e.g. splitting `scoring_program/metadata` on `/` gives you `scoring_program` as the parent dir
                         parent_dir = extracted_file.split('/')[0]
                         break
 
+                # Extract scoring program in the destination directory (with or without parent dir)
                 z.extractall(os.path.join(self.root_dir, destination))
-                if parent_dir:
 
-                    # Move the content of parent dir to the destination
+                if parent_dir:
+                    # parent directory is found. Now the the following
+                    # - Move the content of parent dir to the destination
+                    # - Delete parent dir
                     parent_dir_path = os.path.join(self.root_dir, destination, parent_dir)
                     parent_files = os.listdir(parent_dir_path)
                     for file in parent_files:
                         file_path = os.path.join(parent_dir_path, file)
                         dest_path = os.path.join(self.root_dir, destination, file)
                         os.rename(file_path, dest_path)
-
-                    # Remove the parent dir
                     os.rmdir(parent_dir_path)
             else:
                 z.extractall(os.path.join(self.root_dir, destination))

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -388,7 +388,6 @@ class Run:
                     # that directory is considered the parent dir
                     # Note:
                     # `/` shows that there is a directory structure e.g. scoring_program/metadata
-                    
                     if '/' in extracted_file and os.path.basename(extracted_file) in META_DATA_FILES:
                         # split the path by `/`, the first item is the directory name
                         # e.g. splitting `scoring_program/metadata` on `/` gives you `scoring_program` as the parent dir

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -65,6 +65,9 @@ AVAILABLE_STATUSES = (
     STATUS_FAILED,
 )
 
+# Meta data files
+META_DATA_FILES = ['metadata', 'metadata.yaml']
+
 # Setup the container engine that we are using
 if os.environ.get("CONTAINER_ENGINE_EXECUTABLE"):
     CONTAINER_ENGINE_EXECUTABLE = os.environ.get("CONTAINER_ENGINE_EXECUTABLE")
@@ -385,7 +388,8 @@ class Run:
                     # that directory is considered the parent dir
                     # Note:
                     # `/` shows that there is a directory structure e.g. scoring_program/metadata
-                    if '/' in extracted_file and os.path.basename(extracted_file) == 'metadata':
+                    
+                    if '/' in extracted_file and os.path.basename(extracted_file) in META_DATA_FILES:
                         # split the path by `/`, the first item is the directory name
                         # e.g. splitting `scoring_program/metadata` on `/` gives you `scoring_program` as the parent dir
                         parent_dir = extracted_file.split('/')[0]


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 

# Note:
This a critical PR as it changes the Compute worker. I have added comments to the added code but if that is not sufficient, more explanation should be added. The only part of the code touched is when the `program` is extracted while scoring. I checked and when `destination == "program"` and `is_scoring` is `True` then this means that scoring program is being extracted. We may need the same functionality i.e. extract with or without parent directory for other programs too (to be tested and discussed)

Also note that we can identify a scoring program running by `self.is_scoring` in the compute worker


# A brief description of the purpose of the changes contained in this PR.
Now a scoring program with directory structure will work in the compute worker to execute a submission
```
scoring_program.zip
|-- scoring_program/
|---|-- score.py
|---|-- metadata
```


# Issues this PR resolves
- #968 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

