### PR TITLE
Do not allow special chars in usernames

### DIFF
--- a/src/apps/profiles/forms.py
+++ b/src/apps/profiles/forms.py
@@ -1,3 +1,4 @@
+import re
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from .models import User
@@ -11,12 +12,13 @@ class SignUpForm(UserCreationForm):
 
     def clean_username(self):
         data = self.cleaned_data["username"]
-        if not data.islower():
-            raise forms.ValidationError("Usernames should be in lowercase")
-        if not data.isalnum():
-            raise forms.ValidationError(
-                "Usernames should not contain special characters."
-            )
+
+        # Check if username has allowed characters only
+        # Allow only lowercase letters, numbers, hyphens, and underscores
+        if not re.match(r"^[a-z0-9_-]+$", data):
+            raise forms.ValidationError("Username can only contain lowercase letters, numbers, hyphens, and underscores.")
+
+        # Check username length
         if (len(data) > 15) or (len(data) < 5):
             raise forms.ValidationError(
                 "Username must have at least 5 characters and at most 15 characters"


### PR DESCRIPTION
@Didayolo @ObadaS 


# A brief description of the purpose of the changes contained in this PR.
Special characters in username are problematic when django creates URLs. This PR restricts users to not use special characters in their usernames during signup


# Issues this PR resolves
- #1780 



# A checklist for hand testing
- [x] Check that you cannot create an account if you have special character, capital letter in your username


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

