### PR TITLE
Competition pages are now clickable without any active phase

### DIFF
--- a/src/static/riot/competitions/detail/_tabs.tag
+++ b/src/static/riot/competitions/detail/_tabs.tag
@@ -351,10 +351,22 @@
             })
 
             self.competition.is_admin = CODALAB.state.user.has_competition_admin_privileges(competition)
+            
+            // Find current phase and set selected phase index to its id
             self.selected_phase_index = _.get(_.find(self.competition.phases, {'status': 'Current'}), 'id')
+
+            // If no Current phase in this competition 
+            // Find Final phase and set selected phase index to its id
             if (self.selected_phase_index == null) {
                 self.selected_phase_index = _.get(_.find(self.competition.phases, {is_final_phase: true}), 'id')
             }
+
+            // If no Final phase in this competition 
+            // Find the last phase and set selected phase index to its id
+            if (self.selected_phase_index == null) {
+                self.selected_phase_index = self.competition.phases[self.competition.phases.length - 1].id; 
+            }
+
             self.phase_selected(_.find(self.competition.phases, {id: self.selected_phase_index}))
 
             $('.phases-tab .accordion', self.root).accordion()


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
- resolved issue that made the page tabs unclickable


# Issues this PR resolves
- #1409




# A checklist for hand testing
- [x] check for a competition with all phases ended
- [x] check for a competition with all phases not started
- [x] check for a competition with one phase as current phase


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

