### PR TITLE
show `in-use` for starting kit and public data

### DIFF
--- a/src/apps/datasets/models.py
+++ b/src/apps/datasets/models.py
@@ -102,7 +102,9 @@ class Data(ChaHubSaveMixin, models.Model):
             Q(phases__tasks__ingestion_program=self) |
             Q(phases__tasks__input_data=self) |
             Q(phases__tasks__reference_data=self) |
-            Q(phases__tasks__scoring_program=self)
+            Q(phases__tasks__scoring_program=self) |
+            Q(phases__starting_kit=self) |
+            Q(phases__public_data=self)
         ).values('pk', 'title').distinct()
         return competitions_in_use
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Now users can see `In Use` for starting kit and public data if they are used in a competition
<img width="1155" alt="Screenshot 2024-07-16 at 12 13 17 PM" src="https://github.com/user-attachments/assets/2fadf2bc-f06e-4e61-a3fb-ed44546c628c">



# Issues this PR resolves
- #1476



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

