### PR TITLE
Files Tab: show login if not loggedin + hide available column from no…

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -50,17 +50,25 @@
                             <div class="ui" id="page_term">
                             </div>
                         </div>
-                        <!--  Files  -->
+                        
+                        <!--  Files page  -->
                         <div class="ui tab {active: _.get(competition.pages, 'length') === 0}" data-tab="files">
                             <div class="ui" id="files">
-                                <table class="ui celled table">
+                                <!--  Login message if not loggedin  -->
+                                <div if="{!CODALAB.state.user.logged_in}" class="ui yellow message">
+                                    <a href="{URLS.LOGIN}?next={location.pathname}">Log In</a> or
+                                    <a href="{URLS.SIGNUP}" target="_blank">Sign Up</a> to view availbale files.
+                                </div>
+
+                                <!--  Files table if loggedin  -->
+                                <table if="{CODALAB.state.user.logged_in}" class="ui celled table">
                                     <thead>
                                     <tr>
                                         <th class="index-column">Download</th>
                                         <th>Phase</th>
                                         <th>Task</th>
                                         <th>Type</th>
-                                        <th>Available <span class="ui mini circular icon button"
+                                        <th if="{competition.is_admin}">Available <span class="ui mini circular icon button"
                                                           data-tooltip="Available for download to participants."
                                                           data-position="top center">
                                                           <i class="question icon"></i>
@@ -80,7 +88,7 @@
                                         <td>{file.task}</td>
                                         <td>{file.type}</td>
                                         <!--  <td>{file.type === 'Public Data' || file.type === 'Starting Kit' ? 'yes': 'no'}</td>  -->
-                                        <td class="center aligned">
+                                        <td if="{competition.is_admin}" class="center aligned">
                                             <i if="{file.available}" class="checkmark box icon green"></i>
                                         </td>
                                         <td>{filesize(file.file_size * 1024)}</td>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
### 1. In files tab if you are not loggedin, you will see a login message instead of an empty table
<img width="1358" alt="Screenshot 2024-02-07 at 3 13 24 PM" src="https://github.com/codalab/codabench/assets/13259262/0186bf38-aba8-4090-8c37-6b2fd42b75db">

### 2. When loggedin, only competition admins can see available column

Admin view:
<img width="1231" alt="Screenshot 2024-02-07 at 3 13 08 PM" src="https://github.com/codalab/codabench/assets/13259262/df07f89c-5f97-4611-8d4c-5824a639f021">

Participant view:
<img width="1308" alt="Screenshot 2024-02-07 at 3 13 37 PM" src="https://github.com/codalab/codabench/assets/13259262/36221ebd-f628-4241-bb97-b0cd8dffa19e">



# Issues this PR resolves
- #1229 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

