### PR TITLE
Competition Create form UI updates

### DIFF
--- a/src/static/riot/competitions/editor/form.tag
+++ b/src/static/riot/competitions/editor/form.tag
@@ -96,8 +96,10 @@
                 <button class="ui basic red button discard" onclick="{ discard }">
                     Discard Changes
                 </button>
-                <a class="ui secondary basic button" href="{URLS.COMPETITION_DETAIL(opts.competition_id)}">Back To Competition</a>
-                <help_button href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
+                <!--  Show back button when updating only  -->
+                <a if="{opts.competition_id}" class="ui secondary basic button" href="{URLS.COMPETITION_DETAIL(opts.competition_id)}">Back To Competition</a>
+                <!--  Show help when creating only  -->
+                <help_button if="{!opts.competition_id}" href="https://github.com/codalab/competitions-v2/wiki/Competition-Creation:-Form"></help_button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
@Didayolo 


# Description
- When you are creating a competition from the UI, there is no need to show the back button. 
- The help button is for competition creation so it is not useful in the update view


# Screenshots
### Create competition
<img width="617" alt="Screenshot 2025-03-13 at 12 00 30 PM" src="https://github.com/user-attachments/assets/8205de18-93cb-4966-8267-f66908bbfd55" />

### Update competition
<img width="688" alt="Screenshot 2025-03-13 at 12 00 41 PM" src="https://github.com/user-attachments/assets/5dac3dfc-2033-4bb4-8b24-ba854b85608a" />



# Issues this PR resolves
- No specific issue 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

