### PR TITLE
Double approve/deny partipant

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -836,16 +836,23 @@ class CompetitionParticipantViewSet(ModelViewSet):
             return CompetitionParticipant.objects.none()
 
     def update(self, request, *args, **kwargs):
-        if request.method == 'PATCH':
-            if 'status' in request.data:
-                participation_status = request.data['status']
-                participant = self.get_object()
-                emails = {
-                    'approved': send_participation_accepted_emails,
-                    'denied': send_participation_denied_emails,
-                }
-                if participation_status in emails:
-                    emails[participation_status](participant)
+        if request.method == 'PATCH' and 'status' in request.data:
+            participation_status = request.data['status']
+            participant = self.get_object()
+
+            # Check if the new status is the same as the current status
+            if participation_status == participant.status:
+                return Response(
+                    {"error": f"Status is already set to `{participation_status}`"},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            emails = {
+                'approved': send_participation_accepted_emails,
+                'denied': send_participation_denied_emails,
+            }
+            if participation_status in emails:
+                emails[participation_status](participant)
 
         return super().update(request, *args, **kwargs)
 

--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -169,6 +169,13 @@
                     }
                     self.update_participants()
                 })
+                .fail((resp) => {
+                    let errorMessage = 'An error occurred while updating the status.'
+                    if (resp.responseJSON && resp.responseJSON.error) {
+                        errorMessage = resp.responseJSON.error
+                    }
+                    toastr.error(errorMessage)
+                })
         }
 
         self.revoke_permission = id => {
@@ -178,7 +185,9 @@
         }
 
         self.approve_permission = id => {
-            self._update_status(id, 'approved')
+            if (confirm("Are you sure you want to accept this user's participation request?")) {
+                self._update_status(id, 'approved')
+            }
         }
 
         self.search_participants = () => {


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
A condition is added to avoid double approve or deny participants status. This happens when the server is slow and organizer clicks the button 2 times.


# Issues this PR resolves
- #1443


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

