### PR TITLE
Fix string concat in case of no email in analytics api

### DIFF
--- a/src/apps/api/views/analytics.py
+++ b/src/apps/api/views/analytics.py
@@ -231,10 +231,12 @@ def competitions_usage(request):
             'datefield'
         )
         for su in query.order_by("-datefield", "competition__id"):
+            username = su['competition__created_by__username'] or ("user #" + su['competition__created_by__id']) or "unknown user"
+            email = su['competition__created_by__email'] or "no email"
             competitions_usage.setdefault(su['datefield'].isoformat(), {})[su['competition__id']] = {
                 'snapshot_id': su['id'],
                 'title': su['competition__title'],
-                'organizer': su['competition__created_by__username'] + " (" + su['competition__created_by__email'] + ")",
+                'organizer': username + " (" + email + ")",
                 'created_when': su['competition__created_when'],
                 'datasets': su['datasets_total'],
             }
@@ -275,9 +277,11 @@ def users_usage(request):
             'datefield'
         )
         for su in query.order_by("-datefield", "user__id"):
+            username = su['user__username'] or ("user #" + su['user__id']) or "unknown user"
+            email = su['user__email'] or "no email"
             users_usage.setdefault(su['datefield'].isoformat(), {})[su['user__id']] = {
                 'snapshot_id': su['id'],
-                'name': su['user__username'] + " (" + su['user__email'] + ")",
+                'name': username + " (" + email + ")",
                 'date_joined': su['user__date_joined'],
                 'datasets': su['datasets_total'],
                 'submissions': su['submissions_total'],


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Fixes the bug where the analytics API calls for displaying Competitions and Users usage crashes due to nonexistent email linked to any user.

The solution adds a default string value in such case, None and str concatenation (which does not exist)


# Issues this PR resolves
#1577 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Ready to merge

