### PR TITLE
Server Status:  submissions limit removed

### DIFF
--- a/src/apps/pages/urls.py
+++ b/src/apps/pages/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('search', views.SearchView.as_view(), name="search"),
     path('organize', views.OrganizeView.as_view(), name="organize"),
     path('server_status', views.ServerStatusView.as_view(), name="server_status"),
+    path('monitor_queues', views.MonitorQueuesView.as_view(), name="monitor_queues"),
     # path('test', views.CompetitionListTestView.as_view()),
 ]

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -1,5 +1,4 @@
-from datetime import timedelta
-from django.utils.timezone import now
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.views.generic import TemplateView
 from django.db.models import Count, Q
 
@@ -55,6 +54,8 @@ class ServerStatusView(TemplateView):
     def get_context_data(self, *args, **kwargs):
 
         show_child_submissions = self.request.GET.get('show_child_submissions', False)
+        page = self.request.GET.get('page', 1)
+        submissions_per_page = 50
 
         # Get all submissions
         qs = Submission.objects.all()
@@ -73,9 +74,6 @@ class ServerStatusView(TemplateView):
         else:
             qs = qs.none()  # This returns an empty queryset
 
-        # Filter for fetching last 2 days submissions
-        qs = qs.filter(created_when__gte=now() - timedelta(days=2))
-
         # Filter out child submissions i.e. submission has no parent
         if not show_child_submissions:
             qs = qs.filter(parent__isnull=True)
@@ -83,8 +81,20 @@ class ServerStatusView(TemplateView):
         qs = qs.order_by('-created_when')
         qs = qs.select_related('phase__competition', 'owner')
 
+        # Paginate the queryset
+        paginator = Paginator(qs, submissions_per_page)
+
+        try:
+            submissions = paginator.page(page)
+        except PageNotAnInteger:
+            # If page is not an integer, deliver the first page.
+            submissions = paginator.page(1)
+        except EmptyPage:
+            # If page is out of range, deliver last page of results.
+            submissions = paginator.page(paginator.num_pages)
+
         context = super().get_context_data(*args, **kwargs)
-        context['submissions'] = qs[:250]
+        context['submissions'] = submissions
         context['show_child_submissions'] = show_child_submissions
 
         for submission in context['submissions']:
@@ -102,6 +112,9 @@ class ServerStatusView(TemplateView):
 
             # Add submission owner display name
             submission.owner_display_name = submission.owner.display_name if submission.owner.display_name else submission.owner.username
+
+        context['paginator'] = paginator
+        context['is_paginated'] = paginator.num_pages > 1
 
         return context
 
@@ -121,6 +134,10 @@ class ServerStatusView(TemplateView):
             i += 1
 
         return f"{n:.1f} {units[i]}"
+
+
+class MonitorQueuesView(TemplateView):
+    template_name = 'pages/monitor_queues.html'
 
 
 def page_not_found_view(request, exception):

--- a/src/static/stylus/index.styl
+++ b/src/static/stylus/index.styl
@@ -7,4 +7,5 @@
 @import "src/static/stylus/simple_page.styl"
 @import "src/static/stylus/toastr.styl"
 @import "src/static/stylus/forum.styl"
+@import "src/static/stylus/server_status.styl"
 

--- a/src/static/stylus/server_status.styl
+++ b/src/static/stylus/server_status.styl
@@ -1,0 +1,19 @@
+.pagination-nav
+    padding 10px 0
+    width 100%
+    margin-bottom 20px
+    display flex
+    justify-content center
+    align-items center
+    position relative
+
+.float-left
+    position absolute
+    left 0
+
+.float-right
+    position absolute
+    right 0
+
+.center
+    text-align center

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -128,6 +128,7 @@
 {#                                    <a class="item" href="#">Customize Codalab</a>#}
                                     <a class="item" href="{% url "pages:server_status" %}">Server Status</a>
                                 {% if request.user.is_staff %}
+                                    <a class="item" href="{% url "pages:monitor_queues" %}">Monitor Queues</a>
                                     <a class="item" href="{% url "admin:index" %}">Django Admin</a>
                                     <a class="item" href="{% url "su_login" %}">Change User</a>
                                     <a class="item" href="{% url "analytics:analytics" %}">Analytics</a>

--- a/src/templates/pages/monitor_queues.html
+++ b/src/templates/pages/monitor_queues.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block content %}
+    <div class="ui container">
+        <h1>Monitor queues</h1>
+        <div id="external_monitors" class="ui two column grid">
+            <div class="column">
+                <div class="ui fluid card">
+                    <a class="image" href="{{ RABBITMQ_MANAGEMENT_URL}}" target="_blank">
+                        <img class="ui large image" src="/static/img/RabbitMQ.png">
+                    </a>
+                    <div class="content">
+                        <a class="header" href="{{ RABBITMQ_MANAGEMENT_URL }}" target="_blank">RabbitMQ</a>
+                        <div class="meta">
+                            This page allows admins to view connections, queued messages, message rates, channels,
+                            exchanges, and other administrative features relating to RabbitMQ e.g. Creating users,
+                            adding v-hosts, and creating policies.
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="ui fluid card">
+                    <a class="image" href="{{ FLOWER_URL }}" target="_blank">
+                        <img class="ui large image" src="/static/img/Flower.png">
+                    </a>
+                    <div class="content">
+                        <a class="header" href="{{ FLOWER_URL }}" target="_blank">Flower</a>
+                        <div class="meta">
+                            Flower is a powerful web-based Celery monitoring tool designed to keep track of our
+                            tasks.
+                            Admins may view the state of which tasks were run, with what arguments, and many more
+                            features. Here you may also view which queues your celery workers are consuming, and the
+                            state of any tasks in them. At last, there is also a great monitoring page for viewing
+                            the
+                            systemic impact of your workers.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+{% endblock %}

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="ui container">
-        <h1>Recent submissions (up to 250 or 2 days old)</h1>
+        <h1>Server Status</h1>
         <label>
             <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show child submissions
         </label>
