### PR TITLE
Remove private competitions and competition participants counters from home page

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -22,17 +22,13 @@ class HomeView(TemplateView):
             unpublished_comps=Count('pk', filter=Q(published=False)),
         )
 
-        total_competitions = data['count']
         public_competitions = data['published_comps']
         users = User.objects.all().count()
-        competition_participants = CompetitionParticipant.objects.all().count()
         submissions = Submission.objects.all().count()
 
         context['general_stats'] = [
-            {'label': "Total Competitions", 'count': total_competitions},
             {'label': "Public Competitions", 'count': public_competitions},
             {'label': "Users", 'count': users},
-            {'label': "Competition Participants", 'count': competition_participants},
             {'label': "Submissions", 'count': submissions},
         ]
 

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -3,7 +3,7 @@ from django.utils.timezone import now
 from django.views.generic import TemplateView
 from django.db.models import Count, Q
 
-from competitions.models import Competition, Submission, CompetitionParticipant
+from competitions.models import Competition, Submission
 from profiles.models import User
 from announcements.models import Announcement, NewsPost
 

--- a/src/templates/pages/home.html
+++ b/src/templates/pages/home.html
@@ -87,7 +87,7 @@
         </div>
 
         <!-- Stats section -->
-        <div class="ui five column grid" id="general-stats">
+        <div class="ui three column grid" id="general-stats">
             {% for stat in general_stats %}
                 <div class="column">
                     <div class="ui statistic">


### PR DESCRIPTION
**Total competitions** counter is not relevant because it counts many templates and testing competitions. Very few private competitions are real benchmarks. **Competition participants** is basically the number of users.

Before:

<img width="1102" alt="Capture d’écran 2024-06-13 à 02 36 47" src="https://github.com/codalab/codabench/assets/11784999/a70c1345-5ee2-4bc5-9a53-a7a3c40c80af">


After:

<img width="1112" alt="Capture d’écran 2024-06-13 à 02 36 19" src="https://github.com/codalab/codabench/assets/11784999/d631c11b-56b3-412a-adb0-74f78d210bfc">

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

