### PR TITLE
fix Caddyfile indentation

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,7 +2,6 @@
   # HTTPS Options
   tls {$TLS_EMAIL}
 
-
   # Test HTTPS setup
   # tls {$TLS_EMAIL} {
   #   ca https://acme-staging-v02.api.letsencrypt.org/directory
@@ -20,23 +19,23 @@
     root /srv
     try_files maintenance.on
   }
-	handle @maintenanceModeActive {
+  handle @maintenanceModeActive {
     root * /srv
     redir @noRedirect /maintenance.html
-		file_server {
+    file_server {
       status 503
     }
-	}
+  }
 
   # Serves static files, should be the same as `STATIC_ROOT` setting:
-  root *  /var/www/django
+  root * /var/www/django
   file_server
-  
+
   @noStatic {
     not path /static/*
     not path /media/*
   }
-  
+
 
   # Serving dynamic requests:
   reverse_proxy @noStatic django:8000


### PR DESCRIPTION
tabs and spaces were mixed, which (depending on the editor settings?) would indent differently.

even better would be to do something like `docker run --rm -v ./Caddyfile:/etc/caddy/Caddyfile -it caddy:2.8.4 caddy fmt /etc/caddy/Caddyfile --overwrite` before commiting