### PR TITLE
Resource interface: quota unit is now GB instead of B

### DIFF
--- a/src/static/riot/quota_management.tag
+++ b/src/static/riot/quota_management.tag
@@ -7,7 +7,7 @@
 
             <!--  Quota  -->
             <div style="flex: 0 0 auto; margin-left: auto;">
-                Quota: {pretty_bytes(storage_used)} / {pretty_bytes(quota)}
+                Quota: {pretty_bytes(storage_used)} / {quota} GB
             </div>
         </div>
 


### PR DESCRIPTION
@Didayolo 


# Description
- Resource interface: quota unit is now GB instead of B
<img width="222" alt="Screenshot 2025-03-26 at 10 58 43 AM" src="https://github.com/user-attachments/assets/aa2242be-c0a7-4a14-b1a7-5f6a6e8dcd76" />




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

