### PR TITLE
Delete rerun submission deletes original submission

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -500,10 +500,17 @@ class Submission(ChaHubSaveMixin, models.Model):
         return f"{self.phase.competition.title} submission PK={self.pk} by {self.owner.username}"
 
     def delete(self, **kwargs):
+
+        # Check if any other submissions are using the same data
+        other_submissions_using_data = Submission.objects.filter(data=self.data).exclude(pk=self.pk).exists()
+
+        if not other_submissions_using_data:
+            # If no other submissions are using the same data, delete it
+            self.data.delete()
+
         # Also clean up details on delete
         self.details.all().delete()
-        # Call this here so that the data_file for the submission also gets deleted from storage
-        self.data.delete()
+
         super().delete(**kwargs)
 
     def save(self, ignore_submission_limit=False, **kwargs):


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
We had two problems:
1. When you delete a rerun submission, its original submission is also deleted
2. When you delete original submission, its rerun submissions are also deleted.

**NOW** this PR fixes this problem i.e. *do not delete original submission when a reun is deleted, similarly do not delete rerun submissions when original is deleted*


# Issues this PR resolves
- #1300 
- #1182 -> Deleting a re-run submission also delete the original submission



# A checklist for hand testing
- [ ] upload a submission
- [ ] rerun this submission (it will create a new submission)
- [ ] delete the rerun submission and check that the original submission is NOT deleted
- [ ] rerun the original submission again multiple times
- [ ] delete the original submission and check that the rerun submission are NOT deleted


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

