### PR TITLE
WIP Downloading submissions v1

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -15,6 +15,7 @@ from rest_framework.settings import api_settings
 from rest_framework.viewsets import ModelViewSet
 from rest_framework_csv import renderers
 from django.core.files.base import ContentFile
+from django.http import StreamingHttpResponse
 
 from profiles.models import Organization, Membership
 from tasks.models import Task
@@ -22,6 +23,7 @@ from api.serializers.submissions import SubmissionCreationSerializer, Submission
 from competitions.models import Submission, SubmissionDetails, Phase, CompetitionParticipant
 from leaderboards.strategies import put_on_leaderboard_by_submission_rule
 from leaderboards.models import SubmissionScore, Column, Leaderboard
+
 
 logger = logging.getLogger()
 
@@ -309,6 +311,27 @@ class SubmissionViewSet(ModelViewSet):
         for submission in qs:
             submission.re_run()
         return Response({})
+
+
+    # # New methods impleted !! 
+    @action(detail=False, methods=['get'])
+    def download_many(self, request):
+        pks = request.query_params.get('pks')
+        if pks:
+            pks = json.loads(pks)  # Convert JSON string to list
+
+        # Doing a local import here to avoid circular imports
+        from competitions.tasks import stream_batch_download
+
+        # Call the task and get the result (stream)
+        # in_memory_zip = stream_batch_download.apply_async((pks,)).get()
+        in_memory_zip = stream_batch_download(pks)
+
+        # Stream the response
+        response = StreamingHttpResponse(in_memory_zip, content_type='application/zip')
+        response['Content-Disposition'] = 'attachment; filename="bulk_submissions.zip"'
+
+        return response
 
     @action(detail=True, methods=('GET',))
     def get_details(self, request, pk):

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -20,6 +20,10 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 from rest_framework.exceptions import ValidationError
 
+from urllib.request import urlopen
+from contextlib import closing
+from urllib.error import ContentTooShortError
+
 from celery_config import app
 from competitions.models import Submission, CompetitionCreationTaskStatus, SubmissionDetails, Competition, \
     CompetitionDump, Phase
@@ -261,6 +265,55 @@ def send_child_id(submission, child_id):
         "kind": "child_update",
         "child_id": child_id
     })
+
+
+def retrieve_data(url,data=None):
+    with closing(urlopen(url, data)) as fp:
+        headers = fp.info()
+
+        bs = 1024*8
+        size = -1
+        read = 0
+        blocknum = 0
+        if "content-length" in headers:
+            size = int(headers["Content-Length"])
+
+        while True:
+            block = fp.read(bs)
+            if not block:
+                break
+            read += len(block)
+            yield(block)
+
+    if size >= 0 and read < size:
+        raise ContentTooShortError(
+            "retrieval incomplete: got only %i out of %i bytes"
+            % (read, size))
+
+
+def zip_generator(submission_pks):
+    in_memory_zip = BytesIO()
+    # logger.info("IN zip generator")
+    with zipfile.ZipFile(in_memory_zip, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+        for submission_id in submission_pks:
+            submission = Submission.objects.get(id=submission_id)
+            # logger.info(submission.data.data_file)
+
+            short_name = submission.data.data_file.name.split('/')[-1]
+            url = make_url_sassy(path=submission.data.data_file.name)
+            for block in retrieve_data(url):
+                zip_file.writestr(short_name, block)
+
+    in_memory_zip.seek(0)
+
+    return in_memory_zip
+
+
+@app.task(queue='site-worker', soft_time_limit=60*60)
+def stream_batch_download(submission_pks):
+    # logger.info("In stream_batch_download")
+    # logger.info(submission_pks)
+    return zip_generator(submission_pks)
 
 
 @app.task(queue='site-worker', soft_time_limit=60)

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -124,6 +124,31 @@ CODALAB.api = {
     get_submission_detail_result: function (id) {
         return CODALAB.api.request('GET', `${URLS.API}submissions/${id}/get_detail_result/`)
     },
+    download_many_submissions: function (pks) {
+        console.log('Request bulk');
+        const params = new URLSearchParams({ pks: JSON.stringify(pks) });
+        const url = `${URLS.API}submissions/download_many/?${params}`;
+        return fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }).then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok ' + response.statusText);
+            }
+            return response.blob();
+        }).then(blob => {
+            const link = document.createElement('a');
+            link.href = window.URL.createObjectURL(blob);
+            link.download = 'bulk_submissions.zip';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }).catch(error => {
+            console.error('Error downloading submissions:', error);
+        });
+    },
 
     /*---------------------------------------------------------------------
          Leaderboards


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# Issue resolved

- #1232


# Description
The aim of this PR is to add the feature of downloading all or several submissions at once. 
This bulk downloading is only accessible for a challenge administrator and is accessible through the submissions manager. 

![image](https://github.com/user-attachments/assets/377abc07-b775-4a74-9ef8-81d43aa1ce48)

![image](https://github.com/user-attachments/assets/02e6eac8-918a-4381-84f2-ac2aec97c846)

 
The user interface view could be improved by placing the  drop down menu and apply button on the far right. 

 This implementation can(/should?)  be improved by moving the zip_generator task computation from the django thread to a site-worker by un-commenting `# in_memory_zip = stream_batch_download.apply_async((pks,)).get()` and commenting `in_memory_zip = stream_batch_download(pks)` in the file `submissions.py` line 327.

However, generating zip in a stream by a site-worker is not functional because Celery back end is not configured to return something. This is a part where I would need help if this implementation is mandatory. 
Also, is there a good way to benchmark the cost of this feature on the Django thread? It should not block the responsiveness of Codabench.  

The global implementation follows this path : 
![bulk_download_codabench drawio](https://github.com/user-attachments/assets/c8b82070-df6f-4b99-98b5-b13224957d04)


# A checklist for hand testing
- [ ] Download all / selected submissions
- [ ] Delete selected submissions
- [ ] Re-run selected submissions

# Checklist
- [X] Code review by me 
- [X] Hand tested by me 
- [X] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

