### PR TITLE
`Release PR#1` - Display release version in Codabench footer

### DIFF
--- a/src/static/stylus/base_template.styl
+++ b/src/static/stylus/base_template.styl
@@ -31,22 +31,8 @@ html
     background rgba(19, 48, 70, 0.9)
 
 #jumbo_logo
-    margin-top 40px
+    margin-top 20px
     width 35%
-
-#version
-    background-color #F0F0F0
-    color #2C3E4C
-    padding 5px
-    font-family monospace
-    border-radius 5px
-    font-size 12px
-    font-weight bold
-    display block
-    width 80px
-    margin 0 auto
-    margin-top 5px
-    margin-bottom 20px
 
 .organization-logos
     position absolute
@@ -273,3 +259,16 @@ body.pushable>.pusher
     .modal
         max-height 90vh
         overflow-y scroll
+
+#version
+    margin-top 10px
+    text-align center
+    font-family monospace
+    font-size 12px
+    font-weight bold
+    padding 5px
+    color #8b8d8d
+
+#version a 
+    text-decoration none
+    color inherit

--- a/src/static/stylus/base_template.styl
+++ b/src/static/stylus/base_template.styl
@@ -31,8 +31,22 @@ html
     background rgba(19, 48, 70, 0.9)
 
 #jumbo_logo
-    margin-top 20px
+    margin-top 40px
     width 35%
+
+#version
+    background-color #F0F0F0
+    color #2C3E4C
+    padding 5px
+    font-family monospace
+    border-radius 5px
+    font-size 12px
+    font-weight bold
+    display block
+    width 80px
+    margin 0 auto
+    margin-top 5px
+    margin-bottom 20px
 
 .organization-logos
     position absolute

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -227,7 +227,7 @@
             </div>
         </div>
     </div>
-    <div id="version"><a href="https://github.com/codalab/codabench/releases/tag/v1.1.0" target="_blank">V 1.1.0</a></div>
+    <div id="version"><a href="https://github.com/codalab/codabench/releases/tag/v1.1.0" target="_blank">v1.1.0</a></div>
 </div>
     {# Admin only user switching #}
     <user_switch></user_switch>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -227,7 +227,8 @@
             </div>
         </div>
     </div>
-
+    <div id="version"><a href="https://github.com/codalab/codabench/releases/tag/v1.1.0" target="_blank">V 1.1.0</a></div>
+</div>
     {# Admin only user switching #}
     <user_switch></user_switch>
 

--- a/src/templates/pages/home.html
+++ b/src/templates/pages/home.html
@@ -9,7 +9,6 @@
 
     <div id="logo_div" class="ui text container">
         <img id="jumbo_logo" src="{% static 'img/codabench.png' %}">
-        <div id="version">v 1.1.0</div>
         <div class="organization-logos">
             <!-- LISN logo -->
             <a href="https://www.lisn.upsaclay.fr/" target="_blank">

--- a/src/templates/pages/home.html
+++ b/src/templates/pages/home.html
@@ -7,8 +7,9 @@
 
 {% block top_div_extra_content %}
 
-    <div class="ui text container">
+    <div id="logo_div" class="ui text container">
         <img id="jumbo_logo" src="{% static 'img/codabench.png' %}">
+        <div id="version">v 1.1.0</div>
         <div class="organization-logos">
             <!-- LISN logo -->
             <a href="https://www.lisn.upsaclay.fr/" target="_blank">


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo


# A brief description of the purpose of the changes contained in this PR.
Now we can display release version in the header just below the main logo
<img width="1496" alt="Screenshot 2024-09-14 at 11 20 35 PM" src="https://github.com/user-attachments/assets/cd3c267e-6b29-4bb9-87a4-b7a84c974ac9">



# Issues this PR resolves
- #1582 -> Point 1, 2



# A checklist for hand testing
- [ ] collectstatic and check that the current version is displayed correctly




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

