### PR TITLE
Email in lowercase

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -304,7 +304,8 @@ class CompetitionViewSet(ModelViewSet):
             data.pop('whitelist_emails', None)
             # Loop over whitelist emails and add them back to whitelist emails in dict format
             for email in whitelist_emails:
-                data.setdefault('whitelist_emails', []).append({'email': email})
+                # user lower case email because some emails in the whitelist may have upper case letters 
+                data.setdefault('whitelist_emails', []).append({'email': email.lower()})
 
             serializer = self.get_serializer(instance, data=data, partial=partial)
             serializer.is_valid(raise_exception=True)
@@ -350,7 +351,8 @@ class CompetitionViewSet(ModelViewSet):
             send_participation_accepted_emails(participant)
         else:
             # check if user is in whitelist emails then approve directly
-            if user.email in list(competition.whitelist_emails.values_list('email', flat=True)):
+            # Using lower case because some users have used uppercased emails addresses
+            if user.email.lower() in list(competition.whitelist_emails.values_list('email', flat=True)):
                 participant.status = 'approved'
                 send_participation_accepted_emails(participant)
             else:

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -304,7 +304,7 @@ class CompetitionViewSet(ModelViewSet):
             data.pop('whitelist_emails', None)
             # Loop over whitelist emails and add them back to whitelist emails in dict format
             for email in whitelist_emails:
-                # user lower case email because some emails in the whitelist may have upper case letters 
+                # user lower case email because some emails in the whitelist may have upper case letters
                 data.setdefault('whitelist_emails', []).append({'email': email.lower()})
 
             serializer = self.get_serializer(instance, data=data, partial=partial)

--- a/src/apps/profiles/views.py
+++ b/src/apps/profiles/views.py
@@ -277,7 +277,8 @@ def log_in(request):
 
         if form.is_valid():
             # Get username and password
-            username = form.cleaned_data.get('username')
+            # use lowecased username/email
+            username = form.cleaned_data.get('username').lower()
             password = form.cleaned_data.get('password')
 
             # Check if the user exists


### PR DESCRIPTION
@Didayolo 


# Description
- On signup emails are stored as lowercased to not allow users to create multiple accounts using the same email but in different cases
- White list emails are now checked in lower case to avoid any inconsistencies  


# Issues this PR resolves
- #1766



# A checklist for hand testing
- [x] signup with a dummy uppercased email e.g. `AAA@gmail.com` and check in your profile that it is stored as `aaa@gmail.com`
- [x] Add `AAA@gmail.com` to a competition whitelist and check that when you join the competition with `aaa@gmail.com` it approves you automatically



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

