### PR TITLE
Hide leaderboard when leaderboard is hidden

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -186,15 +186,18 @@
                             </div>
                         </div>
                     </div>
-                <leaderboards class="leaderboard-table"
+                <!-- If there's no leaderboard, show this message -->
+                <div show="{_.isEmpty(competition.leaderboards)}">
+                    <div class="center aligned"><h2>No visible leaderboard for this benchmark</h2></div>
+                </div>
+                <!-- Else, show the leaderboard -->
+                <div show="{!_.isEmpty(competition.leaderboards)}">
+                    <leaderboards class="leaderboard-table"
                               phase_id="{ self.selected_phase_index }"
                               is_admin="{competition.admin}">
-                </leaderboards>
-            </div>
-            <div show="{!loading && _.isEmpty(competition.leaderboards)}">
-                <div class="center aligned"><h2>No Visible Leaderboards for this competition</h2></div>
-            </div>
-            
+                    </leaderboards>
+                </div>
+            </div>           
         </div>
     </div>
 


### PR DESCRIPTION
# Summary

The leaderboard was still visible even with the "Leaderboard is hidden" option enabled. This PR fix this behavior. Only the display is changed here, so the leaderboard may be accessible using API or other tricks.

# Issues this PR resolves
- #1146


# A checklist for hand testing
- [x] Check that you can see the leaderboard with a non-admin account
- [x] Hide the leaderboard
- [x] Check that it is hidden for the non-admin


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

