### PR TITLE
Clickable username in competition header

### DIFF
--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -41,7 +41,7 @@
                             <!-- Main information -->
                             <div>
                                 <span class="detail-label">Organized by:</span>
-                                <span class="detail-item">{competition.created_by}</span>
+                                <span class="detail-item"><a href="/profiles/user/{competition.created_by}" target="_BLANK">{competition.created_by}</a></span>
                                 <span if="{competition.contact_email}">(<span class="contact-email">{competition.contact_email}</span>)</span>
                             </div>
                             <div>


### PR DESCRIPTION
Clickable username for organizer in competition header:

<img width="787" alt="Capture d’écran 2024-01-21 à 02 56 02" src="https://github.com/codalab/codabench/assets/11784999/55f21069-f33e-421f-9c8f-0d2b781d6f5a">



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] CircleCi tests are passing
- [x] Ready to merge

