### PR TITLE
show leaderboard and detailed result page to approved participants only

### DIFF
--- a/src/apps/api/tests/test_submissions.py
+++ b/src/apps/api/tests/test_submissions.py
@@ -251,7 +251,7 @@ class SubmissionAPITests(APITestCase):
         assert resp.status_code == 403
 
         # denied user cannot see submission detail result
-        self.client.force_login(self.pending_participant)
+        self.client.force_login(self.denied_participant)
         resp = self.client.get(url)
         assert resp.status_code == 403
 

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -325,14 +325,14 @@ class SubmissionViewSet(ModelViewSet):
         submission = Submission.objects.get(pk=pk)
         # Check if competition show visualization is true
         if submission.phase.competition.enable_detailed_results:
-            # get submission's competition participants
-            participants = submission.phase.competition.participants.all()
-            participant_usernames = [participant.user.username for participant in participants]
+            # get submission's competition approved participants
+            approved_participants = submission.phase.competition.participants.filter(status=CompetitionParticipant.APPROVED)
+            participant_usernames = [participant.user.username for participant in approved_participants]
 
             # check if in this competition
             # user is collaborator
             # or
-            # user is participant
+            # user is approved participant
             # or
             # user is creator
             # or

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -41,7 +41,24 @@
             
         </tr>
         </thead>
-        <tbody>
+        <!--  Show when particpant registration is pending  -->
+        <tbody if="{participant_status === 'pending'}">
+            <tr class="center aligned ui yellow message">
+                <td colspan="100%">
+                    <em>Your request to participate in this competition is waiting for an approval from the competition organizer.</em>
+                </td>
+            </tr>
+        </tbody>
+        <!--  Show when particpant registration is denied  -->
+        <tbody if="{participant_status === 'denied'}">
+            <tr class="center aligned ui red message">
+                <td colspan="100%">
+                    <em>Your request to participate in this competition is denied. Please contact the competition organizer for more details.</em>
+                </td>
+            </tr>
+        </tbody>
+        <!--  Show when particpant registration is approved  -->
+        <tbody if="{participant_status === 'approved'}">
         <tr if="{_.isEmpty(selected_leaderboard.submissions)}" class="center aligned">
             <td colspan="100%">
                 <em>No submissions have been added to this leaderboard yet!</em>
@@ -70,6 +87,7 @@
         </tr>
         </tbody>
     </table>
+
 
     <script>
         let self = this
@@ -201,6 +219,7 @@
 
         CODALAB.events.on('competition_loaded', (competition) => {
             self.competition_id = competition.id
+            self.participant_status = competition.participant_status
             self.opts.is_admin ? self.show_download = "visible": self.show_download = "hidden"
             self.enable_detailed_results = competition.enable_detailed_results
             self.show_detailed_results_in_leaderboard = competition.show_detailed_results_in_leaderboard

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -41,6 +41,14 @@
             
         </tr>
         </thead>
+        <!--  Show when particpant is not registered  -->
+        <tbody if="{participant_status === null}">
+            <tr class="center aligned ui yellow message">
+                <td colspan="100%">
+                    <em>You are not a participant of this competition. Please register in My Submissions tab to view the leaderboard.</em>
+                </td>
+            </tr>
+        </tbody>
         <!--  Show when particpant registration is pending  -->
         <tbody if="{participant_status === 'pending'}">
             <tr class="center aligned ui yellow message">


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Previously Pending and Denied participants were able to see leaderboard and then see detailed results page. 

NOW only approved participants can see leaderboard and detailed result

# Screenshots 
### Leaderboard:

approved participants will see
<img width="1262" alt="approved" src="https://github.com/user-attachments/assets/95873094-31d8-4239-91dd-967aa2b48d13">

pending participants will see
<img width="1244" alt="pending" src="https://github.com/user-attachments/assets/a79bbeeb-5dc5-456a-a0c4-570de2a2d906">


denied participants will see
<img width="1250" alt="denied" src="https://github.com/user-attachments/assets/bf8bdaad-c0b8-47b2-a963-cbf7e749dfec">


### Detailed result

approved participants will see
<img width="747" alt="approved_result" src="https://github.com/user-attachments/assets/8cb31a4f-76ae-41db-bc8f-eafe5f65abdd">


pending participants will see
<img width="1488" alt="Screenshot 2024-07-12 at 1 15 52 PM" src="https://github.com/user-attachments/assets/64a20b06-be1b-45af-a41c-f5368b2cbba4">


denied participants will see
<img width="1491" alt="Screenshot 2024-07-12 at 1 16 13 PM" src="https://github.com/user-attachments/assets/c181111f-3bd5-48c0-96e8-c29095491d22">





# Issues this PR resolves
- #1475 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

