### PR TITLE
Server status - show parent's queue for child submissions

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -90,8 +90,14 @@ class ServerStatusView(TemplateView):
         for submission in context['submissions']:
             # Get filesize from each submissions's data
             submission.file_size = self.format_file_size(submission.data.file_size)
+
             # Get queue from each submission
-            queue_name = "*" if submission.queue is None else submission.queue.name
+            queue_name = ""
+            # if submission has parent get queue from parent otherwise from the submission iteset
+            if submission.parent:
+                queue_name = "*" if submission.parent.queue is None else submission.parent.queue.name
+            else:
+                queue_name = "*" if submission.queue is None else submission.queue.name
             submission.competition_queue = queue_name
 
         return context


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
In server status page now in queue column, users can see the parent's queue for child submissions

<img width="1342" alt="Screenshot 2023-11-12 at 2 58 19 PM" src="https://github.com/codalab/codabench/assets/13259262/c0e1e3b3-fbc3-47c8-8a90-c2ae1e2a72ee">



# Issues this PR resolves
- #1195





# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

