### PR TITLE
Fix celery_config.py

### DIFF
--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -33,6 +33,6 @@ def app_for_vhost(vhost):
         django_settings = copy.copy(settings)
         django_settings.CELERY_BROKER_URL = broker_url
         vhost_app.config_from_object(django_settings, namespace='CELERY')
-        vhost_app.task_queues = app.conf.task_queues
+        vhost_app.conf.task_queues = app.conf.task_queues
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]


### PR DESCRIPTION
Fix `celery_config.py` to avoid losing the queue configuration when cancelling a submission (patch from #1352).

# Issues this PR resolves
- #1473



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

