### PR TITLE
Add a display when there is no submission limit

### DIFF
--- a/src/static/riot/competitions/detail/submission_limit.tag
+++ b/src/static/riot/competitions/detail/submission_limit.tag
@@ -14,7 +14,7 @@
             </span>
             <!-- Badge for when there is no limit -->
             <span if="{selected_phase.max_submissions_per_day == 0}" class="badge badge-green">
-                ∞
+                {selected_phase.used_submissions_per_day} out of ∞
             </span>
         </div>
         <div class="col">
@@ -27,7 +27,7 @@
             </span>
             <!-- Badge for when there is no limit -->
             <span if="{selected_phase.max_submissions_per_person == 0}" class="badge badge-green">
-                ∞
+                {selected_phase.used_submissions_per_person} out of ∞
             </span>
         </div>
     </div>

--- a/src/static/riot/competitions/detail/submission_limit.tag
+++ b/src/static/riot/competitions/detail/submission_limit.tag
@@ -1,4 +1,5 @@
 <submission-limit>
+
     <div class="ui sixteen wide column submission-container">
         <div class="col">
             <div class="col-content">
@@ -7,19 +8,30 @@
                     <i class="grey question circle icon"></i>
                 </a>
             </div>
-            <span if="{selected_phase.max_submissions_per_day}" class="badge {badgeColor(selected_phase.used_submissions_per_day, selected_phase.max_submissions_per_day)}">
+            <!-- Badge for when there is a limit -->
+            <span if="{selected_phase.max_submissions_per_day > 0}" class="badge {badgeColor(selected_phase.used_submissions_per_day, selected_phase.max_submissions_per_day)}">
                 {selected_phase.used_submissions_per_day} out of {selected_phase.max_submissions_per_day}
+            </span>
+            <!-- Badge for when there is no limit -->
+            <span if="{selected_phase.max_submissions_per_day == 0}" class="badge badge-green">
+                ∞
             </span>
         </div>
         <div class="col">
             <div class="col-content">
                 Number of total submissions used
             </div>
-            <span if="{selected_phase.max_submissions_per_person}" class="badge {badgeColor(selected_phase.used_submissions_per_person, selected_phase.max_submissions_per_person)}">
+            <!-- Badge for when there is a limit -->
+            <span if="{selected_phase.max_submissions_per_person > 0}" class="badge {badgeColor(selected_phase.used_submissions_per_person, selected_phase.max_submissions_per_person)}">
                 {selected_phase.used_submissions_per_person} out of {selected_phase.max_submissions_per_person}
+            </span>
+            <!-- Badge for when there is no limit -->
+            <span if="{selected_phase.max_submissions_per_person == 0}" class="badge badge-green">
+                ∞
             </span>
         </div>
     </div>
+
     <script>
         var self = this;
         self.selected_phase = {}


### PR DESCRIPTION
When there is a limit:
<img width="1062" alt="Capture d’écran 2024-06-25 à 17 47 07" src="https://github.com/codalab/codabench/assets/11784999/89e67a66-dddf-4ade-ba48-c3ec442aa54a">

When there is **no** limit:

<img width="1198" alt="Capture d’écran 2024-06-25 à 17 52 29" src="https://github.com/codalab/codabench/assets/11784999/ef024d75-3197-4a23-bafc-d10ab69ce8bf">


# Issues this PR resolves
- #1501


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

