### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 RUN apt-get update && apt-get install -y gcc build-essential && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.10
 ENV PYTHONUNBUFFERED 1
 ENV C_FORCE_ROOT True
 ADD requirements.txt .

--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8
+FROM --platform=linux/amd64 python:3.10
 
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
This PR is to test if simply bumping to Python 3.10 could work.

Files modified:
- https://github.com/codalab/codabench/blob/python3.10/Dockerfile
- https://github.com/codalab/codabench/blob/python3.10/Dockerfile.compute_worker
- https://github.com/codalab/codabench/blob/python3.10/Dockerfile.celery

Files to be modified:

- https://github.com/codalab/codabench/blob/python3.10/Dockerfile.flower
- https://github.com/codalab/codabench/blob/python3.10/Dockerfile.rabbitmq