### PR TITLE
User quota is updated to GB from Bytes

### DIFF
--- a/src/apps/api/tests/test_datasets.py
+++ b/src/apps/api/tests/test_datasets.py
@@ -3,7 +3,7 @@ from faker import Factory
 from rest_framework.test import APITestCase
 from datasets.models import Data
 from factories import UserFactory, DataFactory
-from utils.data import pretty_bytes
+from utils.data import pretty_bytes, gb_to_bytes
 
 
 faker = Factory.create()
@@ -50,10 +50,19 @@ class DatasetAPITests(APITestCase):
     def test_dataset_api_check_quota(self):
         self.client.login(username='creator', password='creator')
 
+        # User quota is in GB
         quota = float(self.creator.quota)
+        # Convert to bytes to compute available space
+        quota = gb_to_bytes(quota)
+        # Used storage is in bytes
         storage_used = float(self.creator.get_used_storage_space())
+
         available_space = quota - storage_used
-        file_size = 1024 * 1024 * 1024 * 1024
+
+        # 1 GB = 1,000,000,000 Bytes
+        # 1 TB = 1,000 GB = 1,000,000,000,000 Bytes
+        # Using a big file size of 1 TB to run the test
+        file_size = 1000 * 1000 * 1000 * 1000
 
         # Fake upload a very big dataset
         resp = self.client.post(reverse("data-list"), {
@@ -68,7 +77,7 @@ class DatasetAPITests(APITestCase):
         assert resp.data["data_file"][0] == f'Insufficient space. Your available space is {pretty_bytes(available_space)}. The file size is {pretty_bytes(file_size)}. Please free up some space and try again. You can manage your files in the Resources page.'
 
         # Fake upload a small file
-        file_size = available_space - 1024
+        file_size = available_space - 1000
         resp = self.client.post(reverse("data-list"), {
             'name': 'new-file-test',
             'type': Data.COMPETITION_BUNDLE,

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -14,7 +14,7 @@ from api.pagination import BasicPagination
 from api.serializers import datasets as serializers
 from datasets.models import Data, DataGroup
 from competitions.models import CompetitionCreationTaskStatus
-from utils.data import make_url_sassy, pretty_bytes
+from utils.data import make_url_sassy, pretty_bytes, gb_to_bytes
 
 
 class DataViewSet(ModelViewSet):
@@ -90,6 +90,7 @@ class DataViewSet(ModelViewSet):
         # Check User quota
         storage_used = float(request.user.get_used_storage_space())
         quota = float(request.user.quota)
+        quota = gb_to_bytes(quota)
         file_size = float(request.data['file_size'])
         if storage_used + file_size > quota:
             available_space = pretty_bytes(quota - storage_used)

--- a/src/apps/api/views/tasks.py
+++ b/src/apps/api/views/tasks.py
@@ -19,7 +19,7 @@ from competitions.models import Submission, Phase
 from profiles.models import User
 from tasks.models import Task
 from datasets.models import Data
-from utils.data import pretty_bytes
+from utils.data import pretty_bytes, gb_to_bytes
 
 
 # TODO:// TaskViewSimple uses simple serializer from tasks, which exists purely for the use of Select2 on phase modal
@@ -210,7 +210,10 @@ class TaskViewSet(ModelViewSet):
 
         # Check if user has enough quota to proceed
         storage_used = float(request.user.get_used_storage_space())
+        # User quota is in GB
         quota = float(request.user.quota)
+        # Convert user quota to bytes
+        quota = gb_to_bytes(quota)
         file_size = uploaded_file.size
         if storage_used + file_size > quota:
             file_size = pretty_bytes(file_size)

--- a/src/apps/profiles/models.py
+++ b/src/apps/profiles/models.py
@@ -154,6 +154,10 @@ class User(ChaHubSaveMixin, AbstractBaseUser, PermissionsMixin):
         return True
 
     def get_used_storage_space(self, binary=False):
+        """
+        Function to calculate storage used by a user
+        Returns in bytes
+        """
 
         factor = 1024 if binary else 1000
         from datasets.models import Data

--- a/src/apps/profiles/quota.py
+++ b/src/apps/profiles/quota.py
@@ -1,0 +1,19 @@
+import logging
+from .models import User
+
+logger = logging.getLogger()
+
+
+def reset_all_users_quota_to_gb():
+    """
+    Converts user quota from bytes to GB if it's stored in bytes.
+    Skips users whose quota is already in GB.
+    """
+    users = User.objects.all()
+    affted_users_count = 0
+    for user in users:
+        # If quota is in bytes (greater than 1 GB in bytes)
+        if user.quota > 1000 * 1000 * 1000:
+            user.quota = user.quota / 1e9  # Convert to GB
+            user.save()
+            affted_users_count += 1

--- a/src/apps/profiles/quota.py
+++ b/src/apps/profiles/quota.py
@@ -10,10 +10,8 @@ def reset_all_users_quota_to_gb():
     Skips users whose quota is already in GB.
     """
     users = User.objects.all()
-    affted_users_count = 0
     for user in users:
         # If quota is in bytes (greater than 1 GB in bytes)
         if user.quota > 1000 * 1000 * 1000:
             user.quota = user.quota / 1e9  # Convert to GB
             user.save()
-            affted_users_count += 1

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -420,7 +420,7 @@ GS_PRIVATE_BUCKET_NAME = os.environ.get('GS_PRIVATE_BUCKET_NAME')
 GS_BUCKET_NAME = GS_PUBLIC_BUCKET_NAME  # Default bucket set to public bucket
 
 # Quota
-DEFAULT_USER_QUOTA = 15 * 1000 * 1000 * 1000  # 15GB
+DEFAULT_USER_QUOTA = 15  # 15GB
 
 
 # =============================================================================

--- a/src/static/riot/quota_management.tag
+++ b/src/static/riot/quota_management.tag
@@ -7,7 +7,7 @@
 
             <!--  Quota  -->
             <div style="flex: 0 0 auto; margin-left: auto;">
-                Quota: {formatSize(storage_used)} / {formatSize(quota)}
+                Quota: {formatSize(storage_used)} / {quota} GB
             </div>
         </div>
 

--- a/src/utils/data.py
+++ b/src/utils/data.py
@@ -131,3 +131,8 @@ def pretty_bytes(bytes, decimal_places=1, suffix="B", binary=False):
         bytes /= factor
 
     return f"{bytes:.{decimal_places}f}{units[-1]}{suffix}"
+
+
+def gb_to_bytes(gb, binary=False):
+    factor = 1024**3 if binary else 1000**3
+    return gb * factor


### PR DESCRIPTION
@Didayolo @ObadaS 


# Description
User quota was configured in bytes. Now I have changed it to GB so that it is readable. After deployment, all users quota should be updated from bytes to GB. 

~~This documentation [here](https://github.com/codalab/codabench/wiki/Administrator-procedures#reset-user-quota-from-bytes-to-gb) shows how you can do that. I have reorganized the wiki page to gather quota related admin procedures at one place [here](https://github.com/codalab/codabench/wiki/Administrator-procedures#user-quota-management)~~

# Manual intervention

### Reset User Quota from Bytes to GB

**Using django shell**
```python
docker compose exec django ./manage.py shell_plus
```

```python
from profiles.quota import reset_all_users_quota_to_gb
reset_all_users_quota_to_gb()
```



# Issues this PR resolves
- #1748 -> Reset User Quota from bytes to GB



# A checklist for hand testing
- [x] check that function to reset user quota to GB works 
- [x] check that you cannot upload files when your quota is filled
- [x] check that you can now understand and can easily change the quota in the django admin and using the shell as shown in the documentation
- [x] check that it is clear for you and for wiki readers that the quota is in GB e.g. 15 GB



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

