### PR TITLE
Autorun collectstatic when django container starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ server_config.yaml
 
 .DS_Store
 .DS_Store?
+
+caddy_config/
+caddy_data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   django:
     build: .
     # NOTE: We use watchmedo to reload gunicorn nicely, Uvicorn + Gunicorn reloads don't work well
-    command: bash -c "cd /app/src && watchmedo auto-restart -p '*.py' --recursive -- gunicorn asgi:application -w 2 -k uvicorn.workers.UvicornWorker -b :8000 -b :80 --capture-output --log-level debug"
+    command: bash -c "python manage.py collectstatic --noinput && cd /app/src &&  watchmedo auto-restart -p '*.py' --recursive -- gunicorn asgi:application -w 2 -k uvicorn.workers.UvicornWorker -b :8000 -b :80 --capture-output --log-level debug"
     environment:
       - DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
     env_file: .env


### PR DESCRIPTION

# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
django container command updated to run collectstatic when it starts. Added `caddy_data` and `caddy_config` to gitignore


# Issues this PR resolves
- #1478



# A checklist for hand testing
- [ ] delete `src/staticfiles` folder 
- [ ] run `docker-compose up -d`
- [ ] check that `src/staticfiles` folder is created
- [ ] check that CSS works when you access it from `localhost`


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