@@ -55,48 +55,31 @@
             </tbody>
         </table>
 
+        <!-- Pagination Div -->
+        {% if is_paginated %}
+        <div class="pagination-nav">
+            {% if submissions.has_previous %}
+            <span class="float-left">
+                <a class="ui button" href="?page=1{% if show_child_submissions %}&show_child_submissions={{ show_child_submissions }}{% endif %}">First</a>
+                <a class="ui button" href="?page={{ submissions.previous_page_number }}{% if show_child_submissions %}&show_child_submissions={{ show_child_submissions }}{% endif %}">Previous</a>
+            </span>
+            {% endif %}
+            
+            <span class="center">
+                Page {{ submissions.number }} of {{ paginator.num_pages }}
+            </span>
+            
+            
+            {% if submissions.has_next %}
+            <span class="float-right">
+                <a class="ui button" href="?page={{ submissions.next_page_number }}{% if show_child_submissions %}&show_child_submissions={{ show_child_submissions }}{% endif %}">Next</a>
+            <a class="ui button" href="?page={{ paginator.num_pages }}{% if show_child_submissions %}&show_child_submissions={{ show_child_submissions }}{% endif %}">Last</a>
+            </span>
+            {% endif %}
 
-        {% if user.is_superuser %}
-        <h1>Monitor queues</h1>
-        <div id="external_monitors" class="ui two column grid">
-            <div class="column">
-                <div class="ui fluid card">
-                    <a class="image" href="{{ RABBITMQ_MANAGEMENT_URL}}" target="_blank">
-                        <img class="ui large image" src="/static/img/RabbitMQ.png">
-                    </a>
-                    <div class="content">
-                        <a class="header" href="{{ RABBITMQ_MANAGEMENT_URL }}" target="_blank">RabbitMQ</a>
-                        <div class="meta">
-                            This page allows admins to view connections, queued messages, message rates, channels,
-                            exchanges, and other administrative features relating to RabbitMQ e.g. Creating users,
-                            adding v-hosts, and creating policies.
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="column">
-                <div class="ui fluid card">
-                    <a class="image" href="{{ FLOWER_URL }}" target="_blank">
-                        <img class="ui large image" src="/static/img/Flower.png">
-                    </a>
-                    <div class="content">
-                        <a class="header" href="{{ FLOWER_URL }}" target="_blank">Flower</a>
-                        <div class="meta">
-                            Flower is a powerful web-based Celery monitoring tool designed to keep track of our
-                            tasks.
-                            Admins may view the state of which tasks were run, with what arguments, and many more
-                            features. Here you may also view which queues your celery workers are consuming, and the
-                            state of any tasks in them. At last, there is also a great monitoring page for viewing
-                            the
-                            systemic impact of your workers.
-                        </div>
-                    </div>
-                </div>
-            </div>
         </div>
         {% endif %}
     </div>
-
     <script>
         document.addEventListener("DOMContentLoaded", function() {
             const checkbox = document.getElementById("show_child_checkbox");

--- a/src/templates/pages/server_status.html
+++ b/src/templates/pages/server_status.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="ui container">
-        <h1>Server Status</h1>
+        <h1>Recent Submissions</h1>
         <label>
             <input type="checkbox" id="show_child_checkbox" {% if show_child_submissions %}checked{% endif %}> Show child submissions
         </label>


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- Server status page: submissions limit (250 or 2 days old) removed
- Paginations added to handle many submissions (50/page)
- Monitor queues moved to a separate page (http://localhost/monitor_queues)
- Monitor queues page link added to menu


# Screenshots

### Server status first page
<img width="1164" alt="Screenshot 2024-08-13 at 3 10 47 PM" src="https://github.com/user-attachments/assets/e24df465-5047-4a4c-8e70-866496170a40">

### Server status middle page
<img width="1186" alt="Screenshot 2024-08-13 at 3 10 52 PM" src="https://github.com/user-attachments/assets/c9559af6-a347-4539-bcb9-98e3d40caedf">

### Server status last page
<img width="1197" alt="Screenshot 2024-08-13 at 3 10 58 PM" src="https://github.com/user-attachments/assets/97ede189-e888-4234-9b56-b93eb24e8eb6">

### Server status single page where no pagination is needed (submissions count < 50)
<img width="1177" alt="Screenshot 2024-08-13 at 3 11 24 PM" src="https://github.com/user-attachments/assets/8878b0ad-0242-4d85-aa56-18cf71195564">

### Monitors queue new page
<img width="1492" alt="Screenshot 2024-08-13 at 3 18 10 PM" src="https://github.com/user-attachments/assets/fdd62946-fb5b-468b-ab76-f2c651b85add">

### Monitor queues in the menu
<img width="310" alt="Screenshot 2024-08-13 at 3 18 33 PM" src="https://github.com/user-attachments/assets/3739c3a9-a6ee-4783-9d8e-06d693bfa18e">




# Issues this PR resolves
- #1549



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

