### PR TITLE
Public competitions order 

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -517,7 +517,7 @@ class CompetitionViewSet(ModelViewSet):
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True)
-        return None # Response(serializer.data)
+        return Response(serializer.data)
 
     def run_new_task_submissions(self, phase, tasks):
         tasks_ids = set([task.id for task in tasks])

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -508,6 +508,7 @@ class CompetitionViewSet(ModelViewSet):
     def public(self, request):
         qs = self.get_queryset()
         qs = qs.filter(published=True)
+        qs = qs.order_by('-id')
         queryset = self.filter_queryset(qs)
 
         page = self.paginate_queryset(queryset)
@@ -516,7 +517,7 @@ class CompetitionViewSet(ModelViewSet):
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
+        return None # Response(serializer.data)
 
     def run_new_task_submissions(self, phase, tasks):
         tasks_ids = set([task.id for task in tasks])


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now competitions will be returned in DESC order of ids

<img width="1337" alt="Screenshot 2023-09-04 at 5 37 23 PM" src="https://github.com/codalab/codabench/assets/13259262/eff68f96-a7cc-448f-a8c7-15c08ff9e62c">



# Issues this PR resolves
- #1138 





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

