### PR TITLE
Auto-migrate leaderboard submissions

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -117,10 +117,12 @@ class Competition(ChaHubSaveMixin, models.Model):
         self.is_migrating = True
         self.save()
 
+        # Get submissions of current phase with finished status and which are on leaderboard
         submissions = Submission.objects.filter(
             phase=current_phase,
             is_migrated=False,
             parent__isnull=True,
+            leaderboard__isnull=False,
             status=Submission.FINISHED
         )
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Previously, all submissions of a phase were migrated to a new phase in the auto-migration.

NOW, only leaderboard submissions will be migrated


# Issues this PR resolves
- #1182 -> Auto-migration



# Test
- Test it on test server (not tested locally)

# Checklist
- [x] Code review by me 
- [ ] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

