### PR TITLE
Phase Dates - UI Bug removed

### DIFF
--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -389,6 +389,25 @@
             $(self.refs.modal).modal('hide')
         }
 
+        self.formatDateToYYYYMMDD = function(input) {
+            // This function formats date in the format YYYY-MM-DD
+
+            // convert input to date
+            var dateObject = new Date(input)
+
+            // check if date has a time
+            if (!isNaN(dateObject.getTime())) {
+                // Extract year
+                var year = dateObject.getFullYear()
+                // Extract Month
+                var month = (dateObject.getMonth() + 1).toString().padStart(2, '0')
+                // Extract day
+                var day = dateObject.getDate().toString().padStart(2, '0')
+                return `${year}-${month}-${day}`
+            }
+            return input
+        }
+
         self.form_updated = function () {
             // This checks phases overall to make sure they are ready to go
             var is_valid = true
@@ -406,9 +425,8 @@
                 })
                 _.forEach(_.range(self.phases.length), i => {
                     if (i !== 0) {
-                        let end = Date.parse(self.phases[i - 1].end)
-                        let start = Date.parse(self.phases[i].start)
-
+                        let end = Date.parse(self.formatDateToYYYYMMDD(self.phases[i - 1].end))
+                        let start = Date.parse(self.formatDateToYYYYMMDD(self.phases[i].start))
                         if (end > start || !end) {
                             let message = `Phase "${_.get(self.phases[i], 'name', i + 1)}" must start after phase "${_.get(self.phases[i - 1], 'name', i)}" ends`
                             if (!self.warnings.includes(message)) {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can set the start date of Phase 2 similar to Phase 1 end date without the buggy UI warning:
<img width="966" alt="Screenshot 2023-09-18 at 11 01 51 PM" src="https://github.com/codalab/codabench/assets/13259262/07ccd239-0d9b-4a8f-8b31-414da0455e35">

Note: the warning will be shown for wrong dates.



# Issues this PR resolves
- #1155 -> Fix the interface so we don't need to click again on the dates to hide the error message




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

