### PR TITLE
Add a Bundles tab in Resources view

### DIFF
--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -26,7 +26,7 @@ class DataSerializer(DefaultUserCreateMixin, serializers.ModelSerializer):
             'was_created_by_competition',
             'competition',
             'file_name',
-
+            'is_dump',
         )
         read_only_fields = (
             'key',
@@ -98,6 +98,7 @@ class DataDetailSerializer(serializers.ModelSerializer):
             'file_size',
             'competition',
             'file_name',
+            'is_dump'
         )
 
     def get_competition(self, obj):

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -26,8 +26,6 @@ class DataViewSet(ModelViewSet):
 
     def get_queryset(self):
 
-        exclude_bundle = True
-
         if self.request.method == 'GET':
 
             # filters
@@ -55,11 +53,11 @@ class DataViewSet(ModelViewSet):
             # filter datasets and programs
             if is_dataset:
                 qs = qs.filter(~Q(type=Data.SUBMISSION))
+                qs = qs.exclude(Q(type=Data.COMPETITION_BUNDLE))
             
             # filter bundles
             if is_bundle:
                 qs = qs.filter(Q(type=Data.COMPETITION_BUNDLE))
-                exclude_bundle = False
 
             # public filter check
             if is_public:
@@ -76,8 +74,6 @@ class DataViewSet(ModelViewSet):
             qs = self.queryset
             qs = qs.filter(Q(is_public=True) | Q(created_by=self.request.user))
 
-        if exclude_bundle:
-            qs = qs.exclude(Q(type=Data.COMPETITION_BUNDLE))
         qs = qs.exclude(Q(name__isnull=True))
 
         qs = qs.select_related('created_by').order_by('-created_when')

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -26,6 +26,8 @@ class DataViewSet(ModelViewSet):
 
     def get_queryset(self):
 
+        exclude_bundle = True
+
         if self.request.method == 'GET':
 
             # filters
@@ -40,6 +42,9 @@ class DataViewSet(ModelViewSet):
             # _type = dataset if called from datasets and programs tab to filter datasets and programs
             is_dataset = self.request.query_params.get('_type', '') == 'dataset'
 
+            # _type = dataset if called from datasets and programs tab to filter datasets and programs
+            is_bundle = self.request.query_params.get('_type', '') == 'bundle'
+
             # get queryset
             qs = self.queryset
 
@@ -50,6 +55,11 @@ class DataViewSet(ModelViewSet):
             # filter datasets and programs
             if is_dataset:
                 qs = qs.filter(~Q(type=Data.SUBMISSION))
+            
+            # filter bundles
+            if is_bundle:
+                qs = qs.filter(Q(type=Data.COMPETITION_BUNDLE))
+                exclude_bundle = False
 
             # public filter check
             if is_public:
@@ -58,7 +68,7 @@ class DataViewSet(ModelViewSet):
                 qs = qs.filter(Q(created_by=self.request.user))
 
             # if GET is called but provided no filters, fall back to default behaviour
-            if (not is_submission) and (not is_dataset) and (not is_public):
+            if (not is_submission) and (not is_dataset) and (not is_bundle) and (not is_public):
                 qs = self.queryset
                 qs = qs.filter(Q(is_public=True) | Q(created_by=self.request.user))
 
@@ -66,7 +76,9 @@ class DataViewSet(ModelViewSet):
             qs = self.queryset
             qs = qs.filter(Q(is_public=True) | Q(created_by=self.request.user))
 
-        qs = qs.exclude(Q(type=Data.COMPETITION_BUNDLE) | Q(name__isnull=True))
+        if exclude_bundle:
+            qs = qs.exclude(Q(type=Data.COMPETITION_BUNDLE))
+        qs = qs.exclude(Q(name__isnull=True))
 
         qs = qs.select_related('created_by').order_by('-created_when')
 

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -408,6 +408,8 @@ def unpack_competition(status_pk):
             # call again, to make sure phases get sent to chahub
             competition.save()
             logger.info("Competition saved!")
+            status.dataset.name += f" - {competition.title}"
+            status.dataset.save()
 
     except CompetitionUnpackingException as e:
         # We want to catch well handled exceptions and display them to the user

--- a/src/apps/datasets/models.py
+++ b/src/apps/datasets/models.py
@@ -106,11 +106,6 @@ class Data(ChaHubSaveMixin, models.Model):
         ).values('pk', 'title').distinct()
         return competitions_in_use
 
-    @property
-    def is_dump(self):
-        from competitions.models import CompetitionDump
-        return CompetitionDump.objects.filter(dataset=self).exists()
-
     def __str__(self):
         return f'{self.name}({self.id})'
 

--- a/src/apps/datasets/models.py
+++ b/src/apps/datasets/models.py
@@ -106,6 +106,11 @@ class Data(ChaHubSaveMixin, models.Model):
         ).values('pk', 'title').distinct()
         return competitions_in_use
 
+    @property
+    def is_dump(self):
+        from competitions.models import CompetitionDump
+        return CompetitionDump.objects.filter(dataset=self).exists()
+
     def __str__(self):
         return f'{self.name}({self.id})'
 

