### PR TITLE
Clickable username in participant manager

### DIFF
--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -25,7 +25,7 @@
             </thead>
             <tbody>
             <tr each="{participants}">
-                <td>{username}</td>
+                <td><a href="/profiles/user/{username}" target="_BLANK">{username}</a></td>
                 <td>{email}</td>
                 <td>{is_bot}</td>
                 <td>{_.startCase(status)}</td>


### PR DESCRIPTION
This PR makes the username in the participant manager clickable

<img width="868" alt="Capture d’écran 2024-01-20 à 06 27 31" src="https://github.com/codalab/codabench/assets/11784999/69b2bfba-2b1c-45ed-8e08-e0c5f55a39c5">



# Issues this PR resolves

- #1200



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] CircleCi tests are passing
- [x] Ready to merge

