### PR TITLE
Compute worker - docker pull image failure logs

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import logging
 
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
@@ -14,13 +15,16 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.viewsets import ModelViewSet
 from rest_framework_csv import renderers
+from django.core.files.base import ContentFile
 
 from profiles.models import Organization, Membership
 from tasks.models import Task
 from api.serializers.submissions import SubmissionCreationSerializer, SubmissionSerializer, SubmissionFilesSerializer
-from competitions.models import Submission, Phase, CompetitionParticipant
+from competitions.models import Submission, SubmissionDetails, Phase, CompetitionParticipant
 from leaderboards.strategies import put_on_leaderboard_by_submission_rule
 from leaderboards.models import SubmissionScore, Column, Leaderboard
+
+logger = logging.getLogger()
 
 
 class SubmissionViewSet(ModelViewSet):
@@ -50,6 +54,25 @@ class SubmissionViewSet(ModelViewSet):
                     hostname = request.data['status_details'].replace('scoring_hostname-', '')
                     obj.scoring_worker_hostname = hostname
                     obj.save()
+
+            # Set docker pull failure logs in ingestion std_err
+            # check if type: Docker_Image_Pull_Fail is there in the data
+            if "type" in self.request.data.keys():
+                if request.data["type"] == "Docker_Image_Pull_Fail":
+                    # Get the error message
+                    error_message = request.data['error_message']
+                    try:
+                        # Get submission detail for this submissions with name = prediction_ingestion_stderr
+                        submission_detail = SubmissionDetails.objects.get(
+                            name="prediction_ingestion_stderr",
+                            submission=obj,
+                        )
+                        # write the docker pull image error message to the file
+                        submission_detail.data_file.save(submission_detail.data_file.name, ContentFile(error_message.encode("utf-8")))
+
+                    except SubmissionDetails.DoesNotExist:
+                        logger.warning("SubmissionDetails object not found.")
+
             not_bot_user = self.request.user.is_authenticated and not self.request.user.is_bot
 
             if self.action in ['update_fact_sheet', 're_run_submission']:


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now if docker image pull fails, users can see logs live and in ingestion std_err

Live logs:
<img width="1373" alt="Screenshot 2023-09-17 at 8 28 05 PM" src="https://github.com/codalab/codabench/assets/13259262/c6e12588-afc5-4822-ba9c-457bfd21ec9f">

Submission logs:
<img width="1264" alt="Screenshot 2023-09-17 at 8 28 16 PM" src="https://github.com/codalab/codabench/assets/13259262/9f6d76f6-fcf0-43d2-9a7d-1caa972e1b57">




# Issues this PR resolves
- #902 -> Show logs when compute worker crashes because of invalid docker image





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

