### PR TITLE
Phase end date -  calendar fixed

### DIFF
--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -432,19 +432,16 @@
                     }
                 }
 
-                // Create a new options object for the start date calendar by combining 'date_options'
-                // with an additional option to link the end date calendar. This ensures that the start date
-                // cannot be after the selected end date.
-                var start_options = Object.assign({}, date_options, {endCalendar: self.refs.calendar_end_date})
+                // Create a new options object for the start date calendar using 'date_options'
+                var start_options = Object.assign({}, date_options)
                 
-                // Similarly, create a new options object for the end date calendar, linking it to the start date.
-                // This ensures that the end date cannot be before the selected start date.
-                var end_options = Object.assign({}, date_options, {startCalendar: self.refs.calendar_start_date})
+                // Create a new options object for the end date calendar using 'date_options'
+                var end_options = Object.assign({}, date_options)
                 
-                // Initialize the start date calendar using the options defined above, including the end date limitation.
+                // Initialize the start date calendar using the options defined above
                 $(self.refs.calendar_start_date).calendar(start_options)
 
-                // Initialize the end date calendar using the options defined above, which includes the start date limitation.
+                // Initialize the end date calendar using the options defined above
                 $(self.refs.calendar_end_date).calendar(end_options)
 
 
@@ -806,6 +803,12 @@
                     data.end_time = "00:00"
                 }
                 data.end = self.formatDateTo_Y_m_d_T_H_M_S(data.end_date + " " + data.end_time)
+
+                // Check: start date must not be after end date
+                if (new Date(data.start) > new Date(data.end)) {
+                    toastr.error("End date cannot be earlier than the start date. Please choose a valid date range.")
+                    return
+                }
             }else{
                 // end date is set to null if it is not selected because it is optional in the form
                 data.end = null

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -433,18 +433,9 @@
                 }
 
                 // Create a new options object for the start date calendar using 'date_options'
-                var start_options = Object.assign({}, date_options)
-                
+                $(self.refs.calendar_start_date).calendar(date_options)
                 // Create a new options object for the end date calendar using 'date_options'
-                var end_options = Object.assign({}, date_options)
-                
-                // Initialize the start date calendar using the options defined above
-                $(self.refs.calendar_start_date).calendar(start_options)
-
-                // Initialize the end date calendar using the options defined above
-                $(self.refs.calendar_end_date).calendar(end_options)
-
-
+                $(self.refs.calendar_end_date).calendar(date_options)
 
                 // Initialize the start time calendar with the defined options. 
                 // This will create a time picker for the 'start time' field.


### PR DESCRIPTION
@Didayolo 

# Description
For some reason the end date calendar was locked and users were not able to change the end date. This was happening because of the link between start date and end date calendars.

Now this is fixed and the connection between start date and end date is removed. Additional checks are added to make sure end date is not before the start date.

If end date is before the start date then users will see this error:
<img width="316" alt="Screenshot 2025-05-15 at 2 30 40 PM" src="https://github.com/user-attachments/assets/2249acca-2007-49be-8b89-a201d5bdb470" />



# Issues this PR resolves
- #1793



# A checklist for hand testing

- [x] upload the[iris_competition_bundle.zip](https://github.com/user-attachments/files/20225817/iris_competition_bundle.zip)
- [x] Check that for phase 1 you can select any date in the end date calendar
- [x] Select end date that is earlier than start date and check that you see an error when you click the save button



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

