### PR TITLE
Queues - show competitions using the queue

### DIFF
--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -133,11 +133,20 @@
         </div>
         <div class="content">
             <h4>Broker URL:</h4>
-            <div class="ui field">
-                <textarea class="broker_url" value="{selected_queue.broker_url}" disabled></textarea>
-            </div>
-            <h4>Vhost</h4>
-            {selected_queue.vhost}
+            <span>{selected_queue.broker_url}</span>
+            
+            <h4>Vhost:</h4>
+            <span>{selected_queue.vhost}</span>
+
+            <!--  Competitions using this queue  -->
+            <h4 if="{ _.get(selected_queue, 'competitions.length', 0) }">Competitions using this queue:</h4>
+            <ul if="{ _.get(selected_queue, 'competitions.length', 0) }">
+                <li each="{ comp in selected_queue.competitions }">
+                
+                <a class="link-no-deco" target="_blank" href="../competitions/{ comp.id }">{comp.title}</a>
+                </li>
+            </ul>
+ 
         </div>
         <div class="actions">
             <div class="ui cancel button" onclick="{ close_broker_modal }">Close</div>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
When viewing queue details, now you can see which competitions are using this queue with the following conditions:
1. Super admin can see all competitions using this queue
2. Admins/Organizers can see public competitions and competitions which they are organzining (cannot see private competitions where use is not admin)
3. Normal user can see public competitions using this queue (canont see private competitions)


# Screenshot:
<img width="935" alt="Screenshot 2024-02-09 at 4 41 38 PM" src="https://github.com/codalab/codabench/assets/13259262/0ff43b36-4300-472c-9f25-4bb4196746c0">


# Issues this PR resolves
- #1227 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

