### PR TITLE
Public Competitions - Remove cache

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -533,7 +533,6 @@ class CompetitionViewSet(ModelViewSet):
         serializer = CompetitionCreationTaskStatusSerializer({"status": "Success. Competition dump is being created."})
         return Response(serializer.data, status=201)
 
-    @cache_response(key_func=DefaultListKeyConstructor())
     @action(detail=False, methods=('GET',), pagination_class=LargePagination)
     def public(self, request):
         qs = self.get_queryset()

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -18,8 +18,6 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 from rest_framework_csv.renderers import CSVRenderer
-from rest_framework_extensions.cache.decorators import cache_response
-from rest_framework_extensions.key_constructor.constructors import DefaultListKeyConstructor
 from api.pagination import LargePagination
 from api.renderers import ZipRenderer
 from rest_framework.viewsets import ModelViewSet

--- a/src/static/riot/competitions/public-list.tag
+++ b/src/static/riot/competitions/public-list.tag
@@ -49,7 +49,6 @@
 <script>
     var self = this
     self.competitions = {}
-    self.competitions_cache = {}
 
     self.one("mount", function () {
         self.update_competitions_list(self.get_url_page_number_or_default())
@@ -68,26 +67,21 @@
         // Function to handle successful data retrieval
         function handleSuccess(response) {
             self.competitions = response;
-            self.competitions_cache[self.current_page.toString()] = response;
             $('#loading').hide(); // Hide the loading indicator
             $('.pagination-nav').show(); // Show pagination navigation
             history.pushState("", document.title, "?page=" + self.current_page);
             $('.pagination-nav > button').prop('disabled', false);
             self.update();
         }
-        // Check if data is in cache
-        if (self.competitions_cache[self.current_page]) {
-            handleSuccess(self.competitions_cache[self.current_page]);
-        } else {
-            // Fetch data using AJAX call
-            return CODALAB.api.get_public_competitions({"page": self.current_page})
-                .fail(function (response) {
-                    $('#loading').hide(); // Hide the loading indicator
-                    $('.pagination-nav').show(); // Show pagination navigation
-                    toastr.error("Could not load competition list");
-                })
-                .done(handleSuccess);
-        }
+        // Fetch data using AJAX call
+        return CODALAB.api.get_public_competitions({"page": self.current_page})
+            .fail(function (response) {
+                $('#loading').hide(); // Hide the loading indicator
+                $('.pagination-nav').show(); // Show pagination navigation
+                toastr.error("Could not load competition list");
+            })
+            .done(handleSuccess);
+        
     };
 
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Public competition page and django was caching competitions, which was problematic because if you change something e.g. title etc of a competition, this was not reflected until you delete the cache manually. This may also have solved the speed of the page loading.


# Issues this PR resolves
- Maybe #1327-> Optimize the code for loading the competitions list



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

