### PR TITLE
Allow links clicking in `VISUALIZATION` tab

### DIFF
--- a/src/static/riot/competitions/detail/_detailed_results.tag
+++ b/src/static/riot/competitions/detail/_detailed_results.tag
@@ -1,5 +1,4 @@
 <competition-detailed-results>
-    <h3>Detailed Results</h3>
     <iframe src="{detailed_result}" width="100%" height="100%" frameBorder="0"></iframe>
 
     <script>

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -136,7 +136,7 @@
         <div class="ui button green" onclick="{update_fact_sheet.bind(this)}">Save</div>
     </div>
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}graph" show="{opts.show_visualization && (!opts.hide_output || submission.admin)}">
-        <iframe sandbox="allow-scripts" src="{detailed_result}" class="graph-frame" show="{detailed_result}"></iframe>
+        <iframe src="{detailed_result}" class="graph-frame" show="{detailed_result}"></iframe>
     </div>
     <div class="ui tab leaderboard-tab" data-tab="admin" if="{submission.admin}">
         <submission-scores leaderboards="{leaderboards}"></submission-scores>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
It was not possible to click links in the VISUALIZATION tab of a submission because of an iframe property `sandbox`. Now this property is removed to allow clicking links.

# Issues this PR resolves
- #1391



# A checklist for hand testing
- [x] In the detailed result file write a link e.g. `html_file.write("<p><a href='https://www.google.com/' target='_blank'>Click this link</a></p>")` 
- [x] Test that you should NOT be able to click the link (without these changes)
- [x] Test that you should be able to click the link (with these changes)


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

