### PR TITLE
leaderboard api 500 error resolved

### DIFF
--- a/src/apps/api/views/leaderboards.py
+++ b/src/apps/api/views/leaderboards.py
@@ -1,8 +1,7 @@
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 from rest_framework.status import HTTP_405_METHOD_NOT_ALLOWED
-from api.permissions import LeaderboardNotHidden, LeaderboardIsOrganizerOrCollaborator
+from api.permissions import LeaderboardNotHidden
 from api.serializers.leaderboards import LeaderboardEntriesSerializer
 from api.serializers.submissions import SubmissionScoreSerializer
 from leaderboards.models import Leaderboard, SubmissionScore

--- a/src/apps/api/views/leaderboards.py
+++ b/src/apps/api/views/leaderboards.py
@@ -1,6 +1,7 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
+from rest_framework.status import HTTP_405_METHOD_NOT_ALLOWED
 from api.permissions import LeaderboardNotHidden, LeaderboardIsOrganizerOrCollaborator
 from api.serializers.leaderboards import LeaderboardEntriesSerializer
 from api.serializers.submissions import SubmissionScoreSerializer
@@ -10,23 +11,31 @@ from leaderboards.models import Leaderboard, SubmissionScore
 class LeaderboardViewSet(ModelViewSet):
     queryset = Leaderboard.objects.all()
     serializer_class = LeaderboardEntriesSerializer
+    http_method_names = ['get']  # Only allow GET requests
 
-    # TODO: The retrieve and list actions are the only ones used, apparently. Delete other permission checks soon!
-    def get_permissions(self):
-        if self.action in ['update', 'partial_update', 'destroy']:
-            raise Exception('Unexpected code branch execution.')
-            self.permission_classes = [LeaderboardIsOrganizerOrCollaborator]
-        elif self.action in ['create']:
-            raise Exception('Unexpected code branch execution.')
-            self.permission_classes = [IsAuthenticated]
-        elif self.action in ['retrieve', 'list']:
-            self.permission_classes = [LeaderboardNotHidden]
+    def create(self, request, *args, **kwargs):
+        return Response({'detail': 'Method not allowed.'}, status=HTTP_405_METHOD_NOT_ALLOWED)
 
-        return [permission() for permission in self.permission_classes]
+    def update(self, request, *args, **kwargs):
+        return Response({'detail': 'Method not allowed.'}, status=HTTP_405_METHOD_NOT_ALLOWED)
+
+    def partial_update(self, request, *args, **kwargs):
+        return Response({'detail': 'Method not allowed.'}, status=HTTP_405_METHOD_NOT_ALLOWED)
+
+    def destroy(self, request, *args, **kwargs):
+        return Response({'detail': 'Method not allowed.'}, status=HTTP_405_METHOD_NOT_ALLOWED)
 
     def list(self, request, *args, **kwargs):
         # Return an empty list for the leaderboard-list endpoint
         return Response([])
+
+    def get_permissions(self):
+        if self.action in ['create', 'update', 'partial_update', 'destroy']:
+            return []  # No permissions, effectively disables the action
+        elif self.action in ['retrieve', 'list']:
+            self.permission_classes = [LeaderboardNotHidden]
+
+        return [permission() for permission in self.permission_classes]
 
 
 class SubmissionScoreViewSet(ModelViewSet):


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- Leaderboard API was giving `500` error. This is now resolved.
- Unused permissions removed
- raised errors removed
- allowed only GET method
- added error messages for unused methods




# Issues this PR resolves
- #1362



# A checklist for hand testing
- [x] test that you don't get any error when accessing `localhost/api/leaderboards/`



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

