### PR TITLE
Rerun submission when a task used is deleted

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -270,7 +270,14 @@ class SubmissionViewSet(ModelViewSet):
             rerun_kwargs = {}
 
         new_sub = submission.re_run(**rerun_kwargs)
-        return Response({'id': new_sub.id})
+        if new_sub is None:
+            # return error
+            return Response({
+                "error_msg": "You cannot rerun this submission because one or more tasks this submission was running are deleted, resubmit the submission or contact the competition organizer!"},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        else:
+            return Response({'id': new_sub.id})
 
     @action(detail=False, methods=('POST',))
     def re_run_many_submissions(self, request):

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -323,7 +323,11 @@
                 .fail(function (response) {
                     if(response.responseJSON.detail){
                         toastr.error(response.responseJSON.detail)
-                    } else {
+                    } 
+                    else if(response.responseJSON.error_msg){
+                        toastr.error(response.responseJSON.error_msg)
+                    }
+                    else {
                         toastr.error(response.responseText)
                     }
                 })

--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -639,7 +639,7 @@
         }
 
         self.delete_task = function (task) {
-            if (confirm("Are you sure you want to delete '" + task.name + "'?")) {
+            if (confirm("Are you sure you want to delete '" + task.name + "'?\nSubmissions using this task cannot rerun!")) {
                 CODALAB.api.delete_task(task.id)
                     .done(function () {
                         self.update_tasks()
@@ -654,7 +654,7 @@
         }
 
         self.delete_tasks = function () {
-            if (confirm(`Are you sure you want to delete multiple tasks?`)) {
+            if (confirm(`Are you sure you want to delete multiple tasks?\nSubmissions using these tasks cannot rerun!`)) {
                 CODALAB.api.delete_tasks(self.marked_tasks)
                     .done(function () {
                         self.update_tasks()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Previously, when a task was disconnected from a competition but it was used in a submission: Rerunning such submission would result in a submission stuck in `submitted` status.

Now, when task/tasks are deleted, a warning message is shown to the user:
<img width="456" alt="Screenshot 2024-01-28 at 4 12 46 PM" src="https://github.com/codalab/codabench/assets/13259262/dd0191f1-1afa-4699-b93d-37535d63de59">
<img width="456" alt="Screenshot 2024-01-28 at 4 13 25 PM" src="https://github.com/codalab/codabench/assets/13259262/c5b66e0f-bed5-47c3-b0b8-7f099fd53d45">

If a user tries to rerun submission with its task deleted, the following error message is shown:
<img width="1342" alt="Screenshot 2024-01-28 at 4 02 12 PM" src="https://github.com/codalab/codabench/assets/13259262/fb272548-8045-4a07-9cf7-7b5eea4a1261">



# Issues this PR resolves
- #1179 
- #1182 -> Re-run submission on deleted task



# A checklist for hand testing
### For single-task phase
- [x] Create a competition with one task A per phase, 
- [x] upload a submission and wait for its success, 
- [x] add a new task B in resource interface
- [x] remove task A from phase
- [x] connect task B to this phase
- [x] delete task A from resource interface
- [x] rerun the submission and check if you get an error

### For multi-task phase
- [x] repeat the above but make sure to create multi-task phase


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

