### PR TITLE
Submission file name too long

### DIFF
--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -476,19 +476,29 @@
                 .fail(function (response) {
                     if (response) {
                         try {
-                            let errors = JSON.parse(response.responseText);
+                            let errors = JSON.parse(response.responseText)
 
                             // Clean up errors to not be arrays but plain text
                             Object.keys(errors).map(function (key, index) {
                                 errors[key] = errors[key].join('; ')
                             })
 
-                            self.update({errors: errors})
-                        } catch (e) {
+                            // Create a string to concatenate all error messages
+                            let errorMessages = "Error in submission upload:\n"
+                            Object.keys(errors).forEach(function (key) {
+                                errorMessages += key + ": " + errors[key] + "\n"
+                            })
 
+                            toastr.error(errorMessages)
+                            self.update({errors: errors})
+
+                        } catch (e) {
+                            toastr.error("Error in submission upload\n"+e)
                         }
+                    } else {
+                        toastr.error("Something went wrong, please try again later")
                     }
-                    toastr.error(`Creation failed, error occurred: ${response.responseJSON.data_file[0]}`)
+                    
                 })
                 .always(function () {
                     setTimeout(self.hide_progress_bar, 500)


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Uploading a submission with a long name was freezing the upload screen. Now that is fixed along with proper error handling.

You will see this error if you upload a file with a long name
<img width="411" alt="Screenshot 2024-10-12 at 10 41 25 PM" src="https://github.com/user-attachments/assets/72a5fd74-b83e-4b83-ae8b-68319eeb8426">



# Issues this PR resolves
- #1444 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

