### PR TITLE
[Feature] Delete orphan files

### DIFF
--- a/src/apps/analytics/tasks.py
+++ b/src/apps/analytics/tasks.py
@@ -475,7 +475,7 @@ def create_storage_analytics_snapshot():
 
     # Log the results
     log_file = (
-        "/app/logs/" +
+        "/app/var/logs/" +
         "db_storage_inconsistency_" +
         current_datetime.strftime("%Y%m%d-%H%M%S") +
         ".log"

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -67,6 +67,8 @@ urlpatterns = [
     path('analytics/storage_usage_history/', analytics.storage_usage_history, name='storage_usage_history'),
     path('analytics/competitions_usage/', analytics.competitions_usage, name='competitions_usage'),
     path('analytics/users_usage/', analytics.users_usage, name='users_usage'),
+    path('analytics/delete_orphan_files/', analytics.delete_orphan_files, name="delete_orphan_files"),
+    path('analytics/get_orphan_files/', analytics.get_orphan_files, name="get_orphan_files"),
 
     # API Docs
     re_path(r'docs(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),

--- a/src/apps/api/views/analytics.py
+++ b/src/apps/api/views/analytics.py
@@ -12,10 +12,13 @@ from rest_framework_csv import renderers as r
 from competitions.models import Competition, Submission
 from analytics.models import StorageUsageHistory, CompetitionStorageDataPoint, UserStorageDataPoint
 from api.serializers.analytics import AnalyticsSerializer
+from utils.storage import BundleStorage
 
+import os
 import datetime
 import coreapi
 import pytz
+import logging
 
 
 User = get_user_model()
@@ -286,3 +289,111 @@ def users_usage(request):
     }
 
     return Response(response, status=status.HTTP_200_OK)
+
+@api_view(["GET"])
+def get_orphan_files(request):
+    """
+    Get the orphan files based on the last storage analytics
+    """
+
+    if not request.user.is_superuser:
+        raise PermissionDenied(detail="Admin only")
+
+    logger = logging.getLogger(__name__)
+
+    # Find most recent file
+    most_recent_log_file = get_most_recent_storage_inconsistency_log_file()
+    if not most_recent_log_file:
+        logger.warning("No storage inconsistency log file found.")
+        return Response({"message": "No storage inconsistency log file found."}, status=status.HTTP_404_NOT_FOUND)
+    
+    # Get the list of orphan files from the content of the most recent log file
+    log_folder = "/app/logs/"
+    orphan_files_path = get_files_path_from_orphan_log_file(os.path.join(log_folder, most_recent_log_file))
+
+    return Response({"data": orphan_files_path}, status=status.HTTP_200_OK)
+
+@api_view(["DELETE"])
+def delete_orphan_files(request):
+    """
+    Delete all orphan files from the storage based on the last storage analytics
+    """
+
+    if not request.user.is_superuser:
+        raise PermissionDenied(detail="Admin only")
+
+    logger = logging.getLogger(__name__)
+    logger.info("Delete orphan files started")
+
+    # The analytics task generates a db_storage_inconsistency_<date>-<time>.log file that lists, among other things, the orphan files. Let's use it
+
+    # Find most recent file
+    most_recent_log_file = get_most_recent_storage_inconsistency_log_file()
+    if not most_recent_log_file:
+        logger.warning("No storage inconsistency log file found. Nothing will be removed")
+        return Response({"message": "No storage inconsistency log file found. Nothing will be removed"}, status=status.HTTP_404_NOT_FOUND)
+
+    # Get the list of orphan files from the content of the most recent log file
+    log_folder = "/app/logs/"
+    orphan_files_path = get_files_path_from_orphan_log_file(os.path.join(log_folder, most_recent_log_file))
+
+    # Delete those files in batch (max 1000 element at once)
+    batch_size = 1000
+    for i in range(0, len(orphan_files_path), batch_size):
+        batch = orphan_files_path[i:i + batch_size]
+        objects_formatted = [{'Key': path} for path in batch]
+        BundleStorage.bucket.delete_objects(Delete={'Objects': objects_formatted})
+
+    logger.info("Delete oprhan files finished")
+    return Response({"message": "done"}, status=status.HTTP_200_OK)
+
+def get_most_recent_storage_inconsistency_log_file():
+    logger = logging.getLogger(__name__)
+
+    log_folder = "/app/logs/"
+    try:
+        log_files = [f for f in os.listdir(log_folder) if os.path.isfile(os.path.join(log_folder, f))]
+    except FileNotFoundError:
+        logger.info(f"Folder '{log_folder}' does not exist.")
+        return None
+
+    most_recent_log_file = None
+    most_recent_datetime = None
+    datetime_format = "%Y%m%d-%H%M%S"
+    for file in log_files:
+        try:
+            basename = os.path.basename(file)
+            datetime_str = basename[len("db_storage_inconsistency_"):-len(".log")]
+            file_datetime = datetime.datetime.strptime(datetime_str, datetime_format)
+            if most_recent_datetime is None or file_datetime > most_recent_datetime:
+                most_recent_datetime = file_datetime
+                most_recent_log_file = file
+        except ValueError:
+            logger.warning(f"Filename '{file}' does not match the expected format and will be ignored.")
+
+    return most_recent_log_file
+
+def get_files_path_from_orphan_log_file(log_file_path):
+    logger = logging.getLogger(__name__)
+
+    files_path = []
+
+    try:
+        with open(log_file_path) as log_file:
+            lines = log_file.readlines()
+            orphan_files_lines = []
+            for i, line in enumerate(lines):
+                if "Orphaned files" in line:
+                    orphan_files_lines = lines[i + 1:]
+                    break
+
+            for orphan_files_line in orphan_files_lines:
+                files_path.append(orphan_files_line.split(maxsplit=1)[0])
+    except FileNotFoundError:
+        logger.error(f"File '{log_file_path}' does not exist.")
+    except PermissionError:
+        logger.error(f"Permission denied for reading the file '{log_file_path}'.")
+    except IOError as e:
+        logger.error(f"An I/O error occurred while accessing the file at {log_file_path}: {e}")
+    
+    return  files_path

--- a/src/apps/api/views/analytics.py
+++ b/src/apps/api/views/analytics.py
@@ -290,6 +290,7 @@ def users_usage(request):
 
     return Response(response, status=status.HTTP_200_OK)
 
+
 @api_view(["GET"])
 def get_orphan_files(request):
     """
@@ -306,12 +307,13 @@ def get_orphan_files(request):
     if not most_recent_log_file:
         logger.warning("No storage inconsistency log file found.")
         return Response({"message": "No storage inconsistency log file found."}, status=status.HTTP_404_NOT_FOUND)
-    
+
     # Get the list of orphan files from the content of the most recent log file
     log_folder = "/app/logs/"
     orphan_files_path = get_files_path_from_orphan_log_file(os.path.join(log_folder, most_recent_log_file))
 
     return Response({"data": orphan_files_path}, status=status.HTTP_200_OK)
+
 
 @api_view(["DELETE"])
 def delete_orphan_files(request):
@@ -347,6 +349,7 @@ def delete_orphan_files(request):
     logger.info("Delete oprhan files finished")
     return Response({"message": "done"}, status=status.HTTP_200_OK)
 
+
 def get_most_recent_storage_inconsistency_log_file():
     logger = logging.getLogger(__name__)
 
@@ -373,6 +376,7 @@ def get_most_recent_storage_inconsistency_log_file():
 
     return most_recent_log_file
 
+
 def get_files_path_from_orphan_log_file(log_file_path):
     logger = logging.getLogger(__name__)
 
@@ -395,5 +399,5 @@ def get_files_path_from_orphan_log_file(log_file_path):
         logger.error(f"Permission denied for reading the file '{log_file_path}'.")
     except IOError as e:
         logger.error(f"An I/O error occurred while accessing the file at {log_file_path}: {e}")
-    
-    return  files_path
+
+    return files_path

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -346,6 +346,12 @@ CODALAB.api = {
     get_users_usage: (filters) => {
         return CODALAB.api.request('GET', `${URLS.API}analytics/users_usage/`, filters);
     },
+    delete_orphan_files: () => {
+        return CODALAB.api.request('DELETE', `${URLS.API}analytics/delete_orphan_files/`)
+    },
+    get_orphan_files: () => {
+        return CODALAB.api.request('GET', `${URLS.API}analytics/get_orphan_files/`)
+    },
     /*---------------------------------------------------------------------
          User Quota and Cleanup
     ---------------------------------------------------------------------*/


### PR DESCRIPTION
# Original PR

- #1523

# Description

This adds a button in the storage view to trigger, after confirmation, the deletion of orphan files in the storage. The list of orphan files are not computed during the process since it is time expensive. Instead is uses the last storage analytics results and its storage_inconsistency log file.

To learn more about the storage analytics task: https://github.com/codalab/codabench/wiki/Administrator-procedures#storage-analytics

# Issues this PR resolves
Related to issue #713 

# To do once merged (manual intervention)
Copy and paste last storage_inconsistency files from /logs folder to /var/logs/ folder. Mind the 's' at the end of 'logs'.

```
cd codabench
cp -r logs/* var/logs
```

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

