### PR TITLE
Add permissions check for bulk download

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -388,7 +388,7 @@ class SubmissionViewSet(ModelViewSet):
             raise PermissionDenied(
                 "You do not have permission to download one or more of the requested submissions"
             )
-        
+
         # Download
         from competitions.tasks import stream_batch_download
         in_memory_zip = stream_batch_download(pks)

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -351,16 +351,47 @@ class SubmissionViewSet(ModelViewSet):
 
     @action(detail=False, methods=['get'])
     def download_many(self, request):
+        """
+        Download a ZIP containing several submissions.
+        """
         pks = request.query_params.get('pks')
         if pks:
             pks = json.loads(pks)  # Convert JSON string to list
+        else:
+            return Response({"error": "`pks` query parameter is required"}, status=400)
 
-        # Doing a local import here to avoid circular imports
+        # Get submissions
+        submissions = Submission.objects.filter(pk__in=pks).select_related(
+            "owner",
+            "phase__competition",
+            "phase__competition__created_by",
+        ).prefetch_related("phase__competition__collaborators")
+        if submissions.count() != len(pks):
+            return Response({"error": "One or more submission IDs are invalid"}, status=404)
+
+        # Check permissions
+        if not request.user.is_authenticated:
+            raise PermissionDenied("You must be logged in to download submissions")
+        # Allow admins
+        if request.user.is_superuser or request.user.is_staff:
+            allowed = True
+        else:
+            # Build one Q object for "owner OR organizer"
+            organiser_q = (
+                Q(phase__competition__created_by=request.user) |
+                Q(phase__competition__collaborators=request.user)
+            )
+            # Submissions that violate the rule
+            disallowed = submissions.exclude(Q(owner=request.user) | organiser_q)
+            allowed = not disallowed.exists()
+        if not allowed:
+            raise PermissionDenied(
+                "You do not have permission to download one or more of the requested submissions"
+            )
+        
+        # Download
         from competitions.tasks import stream_batch_download
-
-        # in_memory_zip = stream_batch_download.apply_async((pks,)).get()
         in_memory_zip = stream_batch_download(pks)
-
         response = StreamingHttpResponse(in_memory_zip, content_type='application/zip')
         response['Content-Disposition'] = 'attachment; filename="bulk_submissions.zip"'
         return response


### PR DESCRIPTION
# Description

Adding permissions to avoid that any user can bulk download any submissions using the API.

# Issues this PR resolves

- Closes: #1824


# A checklist for hand testing

Access the following URL:
```
http://localhost/api/submissions/download_many/?pks=["3", "12"]
```

Replace `["3", "12"]` by a list with different submissions ID.

Check that the download works only if you are allowed to download all submissions, otherwise you should have a relevant error message ("You need to be logged in", "You are not allowed to download", etc.)

You should be able to download a submission only if:
- You are the owner of the submission
- You are the competition organizer of the competition that received the submission
- You are super-user of the platform


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

