### PR TITLE
Server status - Rabbit and flower links

### DIFF
--- a/src/utils/context_processors.py
+++ b/src/utils/context_processors.py
@@ -21,6 +21,6 @@ def common_settings(request):
     return {
         'STORAGE_TYPE': settings.STORAGE_TYPE,
         'USER_JSON_DATA': json.dumps(user_json_data),
-        'RABBITMQ_MANAGEMENT_URL': f"{settings.DOMAIN_NAME}:{settings.RABBITMQ_MANAGEMENT_PORT}",
-        'FLOWER_URL': f"{settings.DOMAIN_NAME}:{settings.FLOWER_PUBLIC_PORT}",
+        'RABBITMQ_MANAGEMENT_URL': f"https://{settings.DOMAIN_NAME}:{settings.RABBITMQ_MANAGEMENT_PORT}",
+        'FLOWER_URL': f"https://{settings.DOMAIN_NAME}:{settings.FLOWER_PUBLIC_PORT}",
     }


### PR DESCRIPTION
`https://` added with domain name. Now it should work.
Locally `https` does not work but `http` does. I am keeping https because this feature is not useful locally

Linked to : 
- #1144 
- #1145 