### PR TITLE
OIDC PR#1 --- Enable/Disable regular Login and Signup

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -70,6 +70,12 @@ AWS_QUERYSTRING_AUTH=False
 # -----------------------------------------------------------------------------
 RERUN_SUBMISSION_LIMIT=30
 
+    # -----------------------------------------------------------------------------
+    # Enable or disbale regular email sign-in an sign-up
+    # -----------------------------------------------------------------------------
+    ENABLE_SIGN_UP=True
+    ENABLE_SIGN_IN=True
+
 
 # # S3 storage example
 # STORAGE_TYPE=s3

--- a/src/apps/profiles/urls_accounts.py
+++ b/src/apps/profiles/urls_accounts.py
@@ -8,10 +8,6 @@ app_name = "accounts"
 urlpatterns = [
     url(r'^signup', views.sign_up, name="signup"),
     path('login/', views.log_in, name='login'),
-    # url(r'^user_profile', views.user_profile, name="user_profile"),
-    # path('login/', auth_views.LoginView.as_view(extra_context=extra_context), name='login'),
-    # path('login/', views.LoginView.as_view(), name='login'),
-    # path('logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('logout/', views.LogoutView.as_view(), name='logout'),
     path('password_reset/', views.CustomPasswordResetView.as_view(), name='password_reset'),
     path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(), name='password_reset_done'),

--- a/src/apps/profiles/views.py
+++ b/src/apps/profiles/views.py
@@ -104,6 +104,12 @@ def activateEmail(request, user, to_email):
 
 
 def sign_up(request):
+
+    # If sign up is not enabled then redirect to login
+    # this is for security as some users may access sign up page using the url
+    if not settings.ENABLE_SIGN_UP:
+        return redirect('accounts:login')
+
     context = {}
     context['chahub_signup_url'] = "{}/profiles/signup?next={}/social/login/chahub".format(
         settings.SOCIAL_AUTH_CHAHUB_BASE_URL,

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -469,3 +469,10 @@ AJAX_LOOKUP_CHANNELS = {'django_su': dict(model='profiles.User', search_field='u
 # on default queue when number of submissions are < RERUN_SUBMISSION_LIMIT
 # =============================================================================
 RERUN_SUBMISSION_LIMIT = os.environ.get('RERUN_SUBMISSION_LIMIT', 30)
+
+
+# =============================================================================
+# Enable or disbale regular email sign-in an sign-up
+# =============================================================================
+ENABLE_SIGN_UP = os.environ.get('ENABLE_SIGN_UP', 'True').lower() == 'true'
+ENABLE_SIGN_IN = os.environ.get('ENABLE_SIGN_IN', 'True').lower() == 'true'

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -177,7 +177,9 @@
                         </div>
                     {% else %}
                         <a href="{% url 'accounts:login' %}" class="ui button style_button item">Login</a>
-                        <a href="{% url 'accounts:signup' %}" class="ui button style_button item">Sign-up</a>
+                        {% if ENABLE_SIGN_UP %}
+                            <a href="{% url 'accounts:signup' %}" class="ui button style_button item">Sign-up</a>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/src/templates/registration/login.html
+++ b/src/templates/registration/login.html
@@ -6,6 +6,7 @@
     <h2 class="ui blue centered header">
         Login
     </h2>
+    {% if ENABLE_SIGN_IN %}
     <div class="ui stacked segment">
         <form class="ui form" method="POST">
             {% csrf_token %}
@@ -52,11 +53,14 @@
             </div>
             <button class="ui fluid blue submit button" type="submit">Log In</button>
             <div class="ui divider"></div>
-            <p>New to us? <a href="{% url 'accounts:signup' %}">Sign Up</a></p>
+            {% if ENABLE_SIGN_UP %}
+                <p>Don't have an account? <a href="{% url 'accounts:signup' %}">Sign Up</a></p>
+            {% endif %}
             <p><a href="{% url 'accounts:password_reset' %}">Forgot your password?</a></p>
 
             <div class="ui error message"></div>
         </form>
     </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/src/templates/registration/login.html
+++ b/src/templates/registration/login.html
@@ -3,10 +3,10 @@
 
 {% block content %}
 <div class="sixteen wide mobile six wide computer centered column">
+    {% if ENABLE_SIGN_IN %}
     <h2 class="ui blue centered header">
         Login
     </h2>
-    {% if ENABLE_SIGN_IN %}
     <div class="ui stacked segment">
         <form class="ui form" method="POST">
             {% csrf_token %}

--- a/src/utils/context_processors.py
+++ b/src/utils/context_processors.py
@@ -23,4 +23,6 @@ def common_settings(request):
         'USER_JSON_DATA': json.dumps(user_json_data),
         'RABBITMQ_MANAGEMENT_URL': f"http://{settings.DOMAIN_NAME}:{settings.RABBITMQ_MANAGEMENT_PORT}",
         'FLOWER_URL': f"http://{settings.DOMAIN_NAME}:{settings.FLOWER_PUBLIC_PORT}",
+        'ENABLE_SIGN_UP': settings.ENABLE_SIGN_UP,
+        'ENABLE_SIGN_IN': settings.ENABLE_SIGN_IN,
     }


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo @cjh1 


# A brief description of the purpose of the changes contained in this PR.
This is PR-1 for changes needed for feature: #1298  

Platform owners can now enable/disable regular signup and login. This is useful for dedicated instances where people just want Organization authentication rather than using the normal sign in and signup.

- If you disable signup i.e. set `ENABLE_SIGN_UP=False` in your .env, you will not see sign up button and sign up page
- If you disable sigin i.e. set `ENABLE_SIGN_IN=False` in your .env, you will see empty login page. This is on purpose because you will see organization authentication buttons there (soon)

Note: if you change either of these variables in your .env you need to stop and start the service:
```
docker-compose down
```

```
docker-compose up -d
```


# Issues this PR resolves
- #1298 -> Regular signup/signIn



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

