### PR TITLE
Changed submission name to add ID when downloading many submissions

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -312,18 +312,18 @@ class SubmissionViewSet(ModelViewSet):
             submission.re_run()
         return Response({})
 
-    # New methods impleted!
     @action(detail=False, methods=['get'])
     def download_many(self, request):
         pks = request.query_params.get('pks')
         if pks:
             pks = json.loads(pks)  # Convert JSON string to list
+
         # Doing a local import here to avoid circular imports
         from competitions.tasks import stream_batch_download
-        # Call the task and get the result (stream)
+
         # in_memory_zip = stream_batch_download.apply_async((pks,)).get()
         in_memory_zip = stream_batch_download(pks)
-        # Stream the response
+
         response = StreamingHttpResponse(in_memory_zip, content_type='application/zip')
         response['Content-Disposition'] = 'attachment; filename="bulk_submissions.zip"'
         return response

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -292,13 +292,10 @@ def retrieve_data(url, data=None):
 
 def zip_generator(submission_pks):
     in_memory_zip = BytesIO()
-    # logger.info("IN zip generator")
     with zipfile.ZipFile(in_memory_zip, 'w', zipfile.ZIP_DEFLATED) as zip_file:
         for submission_id in submission_pks:
             submission = Submission.objects.get(id=submission_id)
-            # logger.info(submission.data.data_file)
-
-            short_name = submission.data.data_file.name.split('/')[-1]
+            short_name = "ID_" + str(submission_id)+ '_' + submission.data.data_file.name.split('/')[-1]
             url = make_url_sassy(path=submission.data.data_file.name)
             for block in retrieve_data(url):
                 zip_file.writestr(short_name, block)
@@ -310,8 +307,6 @@ def zip_generator(submission_pks):
 
 @app.task(queue='site-worker', soft_time_limit=60 * 60)
 def stream_batch_download(submission_pks):
-    # logger.info("In stream_batch_download")
-    # logger.info(submission_pks)
     return zip_generator(submission_pks)
 
 


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
This PR should solve the naming issue (#1548 ) by adding the ID to submission names like this : 
```ID_82_program_2024_07_26_11_17_05.zip```

Cleaned the code, by removing some comments. 

# A checklist for hand testing
- [x] Download selected submissions 


# Any relevant files for testing

# Checklist
- [X] Code review by me 
- [X] Hand tested by me 
- [X] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge

