### PR TITLE
Edit Profile - Do not allow updation of email

### DIFF
--- a/src/static/riot/profiles/profile_edit.tag
+++ b/src/static/riot/profiles/profile_edit.tag
@@ -41,7 +41,7 @@
             <input type="text" name="location" placeholder="Location"></div>
         <div class="field" id="email">
             <label>Email</label>
-            <input type="text" name="email" placeholder="Email">
+            <input disabled type="text" name="email" placeholder="Email">
         </div>
         <div class="two fields">
             <div class="field" id="personal_url">
@@ -99,16 +99,10 @@
              $('#user-form').form({
                  keyboardShortcuts: false,
                  fields: {
-                     email: {
-                         identifier: 'email',
-                         optional: true,
-                         rules: [
-                             {
-                                 type: 'email',
-                                 prompt: 'Please enter a valid {name}'
-                             }
-                         ]
-                     },
+                    email: {
+                        identifier: 'email',
+                        optional: true // Make the email field optional
+                    },
                      personal_url: {
                          identifier: 'personal_url',
                          optional: true,
@@ -167,7 +161,13 @@
                      },
                  },
                  onSuccess: function () {
-                     _.extend(self.selected_user, $('#user-form').form('get values'))
+                     // get form values from user-form
+                     const formValues = $('#user-form').form('get values')
+                     
+                     // delete email from form values
+                     delete formValues.email;
+
+                     _.extend(self.selected_user, formValues)
                      CODALAB.api.update_user_details(self.selected_user.id, self.selected_user)
                          .done(data => {
                              toastr.success("Details Saved")


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
The following are changed to not allow users to update email in edit profile:
- disabled email input field
- removed email from form values before sending to server (in case someone enables the input using inspect feature of browser)

<img width="996" alt="Screenshot 2023-11-10 at 4 44 32 PM" src="https://github.com/codalab/codabench/assets/13259262/c3aed5dc-504b-46e2-83db-d20676269e6d">



# Issues this PR resolves
- #1215 





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

