### PR TITLE
Leaderboard ordering - Use value of primary_col instead of string literal

### DIFF
--- a/src/apps/api/serializers/leaderboards.py
+++ b/src/apps/api/serializers/leaderboards.py
@@ -152,7 +152,7 @@ class LeaderboardPhaseSerializer(serializers.ModelSerializer):
         # desc == -colname
         # asc == colname
         primary_col = instance.leaderboard.columns.get(index=instance.leaderboard.primary_index)
-        ordering = [f'{"-" if primary_col.sorting == "desc" else ""}primary_col']
+        ordering = [f'{"-" if primary_col.sorting == "desc" else ""}{primary_col.name}']
         submissions = Submission.objects.filter(
             phase=instance,
             has_children=False,


### PR DESCRIPTION
Tentative in solving the ordering problem. Could not check it manually for now.

# Issues this PR resolves
- #1171


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

