### PR TITLE
Task list pagination issues resolved

### DIFF
--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -543,7 +543,8 @@
                         CODALAB.events.trigger('reload_quota_cleanup')
                         CODALAB.events.trigger('reload_datasets')
                         self.close_upload_task_modal()
-                        self.update_tasks()
+                        self.page = 1 // set current page to 1
+                        self.update_tasks({page: self.page}) // on new task creation, go to first page i.e. page=1
                     }, 500)
                     
                 })
@@ -563,7 +564,8 @@
                 .done((response) => {
                     toastr.success('Task Created')
                     self.close_modal()
-                    self.update_tasks()
+                    self.page = 1 // set current page to 1
+                    self.update_tasks({page: self.page}) // on new task creation, go to first page i.e. page=1
                     CODALAB.events.trigger('reload_quota_cleanup')
                 })
                 .fail((response) => {
@@ -704,7 +706,7 @@
                 .done((response) => {
                     toastr.success('Task Updated')
                     self.close_edit_modal()
-                    self.update_tasks()
+                    self.update_tasks({page: self.page}) // pass the current page to stay on the page after the update
                     CODALAB.events.trigger('reload_quota_cleanup')
                 })
                 .fail((response) => {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
In the resource interface, there were some problems in the pagination when a task was created or updated. This PR has fixed those problems:
- On task update, now user will stay on the same page e.g. (page: 3)
- On task create or upload, user will go to the first page (page: 1)


# Issues this PR resolves
- #1429



# A checklist for hand testing
- [x] upload task when you are not on the first page and see that you are taken to page 1 with the correct page mentioned in the pagination area
- [x] create task when you are not on the first page and see that you are taken to page 1 with the correct page mentioned in the pagination area
- [x] update a task on any page and see that you stay on the same page



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

