### PR TITLE
Fix daily submission counter

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -179,7 +179,7 @@ class PhaseDetailSerializer(serializers.ModelSerializer):
                 # Get all submissions which are not failed and belongs to this user for this phase
                 qs = obj.submissions.filter(owner=user, parent__isnull=True).exclude(status='Failed')
                 # Count submissions made today
-                daily_submission_count = qs.filter(created_when__day=now().day).count()
+                daily_submission_count = qs.filter(created_when__date=now().date()).count()
                 return daily_submission_count
         return 0
 


### PR DESCRIPTION
# Description

We were using `now().day`, instead of `now().date()`, hence counting submissions from the same day on different months or years.

# Issues this PR resolves
- #1469


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

