### PR TITLE
Participant Registration Status

### DIFF
--- a/src/static/riot/competitions/detail/_registration.tag
+++ b/src/static/riot/competitions/detail/_registration.tag
@@ -43,9 +43,13 @@
     </div>
 
     <div if="{status}">
-        <div class="ui yellow message">
+        <div if="{status === 'pending'}" class="ui yellow message">
             <h3>Registration Status: {_.startCase(status)}</h3>
-            Your request to participate in this competition is waiting for an approval from the competition organizer
+            Your request to participate in this competition is waiting for an approval from the competition organizer.
+        </div>
+        <div if="{status === 'denied'}" class="ui red message">
+            <h3>Registration Status: {_.startCase(status)}</h3>
+            Your request to participate in this competition is denier. Please contact the competition organizer for more details.
         </div>
     </div>
 

--- a/src/static/riot/competitions/detail/_registration.tag
+++ b/src/static/riot/competitions/detail/_registration.tag
@@ -49,7 +49,7 @@
         </div>
         <div if="{status === 'denied'}" class="ui red message">
             <h3>Registration Status: {_.startCase(status)}</h3>
-            Your request to participate in this competition is denier. Please contact the competition organizer for more details.
+            Your request to participate in this competition is denied. Please contact the competition organizer for more details.
         </div>
     </div>
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
UI updated to show different messages for `pending` and `denied` statuses

Pending:
<img width="1406" alt="Screenshot 2023-09-02 at 9 32 45 PM" src="https://github.com/codalab/codabench/assets/13259262/c51f86da-b2b2-48e9-a78e-fd876155c985">

Denied:
<img width="1429" alt="Screenshot 2023-09-02 at 9 32 14 PM" src="https://github.com/codalab/codabench/assets/13259262/ff7a1689-6bb4-4d49-906c-6e3beb611da3">


# Issues this PR resolves
- #1131 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

