### PR TITLE
Do not allow signup with email with `*`

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -588,7 +588,7 @@ class Run:
         Function responsible for running program directory
 
         Args:
-            - program_dir : can be either ingestion program or program(submission or scoring)
+            - program_dir : can be either ingestion program or program/submission
             - kind : either `program` or `ingestion`
         """
         # If the directory doesn't even exist, move on
@@ -609,9 +609,6 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
-                # Copy program dir content to output directory because in case of only result submission, 
-                # we need to copy the result submission files because the scoring program will use these as predictions
-                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -588,7 +588,7 @@ class Run:
         Function responsible for running program directory
 
         Args:
-            - program_dir : can be either ingestion program or program/submission
+            - program_dir : can be either ingestion program or program(submission or scoring)
             - kind : either `program` or `ingestion`
         """
         # If the directory doesn't even exist, move on
@@ -609,6 +609,9 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
+                # Copy program dir content to output directory because in case of only result submission, 
+                # we need to copy the result submission files because the scoring program will use these as predictions
+                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")

--- a/src/apps/profiles/forms.py
+++ b/src/apps/profiles/forms.py
@@ -25,6 +25,12 @@ class SignUpForm(UserCreationForm):
             )
         return data
 
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        if "*" in email:
+            raise forms.ValidationError("Email address cannot contain the '*' character.")
+        return email
+
     class Meta:
 
         model = User


### PR DESCRIPTION
@Didayolo 


# Description
Codabench was allowing users to use emails with `*` e.g. ihsan*@gmail.com was considered a valid email. Now this will raise an error.

<img width="454" alt="Screenshot 2025-06-18 at 4 38 44 PM" src="https://github.com/user-attachments/assets/d1b1ebaa-ef4e-4759-95c1-e4c4690928b7" />


# Issues this PR resolves
- #1881



# A checklist for hand testing
- [x] try signing up with an email with `*` in it



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

