### PR TITLE
Resource interface: bundles renamed to competition bundles, swapped postions of bundles and tasks

### DIFF
--- a/src/static/riot/management.tag
+++ b/src/static/riot/management.tag
@@ -4,8 +4,8 @@
     <div class="ui top attached tabular menu">
         <div class="active item" data-tab="submissions">Submissions</div>
         <div class="item" data-tab="datasets">Datasets and programs</div>
-        <div class="item" data-tab="bundles">Bundles</div>
         <div class="item" data-tab="tasks">Tasks</div>
+        <div class="item" data-tab="bundles">Competition Bundles</div>
         <div class="right menu">
             <div class="item">
                 <help_button href="https://github.com/codalab/competitions-v2/wiki/Task-&-Dataset-Management"
@@ -20,11 +20,11 @@
     <div class="ui bottom attached tab segment" data-tab="datasets">
         <data-management></data-management>
     </div>
-    <div class="ui bottom attached tab segment" data-tab="bundles">
-        <bundle-management></bundle-management>
-    </div>
     <div class="ui bottom attached tab segment" data-tab="tasks">
         <task-management></task-management>
+    </div>
+    <div class="ui bottom attached tab segment" data-tab="bundles">
+        <bundle-management></bundle-management>
     </div>
 
     <script>


### PR DESCRIPTION

# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- Put Tasks tab before bundles
- rename Bundles to Competition Bundles

<img width="1204" alt="Screenshot 2024-09-20 at 10 35 18 AM" src="https://github.com/user-attachments/assets/bbcfed06-b0a9-4a74-a3f5-e5c436796e09">


# Issues this PR resolves
- #1590



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

