### PR TITLE
save comp to persist logo_icon

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -261,8 +261,10 @@ class Competition(ChaHubSaveMixin, models.Model):
             pass
         elif not self.logo_icon:
             self.make_logo_icon()
+            self.save()
         elif os.path.dirname(self.logo.name) != os.path.dirname(self.logo_icon.name):
             self.make_logo_icon()
+            self.save()
         to_create = User.objects.filter(
             Q(id=self.created_by_id) | Q(id__in=self.collaborators.all().values_list('id', flat=True))
         ).exclude(id__in=self.participants.values_list('user_id', flat=True)).distinct()


### PR DESCRIPTION
# @ mention of reviewers
@ihsaan-ullah @Didayolo 

# A brief description of the purpose of the changes contained in this PR.
Upon comp logo upload in competition editor, the logo_icon minio path isn't being updated (even though logo icon was being created). This change makes a specific call to save the competition post making a logo_icon. 

> Basically the competition.save method is saving everything about a competition when you save from the ui, except the new small icon it created. So even though we do an initial save with super().save(*args, **kwargs), we now resave after making the small logo to ensure the new path is reflected in the database.


# Issues this PR resolves

- #1390



# A checklist for hand testing
- [x] upload competition of find existing one
- [x] upload new logo and save competition
- [x] go to /admin and look into the competition record. The paths for both new logos should be similar with the exception of "_icon" in the icon path. 
- [x] ![image](https://github.com/codalab/codabench/assets/7649007/304f501c-1499-46ff-924e-73c1465bcdc9)



# Any relevant files for testing
* any comp

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

