### PR TITLE
Add help in Files table

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -60,7 +60,12 @@
                                         <th>Phase</th>
                                         <th>Task</th>
                                         <th>Type</th>
-                                        <th>Available</th>
+                                        <th>Available <span class="ui mini circular icon button"
+                                                          data-tooltip="Available for download to participants."
+                                                          data-position="top center">
+                                                          <i class="question icon"></i>
+                                                      </span>
+                                        </th>
                                         <th>Size</th>
                                     </tr>
                                     </thead>


### PR DESCRIPTION
# Summary

The goal of this PR is to add a question mark `(?)` to clarify what the "Available" column is in the Files tab: "Available for download to participants".

However, currently with this change, the display is not satisfying as the line breaks:

<img width="918" alt="Capture d’écran 2023-09-14 à 13 49 29" src="https://github.com/codalab/codabench/assets/11784999/8aca6fa0-596d-4e10-ba1e-516c44e6ecbc">


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

