### PR TITLE
Added search bar in Django Admin Users page for emails and username

### DIFF
--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -10,7 +10,6 @@ class UserAdmin(admin.ModelAdmin):
     search_fields = ['username', 'email']
 
 
-
 admin.site.register(User, UserAdmin)
 admin.site.register(Organization)
 admin.site.register(Membership)

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -7,7 +7,8 @@ class UserAdmin(admin.ModelAdmin):
     # The following two lines are needed for Django-su:
     change_form_template = "admin/auth/user/change_form.html"
     change_list_template = "admin/auth/user/change_list.html"
-    search_fields = ['username','email']
+    search_fields = ['username', 'email']
+
 
 
 admin.site.register(User, UserAdmin)

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -7,7 +7,7 @@ class UserAdmin(admin.ModelAdmin):
     # The following two lines are needed for Django-su:
     change_form_template = "admin/auth/user/change_form.html"
     change_list_template = "admin/auth/user/change_list.html"
-
+    search_fields = ['username','email']
 
 admin.site.register(User, UserAdmin)
 admin.site.register(Organization)

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -9,6 +9,7 @@ class UserAdmin(admin.ModelAdmin):
     change_list_template = "admin/auth/user/change_list.html"
     search_fields = ['username','email']
 
+
 admin.site.register(User, UserAdmin)
 admin.site.register(Organization)
 admin.site.register(Membership)


### PR DESCRIPTION
# @ mention of reviewers
@ihsaan-ullah @Didayolo 


# Description
Added a search bar in the Django admin interface for the Users page. We can now look up Users bases on their username and emails.
We can also easily add a search bar in other pages for different fields in later PRs

I tested it locally and everything worked fine. 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

