### PR TITLE
Only lookup by id if search is an int

### DIFF
--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -69,8 +69,17 @@ def user_lookup(request):
     if search:
         filters |= Q(username__icontains=search)
         filters |= Q(email__icontains=search) if is_admin else Q(email__iexact=search)
-    elif id and id.isdigit():
-        filters = Q(id=search)
+    elif id:
+        if not is_admin:
+            raise PermissionDenied('Cannot look up by id')
+
+        if not id.isdigit():
+            return HttpResponse(
+                'Invalid id',
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        filters = Q(id=id)
 
     users = User.objects.exclude(id=request.user.id).filter(filters)[:5]
 

--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -68,7 +68,8 @@ def user_lookup(request):
     if search:
         filters |= Q(username__icontains=search)
         filters |= Q(email__icontains=search) if is_admin else Q(email__iexact=search)
-        filters |= Q(id=search)
+        if search.isdigit():
+            filters |= Q(id=search)
 
     users = User.objects.exclude(id=request.user.id).filter(filters)[:5]
 

--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -62,14 +62,15 @@ class GetMyProfile(RetrieveAPIView, GenericAPIView):
 @login_required
 def user_lookup(request):
     search = request.GET.get('q', '')
+    id = request.GET.get('id')
     filters = Q()
     is_admin = request.user.is_superuser or request.user.is_staff
 
     if search:
         filters |= Q(username__icontains=search)
         filters |= Q(email__icontains=search) if is_admin else Q(email__iexact=search)
-        if search.isdigit():
-            filters |= Q(id=search)
+    elif id and id.isdigit():
+        filters = Q(id=search)
 
     users = User.objects.exclude(id=request.user.id).filter(filters)[:5]
 


### PR DESCRIPTION
@Didayolo This a follow up to #1206 to only perform id lookup if the search term can be converted to a int. It also restricts it to admin accounts. It also separates the query into a separate query parameter, which I think is better.
