### PR TITLE
URGENT - Optimize Home page: Featured and popular comps and counters made static

### DIFF
--- a/src/apps/competitions/utils.py
+++ b/src/apps/competitions/utils.py
@@ -1,9 +1,8 @@
 '''
 This file contains utilities for competitions
 '''
-import random
-
-from django.db.models import Count
+# import random
+# from django.db.models import Count
 
 from competitions.models import Competition
 
@@ -16,14 +15,26 @@ def get_popular_competitions(limit=4):
     :rtype: list
     :return:  Most popular competitions.
     '''
-    competitions = Competition.objects.filter(published=True) \
-        .annotate(participant_count=Count('participants')) \
-        .order_by('-participant_count')
 
-    if len(competitions) <= limit:
+    # TODO: Fix the fetching of the popular competitions
+    # Uncomment and update the following code when a long term fix is implemented for participants count
+
+    # competitions = Competition.objects.filter(published=True) \
+    #     .annotate(participant_count=Count('participants')) \
+    #     .order_by('-participant_count')
+
+    # if len(competitions) <= limit:
+    #     return competitions
+
+    # return competitions[:limit]
+
+    # Temporary solution to show specific popular competitions
+    try:
+        popular_competiion_ids = [1752, 1772, 2338, 3863]
+        competitions = Competition.objects.filter(id__in=popular_competiion_ids)
         return competitions
-
-    return competitions[:limit]
+    except Exception:
+        return []
 
 
 def get_featured_competitions(limit=4, excluded_competitions=None):
@@ -36,13 +47,24 @@ def get_featured_competitions(limit=4, excluded_competitions=None):
     :return: list of featured competitions
     '''
 
-    competitions = Competition.objects.filter(published=True) \
-        .annotate(participant_count=Count('participants'))
+    # TODO: Fix the fetching of the featured competitions
+    # Uncomment and update the following code when a long term fix is implemented for participants count
 
-    if excluded_competitions:
-        competitions = competitions.exclude(pk__in=[c.pk for c in excluded_competitions])
+    # competitions = Competition.objects.filter(published=True) \
+    #     .annotate(participant_count=Count('participants'))
 
-    if len(competitions) <= limit:
+    # if excluded_competitions:
+    #     competitions = competitions.exclude(pk__in=[c.pk for c in excluded_competitions])
+
+    # if len(competitions) <= limit:
+    #     return competitions
+    # else:
+    #     return random.sample(list(competitions), limit)
+
+    # Temporary solution to show specific featured competitions
+    try:
+        featured_competiion_ids = [3523, 2745, 3160, 1567]
+        competitions = Competition.objects.filter(id__in=featured_competiion_ids)
         return competitions
-    else:
-        return random.sample(list(competitions), limit)
+    except Exception:
+        return []

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -15,15 +15,24 @@ class HomeView(TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        data = Competition.objects.aggregate(
-            count=Count('*'),
-            published_comps=Count('pk', filter=Q(published=True)),
-            unpublished_comps=Count('pk', filter=Q(published=False)),
-        )
+        # TODO: Optimize fetching the statistics
+        # Possibly from a file where they are written by an automated script once a day
+        # For now showing latest numbers from live codabench
+        # The following commented code is slowing down the loading of the home page
 
-        public_competitions = data['published_comps']
-        users = User.objects.all().count()
-        submissions = Submission.objects.all().count()
+        # data = Competition.objects.aggregate(
+        #     count=Count('*'),
+        #     published_comps=Count('pk', filter=Q(published=True)),
+        #     unpublished_comps=Count('pk', filter=Q(published=False)),
+        # )
+
+        # public_competitions = data['published_comps']
+        # users = User.objects.all().count()
+        # submissions = Submission.objects.all().count()
+
+        public_competitions = 204
+        users = 12216
+        submissions = 70276
 
         context['general_stats'] = [
             {'label': "Public Competitions", 'count': public_competitions},

--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -1,9 +1,8 @@
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.views.generic import TemplateView
-from django.db.models import Count, Q
+from django.db.models import Q
 
-from competitions.models import Competition, Submission
-from profiles.models import User
+from competitions.models import Submission
 from announcements.models import Announcement, NewsPost
 
 from django.shortcuts import render

--- a/src/templates/pages/home.html
+++ b/src/templates/pages/home.html
@@ -48,7 +48,7 @@
     {% endif %}
 
     <div class="home-wrap">
-        <!-- <front-page-competitions></front-page-competitions> -->
+        <front-page-competitions></front-page-competitions>
 
         <!-- Action Section -->
         <div id="action-container" class="segment-container ui segment full-width">

--- a/src/templates/pages/home.html
+++ b/src/templates/pages/home.html
@@ -48,7 +48,7 @@
     {% endif %}
 
     <div class="home-wrap">
-        <front-page-competitions></front-page-competitions>
+        <!-- <front-page-competitions></front-page-competitions> -->
 
         <!-- Action Section -->
         <div id="action-container" class="segment-container ui segment full-width">


### PR DESCRIPTION
### 1. Home page Competitions are static now

Now you will see specific competitions in popular and featured competitions as a temporary fix to not use count participants. We should put this back as a dynamic feature when we optimize the code.

- Popular: competition with many participants and submissions
- Featured: we should be able to manually feature a competition from django admin/django bash

Solves: part of #1648 -> Home page popular and featured competitions

**TODO**: show the competitions again after fixing the queries

### 2. Home page static counters

Now we will see static number of comps, users and submissions to unblock users from using codabench. We want to update these numbers in a db or a file once a day and then fetch from there to not run expensive queries all the time when someone loads the home page


Solves: part of #1648 -> Global counters

**TODO**: show real counters from file/db when implemented

***
We should add the TODOs to #1647
