### PR TITLE
Home page competitions updates

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -449,6 +449,7 @@ class CompetitionSerializerSimple(serializers.ModelSerializer):
             'reward',
             'contact_email',
             'report',
+            'is_featured',
         )
 
     def get_created_by(self, obj):
@@ -494,7 +495,7 @@ class CompetitionParticipantSerializer(serializers.ModelSerializer):
 
 class FrontPageCompetitionsSerializer(serializers.Serializer):
     popular_comps = CompetitionSerializerSimple(many=True)
-    featured_comps = CompetitionSerializerSimple(many=True)
+    recent_comps = CompetitionSerializerSimple(many=True)
 
 
 class PhaseResultsSubmissionSerializer(serializers.Serializer):

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -30,7 +30,7 @@ from competitions.emails import send_participation_requested_emails, send_partic
 from competitions.models import Competition, Phase, CompetitionCreationTaskStatus, CompetitionParticipant, Submission
 from datasets.models import Data
 from competitions.tasks import batch_send_email, manual_migration, create_competition_dump
-from competitions.utils import get_popular_competitions, get_featured_competitions
+from competitions.utils import get_popular_competitions, get_recent_competitions
 from leaderboards.models import Leaderboard
 from utils.data import make_url_sassy
 from api.permissions import IsOrganizerOrCollaborator
@@ -507,12 +507,12 @@ class CompetitionViewSet(ModelViewSet):
     @action(detail=False, methods=('GET',), permission_classes=(AllowAny,))
     def front_page(self, request):
         popular_comps = get_popular_competitions()
-        featured_comps = get_featured_competitions()
+        recent_comps = get_recent_competitions(exclude_comps=popular_comps)
         popular_comps_serializer = CompetitionSerializerSimple(popular_comps, many=True)
-        featured_comps_serializer = CompetitionSerializerSimple(featured_comps, many=True)
+        recent_comps_serializer = CompetitionSerializerSimple(recent_comps, many=True)
         return Response(data={
             "popular_comps": popular_comps_serializer.data,
-            "featured_comps": featured_comps_serializer.data
+            "recent_comps": recent_comps_serializer.data
         })
 
     @swagger_auto_schema(request_body=no_body, responses={201: CompetitionCreationTaskStatusSerializer()})

--- a/src/apps/competitions/utils.py
+++ b/src/apps/competitions/utils.py
@@ -2,22 +2,21 @@
 This file contains utilities for competitions
 '''
 import random
-# from django.db.models import Count
 
 from competitions.models import Competition
 
 
 def get_popular_competitions(limit=4):
-    '''
+    """
     Function to return most popular competitions based on the amount of participants.
 
     :param limit: Amount of competitions to return. Default is 3.
     :rtype: list
     :return:  Most popular competitions.
-    '''
+    """
 
     competitions = Competition.objects.filter(published=True) \
-        .order_by('-participants_count')
+        .order_by('-is_featured', '-participants_count')
 
     if len(competitions) <= limit:
         return competitions
@@ -25,16 +24,19 @@ def get_popular_competitions(limit=4):
     return competitions[:limit]
 
 
-def get_featured_competitions(limit=4):
-    '''
-    Function to return featured competitions
+def get_recent_competitions(exclude_comps=None, limit=4):
+    """
+    Function to return recent competitions, excluding given and featured competitions.
 
-    :param limit: Amount of competitions to return. Default is 4
+    :param limit: Amount of competitions to return. Default is 4.
+    :param exclude_comps: A queryset or list of competitions to exclude.
     :rtype: list
-    :return: list of featured competitions
-    '''
-
-    competitions = Competition.objects.filter(is_featured=True)
+    :return: List of featured competitions.
+    """
+    exclude_ids = [comp.id for comp in exclude_comps] if exclude_comps else []
+    competitions = Competition.objects.filter(published=True, is_featured=False) \
+        .exclude(id__in=exclude_ids) \
+        .order_by('-created_when')
 
     if len(competitions) <= limit:
         return competitions

--- a/src/static/riot/competitions/tile/competition_tile.tag
+++ b/src/static/riot/competitions/tile/competition_tile.tag
@@ -1,6 +1,7 @@
 <competition-tile>
     
-        <div class="tile-wrapper">
+        <!--  <div class="tile-wrapper">  -->
+        <div class="tile-wrapper {is_featured ? 'featured' : ''}">
             <div class="ui square tiny bordered image img-wrapper">
                 <img src="{logo_icon ? logo_icon : logo}">
             </div>
@@ -8,6 +9,7 @@
             <div class="comp-info">
                 <h4 class="heading">
                     {title}
+                    <span if="{is_featured}" class="featured-badge">Featured</span>
                 </h4>
                 <p class="comp-description">
                     {pretty_description(description)}
@@ -74,6 +76,11 @@
             .comp-stats
                 background-color #344d5e
                 transition background-color 75ms ease-in-out
+       
+        .tile-wrapper.featured
+            border solid 2px gold
+            background-color #fffbea  /* Light yellow */
+            box-shadow 0 0 10px rgba(255, 215, 0, 0.6)
 
         .img-wrapper
             padding 5px
@@ -89,6 +96,16 @@
             padding 5px
             color #1b1b1b
             margin-bottom 0
+
+        .featured-badge
+            background-color gold
+            color #222
+            font-size 12px
+            font-weight 600
+            padding 2px 7px
+            border-radius 5px
+            margin-left 8px
+            display inline-block
 
         .comp-info .comp-description
             text-align: left;

--- a/src/static/riot/competitions/tile/front_page_competitions.tag
+++ b/src/static/riot/competitions/tile/front_page_competitions.tag
@@ -18,7 +18,7 @@
 
         <div class="eight wide column">
             <div class="ui large header">
-                Featured Benchmarks
+                Recent Benchmarks
             </div>
             <div class="loader-container popular">
                 <div class="lds-ring">
@@ -28,7 +28,7 @@
                     <div></div>
                 </div>
             </div>
-            <competition-tile each="{featured_competitions}"></competition-tile>
+            <competition-tile each="{recent_competitions}"></competition-tile>
             <a class="show-more" href="/competitions/public/">Show more</a>
         </div>
     </div>
@@ -47,7 +47,7 @@
                     toastr.error("Could not load competition list")
                 })
                 .done(function (data) {
-                    self.featured_competitions = data["featured_comps"]
+                    self.recent_competitions = data["recent_comps"]
                     self.popular_competitions = data["popular_comps"]
                     self.update()
                     $('.loader-container').hide()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- Now featured competitions will be shown at the top of the popular competitions list
- Style added to featured competitions
- Featured comps section renamed to Recent comps
- Queries updated for both popular and recent comps
- Popular and Featured comps are excluded from Recent comps

<img width="1204" alt="Screenshot 2025-02-13 at 12 59 02 PM" src="https://github.com/user-attachments/assets/14cbf7ec-dd4b-4752-8505-50094f41b3ca" />



# Issues this PR resolves
- #1703 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

