### PR TITLE
ingore datapoint with deleted competitions or deleted users

### DIFF
--- a/src/apps/api/views/analytics.py
+++ b/src/apps/api/views/analytics.py
@@ -221,6 +221,7 @@ def competitions_usage(request):
 
         query = CompetitionStorageDataPoint.objects.filter(
             at_date__range=(start_date, end_date),
+            competition__isnull=False
         ).dates("at_date", resolution).values(
             'id',
             'competition__id',
@@ -267,6 +268,7 @@ def users_usage(request):
 
         query = UserStorageDataPoint.objects.filter(
             at_date__range=(start_date, end_date),
+            user__isnull=False
         ).dates("at_date", resolution).values(
             'id',
             'user__id',


### PR DESCRIPTION
# Description
This fixes the problem where a removed competition are still looked up when measuring, per competition or per user, the size taken in the storage. Those datapoint are now ignored since they are now orphans.

# Issues this PR resolves
#1654 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge