### PR TITLE
Remove score rouding in Submissions tab

### DIFF
--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -389,7 +389,7 @@
 
         self.get_score = function (submission) {
             try{
-                return parseFloat(submission.scores[0].score).toFixed(2)
+                return parseFloat(submission.scores[0].score) // not rounded to avoid problems
                 
             } catch {
                 return ""


### PR DESCRIPTION
The score found in the "My Submissions" tab is not coherent with the leaderboard score. This is likely due to an imprecision in the rounding using javascript.

This PR simply removes the rounding, so we have a long float in "My Submissions" table. Maybe instead we should look at how the leaderboard score is retrieved.

We need a bundle and submissions that reproduce the difference between the leaderboard score and "My submissions" score to test this.

---

Maybe `parseFloat` is also imprecise

---

Other ways of rounding in javascript are described here:
https://sanori.github.io/2019/04/JavaScript-Pitfalls-Tips-toFixed/

# Issues this PR resolves

- #1171

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

