### PR TITLE
Resources : Show edit/delete task to owner only

### DIFF
--- a/src/apps/api/serializers/tasks.py
+++ b/src/apps/api/serializers/tasks.py
@@ -138,6 +138,7 @@ class TaskListSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'created_when',
+            'created_by',
             'key',
             'name',
             'solutions',

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -45,15 +45,17 @@
                 <i class="checkmark box icon green" show="{ task.is_public }"></i>
             </td>
             <td>
-                <button class="mini ui button blue icon" onclick="{show_edit_modal.bind(this, task)}">
-                    <i class="icon pencil"></i>
-                </button>
-                <button class="mini ui button red icon" onclick="{ delete_task.bind(this, task) }">
-                    <i class="icon trash"></i>
-                </button>
+                <div if="{ task.created_by == CODALAB.state.user.id }">
+                    <button class="mini ui button blue icon" onclick="{show_edit_modal.bind(this, task)}">
+                        <i class="icon pencil"></i>
+                    </button>
+                    <button class="mini ui button red icon" onclick="{ delete_task.bind(this, task) }">
+                        <i class="icon trash"></i>
+                    </button>
+                </div>
             </td>
             <td class="center aligned">
-                <div class="ui fitted checkbox">
+                <div class="ui fitted checkbox" if="{ task.created_by == CODALAB.state.user.id }">
                     <input type="checkbox" name="delete_checkbox" onclick="{ mark_task_for_deletion.bind(this, task) }">
                     <label></label>
                 </div>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now only owner can see edit/delete task buttons

Owner view
<img width="1476" alt="Screenshot 2023-09-14 at 4 07 22 PM" src="https://github.com/codalab/codabench/assets/13259262/23f73208-2daa-48a5-9b8e-18f1020a58fc">

Shared with user view
<img width="1488" alt="Screenshot 2023-09-14 at 4 06 55 PM" src="https://github.com/codalab/codabench/assets/13259262/8a1b713b-9c2a-415b-b479-c5b8ef012bf9">



# Issues this PR resolves
- #1156 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

