### PR TITLE
Use competition queue in submission queue on rerun

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -645,6 +645,7 @@ class Submission(ChaHubSaveMixin, models.Model):
             'has_children': self.has_children,
             'is_specific_task_re_run': is_specific_task_re_run,
             'fact_sheet_answers': self.fact_sheet_answers,
+            'queue': self.phase.competition.queue
         }
         sub = Submission(**submission_arg_dict)
         sub.save(ignore_submission_limit=True)


### PR DESCRIPTION
# @ mention of reviewers
@ObadaS 


# A brief description of the purpose of the changes contained in this PR.
Now when you rerun a submission, it will show the correct queue in the server status page


# Issues this PR resolves
- #1595



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

