### PR TITLE
Task deletion warning

### DIFF
--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -639,7 +639,7 @@
         }
 
         self.delete_task = function (task) {
-            if (confirm("Are you sure you want to delete '" + task.name + "'?\nSubmissions using this task cannot rerun!")) {
+            if (confirm("Are you sure you want to delete '" + task.name + "'?\nSubmissions using this task cannot rerun! Results displayed on leaderboard can also be affected!")) {
                 CODALAB.api.delete_task(task.id)
                     .done(function () {
                         self.update_tasks()
@@ -654,7 +654,7 @@
         }
 
         self.delete_tasks = function () {
-            if (confirm(`Are you sure you want to delete multiple tasks?\nSubmissions using these tasks cannot rerun!`)) {
+            if (confirm(`Are you sure you want to delete multiple tasks?\nSubmissions using these tasks cannot rerun! Results displayed on leaderboard can also be affected!`)) {
                 CODALAB.api.delete_tasks(self.marked_tasks)
                     .done(function () {
                         self.update_tasks()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
A warning `Results displayed on leaderboard can also be affected!` is added to the deletion confirmation

Single task deletion:
<img width="462" alt="Screenshot 2024-02-09 at 3 21 33 PM" src="https://github.com/codalab/codabench/assets/13259262/b5e64e82-09eb-46f3-9ecd-aea698d147ef">


Multip task deletion:
<img width="464" alt="Screenshot 2024-02-09 at 3 21 20 PM" src="https://github.com/codalab/codabench/assets/13259262/a2622a6a-8ec7-4f7f-b3b2-727589bedd75">


# Issues this PR resolves
- #1250 




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

