### PR TITLE
html tags in email text

### DIFF
--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -41,9 +41,10 @@ def sanitize(content):
 
 def codalab_send_markdown_email(subject, markdown_content, recipient_list, from_email=None):
     from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
-    message = sanitize(markdown_content)
-    html_message = sanitize(markdown.markdown(message))
+    html_message = markdown.markdown(markdown_content)
+    # message = sanitize(markdown_content)
+    # html_message = sanitize(markdown.markdown(message))
 
-    message = EmailMultiAlternatives(subject, message, from_email=from_email, bcc=recipient_list)
+    message = EmailMultiAlternatives(subject, '', from_email=from_email, bcc=recipient_list)
     message.attach_alternative(html_message, 'text/html')
     message.send()


### PR DESCRIPTION
@Didayolo 

we need to test this on test server. I think this change should fix the issue

### How to test:

Send an email to a participant with text:
```
**bold** [link](https://codabench.org)
```

Participant should receive:

**bold** [link](https://codabench.org)

Participant should not receive:
```
<strong>bold</strong> <a href="https://codabench.org">link</a>
```


### Why I think this is fixed?

Before the fix, I see the following in the django logs:

```
<p>&lt;strong&gt;bold&lt;/strong&gt; &lt;a href="https://codabench.org"&gt;link&lt;/a&gt;</p>
```

after the fix I see this:
```
<p><strong>bold</strong> <a href="https://codabench.org">link</a></p>
```


If this fixes the problem, then I will cleanup and add some comments