### PR TITLE
Show error in scoring std_err

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -376,6 +376,7 @@ class Run:
                     docker_pull_fail_data = {
                         "type": "Docker_Image_Pull_Fail",
                         "error_message": error_message,
+                        "is_scoring": self.is_scoring
                     }
                     # Send data to be written to ingestion logs
                     self._update_submission(docker_pull_fail_data)

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -68,9 +68,8 @@ class SubmissionViewSet(ModelViewSet):
                     # Set file name to ingestion std error as default
                     error_file_name = "prediction_ingestion_stderr"
 
-                    # Change error file name when error comes from execution time limit
-                    # and error occured during scoring
-                    if request.data["type"] == "Execution_Time_Limit_Exceeded" and request.data['is_scoring'] == "True":
+                    # Change error file name to scoring_stderr when error occurs during scoring
+                    if request.data['is_scoring'] == "True":
                         error_file_name = "scoring_stderr"
 
                     try:


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now either docker pull or execution time limit errors occurred during scoring with be shown in scoring `std_err`


# Issues this PR resolves
- #1205 -> Docker pull error during scoring are written in ingestion stderr instead of scoring stdrerr




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

