### PR TITLE
Show server error instead of fronend parsing/JSON error

### DIFF
--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -477,23 +477,12 @@
                     if (response) {
                         try {
                             let errors = JSON.parse(response.responseText)
-
-                            // Clean up errors to not be arrays but plain text
-                            Object.keys(errors).map(function (key, index) {
-                                errors[key] = errors[key].join('; ')
-                            })
-
-                            // Create a string to concatenate all error messages
-                            let errorMessages = "Error in submission upload:\n"
-                            Object.keys(errors).forEach(function (key) {
-                                errorMessages += key + ": " + errors[key] + "\n"
-                            })
-
-                            toastr.error(errorMessages)
+                            let error_str = Object.keys(errors).map(function (key) { return errors[key] }).join("; ")
+                            toastr.error("Submission upload failed: " + error_str)
                             self.update({errors: errors})
 
                         } catch (e) {
-                            toastr.error("Error in submission upload\n"+e)
+                            toastr.error("Submission upload failed. Server returned: " + response.status + " " + response.statusText);
                         }
                     } else {
                         toastr.error("Something went wrong, please try again later")


### PR DESCRIPTION
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
In submission upload when server returns 500, that error is not captured properly because of response parsing error. User is shown `Error in submission upload SyntaxError: "undefined" is not valid JSON`. Now user will see the actual error returned.


# Issues this PR resolves
- Part of #1776 



# A checklist for hand testing
- [x] You can test this by manually raising an error in `src/apps/api/views/datasets.py/DataViewset/create` 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

