### PR TITLE
Fix submission stuck at scoring 

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -383,7 +383,7 @@ class Run:
                 if retries >= max_retries:
                     raise  # Re-raise the last caught BadZipFile exception
                 else:
-                    logger.info("Failed. Retrying in 30 seconds...")
+                    logger.info("Failed. Retrying in 60 seconds...")
                     time.sleep(60) # Wait 60 seconds before retrying
         # Return the zip file path for other uses, e.g. for creating a MD5 hash to identify it
         return bundle_file

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -374,6 +374,7 @@ class Run:
                 if retries >= max_retries:
                     raise  # Re-raise the last caught BadZipFile exception
                 else:
+                    logger.info("Failed. Retrying in 30 seconds...")
                     time.sleep(30) # Wait 30 seconds before retrying
         # Return the zip file path for other uses, e.g. for creating a MD5 hash to identify it
         return bundle_file
@@ -614,6 +615,7 @@ class Run:
                 if retries >= max_retries:
                     raise Exception("ZIP file is corrupted or incomplete.")
                 else:
+                    logger.info("Failed. Retrying in 30 seconds...")
                     time.sleep(30) # Wait 30 seconds before retrying
 
     def _put_file(self, url, file=None, raw_data=None, content_type='application/zip'):


### PR DESCRIPTION
# Issue solved

- #1011


# Summary

The problem was that this two actions starts simultaneously:
- Uploading the output of the ingestion program
- Download it in the scoring program

If the ingestion and scoring are separated in two workers, and the output from ingestion step is big, then it results in a BadZipFile error because the scoring program download a file that is not completely uploaded yet.

This pull request:
- Add comments to clarify compute_worker.py
- Add retries and waiting

Note that it may not always work. The max wait is 10 minutes.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] CircleCi tests are passing
- [x] Ready to merge

