### PR TITLE
Competition console prints removed

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -33,7 +33,7 @@
                                  data-tab="_tab_page_term">
                                 Terms
                             </div>
-                            <div  if={competition.files.length != 0} class="{active: _.get(competition.pages, 'length') === 0} item" data-tab="files">
+                            <div  if={competition.files && competition.files.length != 0} class="{active: _.get(competition.pages, 'length') === 0} item" data-tab="files">
                                 Files
                             </div>
                         </div>

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -675,7 +675,6 @@
          Events
         ---------------------------------------------------------------------*/
         CODALAB.events.on('competition_loaded', function (competition) {
-            debugger
             self.phases = competition.phases
             self.form_updated()
         })

--- a/src/static/riot/profiles/organization_create.tag
+++ b/src/static/riot/profiles/organization_create.tag
@@ -148,7 +148,6 @@
                         .done(data => {
                             toastr.success("Organization Created")
                             window.location.href = data.url
-                            console.log(data)
                         })
                         .fail(data => {
                             let errorsJSON = data.responseJSON

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -109,7 +109,6 @@
                 } else {
                     url.searchParams.delete('show_child_submissions');
                 }
-                console.log(url)
                 window.location.href = url.toString();
             });
         });


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- Due to an error in `competition.files.length` the whole competition was printed in the console. Now that is fixed.
- Other console prints removed


# Issues this PR resolves
- #1474 -> Fix competition printing in console



# A checklist for hand testing
- [x] check that when you load competition detail page you don't see competition details in the console 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

