### PR TITLE
Current phase ends never - handled

### DIFF
--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -45,7 +45,7 @@
                                 <span if="{competition.contact_email}">(<span class="contact-email">{competition.contact_email}</span>)</span>
                             </div>
                             <div>
-                                <span class="detail-label">Current phase ends:</span>
+                                <span class="detail-label">{has_current_phase(competition) ? 'Current Phase Ends' : 'Current Active Phase'}:</span>
                                 <span class="detail-item">{get_end_date(competition)}</span>
                             </div>
                             <div>
@@ -274,9 +274,19 @@
             $('.send-pop-report').popup('toggle')
         }
 
+        self.has_current_phase = function (competition) {
+            let current_phase = _.find(competition.phases, {status: 'Current'})
+            return current_phase ? true : false
+        }
+
         self.get_end_date = function (competition) {
-            let end_date = _.get(_.find(competition.phases, {status: 'Current'}), 'end')
-            return end_date ? pretty_date(end_date) : 'Never'
+            if(self.has_current_phase(competition)){
+                let end_date = _.get(_.find(competition.phases, {status: 'Current'}), 'end')
+                return end_date ? pretty_date(end_date) : 'Never'
+            }else{
+                return 'None'
+            }
+            
         }
 
         self.migrate_phase = function (phase_id) {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
If there is current phase, user will see its end date or `Never` if there is no end date
<img width="817" alt="Screenshot 2024-10-14 at 1 22 08 PM" src="https://github.com/user-attachments/assets/f42505f0-e7fb-40e7-a761-582bd73fb7b8">


If there is no current phase, user will see `Current Active Phase: None`
<img width="807" alt="Screenshot 2024-10-14 at 1 21 44 PM" src="https://github.com/user-attachments/assets/9feb133b-0df7-43e9-b51d-7039f552c981">

# Issues this PR resolves
- #1617


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