--- a/src/static/riot/competitions/bundle_management.tag
+++ b/src/static/riot/competitions/bundle_management.tag
@@ -1,0 +1,149 @@
+<bundle-management>
+    <!--  Search -->
+    <div class="ui icon input">
+        <input type="text" placeholder="Search..." ref="search" onkeyup="{ filter.bind(this, undefined) }">
+        <i class="search icon"></i>
+    </div>
+
+    <!-- Data Table -->
+    <table id="bundlesTable" class="ui {selectable: datasets.length > 0} celled compact sortable table">
+        <thead>
+            <tr>
+                <th>File Name</th>
+                <th width="175px">Size</th>
+                <th width="125px">Uploaded</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr each="{ dataset, index in datasets }" class="dataset-row">
+                <td>{ dataset.name }</td>
+                <td>{ format_file_size(dataset.file_size) }</td>
+                <td>{ timeSince(Date.parse(dataset.created_when)) } ago</td>
+            </tr>
+            <tr if="{datasets.length === 0}">
+                <td class="center aligned" colspan="6">
+                    <em>No Datasets Yet!</em>
+                </td>
+            </tr>
+        </tbody>
+
+        <tfoot>
+            <!-- Pagination -->
+            <tr>
+                <th colspan="8" if="{datasets.length > 0}">
+                    <div class="ui right floated pagination menu" if="{datasets.length > 0}">
+                        <a show="{!!_.get(pagination, 'previous')}" class="icon item" onclick="{previous_page}">
+                            <i class="left chevron icon"></i>
+                        </a>
+                        <div class="item">
+                            <label>{page}</label>
+                        </div>
+                        <a show="{!!_.get(pagination, 'next')}" class="icon item" onclick="{next_page}">
+                            <i class="right chevron icon"></i>
+                        </a>
+                    </div>
+                </th>
+            </tr>
+        </tfoot>
+    </table>
+
+    <script>
+        var self = this
+
+        /*---------------------------------------------------------------------
+         Init
+        ---------------------------------------------------------------------*/
+
+        self.datasets = []
+        self.page = 1
+
+        self.one("mount", function () {
+            $(".ui.dropdown", self.root).dropdown()
+            $(".ui.checkbox", self.root).checkbox()
+            $('#bundlesTable').tablesort()
+            self.update_datasets()
+        })
+
+        /*---------------------------------------------------------------------
+         Methods
+        ---------------------------------------------------------------------*/
+
+        self.pretty_date = date => luxon.DateTime.fromISO(date).toLocaleString(luxon.DateTime.DATE_FULL)
+
+        self.filter = function (filters) {
+            filters = filters || {}
+            _.defaults(filters, {
+                search: $(self.refs.search).val(),
+                page: 1,
+            })
+            self.page = filters.page
+            self.update_datasets(filters)
+        }
+
+        self.next_page = function () {
+            if (!!self.pagination.next) {
+                self.page += 1
+                self.filter({page: self.page})
+            } else {
+                alert("No valid page to go to!")
+            }
+        }
+
+        self.previous_page = function () {
+            if (!!self.pagination.previous) {
+                self.page -= 1
+                self.filter({page: self.page})
+            } else {
+                alert("No valid page to go to!")
+            }
+        }
+
+        self.update_datasets = function (filters) {
+            filters = filters || {}
+            filters._type = "bundle"
+            CODALAB.api.get_datasets(filters)
+                .done(function (data) {
+                    self.datasets = data.results
+                    self.pagination = {
+                        "count": data.count,
+                        "next": data.next,
+                        "previous": data.previous
+                    }
+                    self.update()
+                })
+                .fail(function (response) {
+                    toastr.error("Could not load datasets...")
+                })
+        }
+
+        // Function to format file size 
+        self.format_file_size = function(file_size) {
+            // parse file size from string to float
+            try {
+                n = parseFloat(file_size)
+            }
+            catch(err) {
+                // return empty string if parsing fails
+                return ""
+            }
+            // a file_size of -1 indicated an error
+            if(n < 0) {
+                return ""
+            }
+            // constant units to show with files size
+            // file size is in KB, converting it to MB and GB 
+            const units = ['KB', 'MB', 'GB']
+            // loop incrementer for selecting desired unit
+            let i = 0
+            // loop over n until it is greater than 1000
+            while(n >= 1000 && ++i){
+                n = n/1000;
+            }
+            // restrict file size to 1 decimal number concatinated with unit
+            return(n.toFixed(1) + ' ' + units[i]);
+        }
+
+    </script>
+
+</bundle-management>

--- a/src/static/riot/management.tag
+++ b/src/static/riot/management.tag
@@ -4,6 +4,7 @@
     <div class="ui top attached tabular menu">
         <div class="active item" data-tab="submissions">Submissions</div>
         <div class="item" data-tab="datasets">Datasets and programs</div>
+        <div class="item" data-tab="bundles">Bundles</div>
         <div class="item" data-tab="tasks">Tasks</div>
         <div class="right menu">
             <div class="item">
@@ -18,6 +19,9 @@
     </div>
     <div class="ui bottom attached tab segment" data-tab="datasets">
         <data-management></data-management>
+    </div>
+    <div class="ui bottom attached tab segment" data-tab="bundles">
+        <bundle-management></bundle-management>
     </div>
     <div class="ui bottom attached tab segment" data-tab="tasks">
         <task-management></task-management>


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
This adds a tab in the Resources view (Bundles tab) that displays the bundles and dump created by the user.


# Issues this PR resolves
Related to issue #1364 


# A checklist for hand testing
- [x] New tab "Bundle"
- [x] Include bundles and dumps
- [x] Possibility to remove dumps
- [ ] ~Bundles should be removed when removing a competition~


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

