### PR TITLE
.gitingore update to ignore the home page counters file. Also removed the file from cache so that it's not tracked anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ server_config.yaml
 
 caddy_config/
 caddy_data/
+
+home_page_counters.json

--- a/home_page_counters.json
+++ b/home_page_counters.json
@@ -1,6 +1,0 @@
-{
-    "public_competitions": 0,
-    "users": 0,
-    "submissions": 0,
-    "last_updated": "2000-01-01T00:00:00.000000+00:00"
-}


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
.gitingore update to ignore the home page counters file. Also removed the file from cache so that it's not tracked anymore

The home page counters file should probably be rebuilt manually after this change is live, which can be done by following the instructions on this [link](https://github.com/codalab/codabench/wiki/Homepage-Counters)

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

