### PR TITLE
Delete non active users

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -588,7 +588,7 @@ class Run:
         Function responsible for running program directory
 
         Args:
-            - program_dir : can be either ingestion program or program(submission or scoring)
+            - program_dir : can be either ingestion program or program/submission
             - kind : either `program` or `ingestion`
         """
         # If the directory doesn't even exist, move on
@@ -609,9 +609,6 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
-                # Copy program dir content to output directory because in case of only result submission, 
-                # we need to copy the result submission files because the scoring program will use these as predictions
-                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -588,7 +588,7 @@ class Run:
         Function responsible for running program directory
 
         Args:
-            - program_dir : can be either ingestion program or program/submission
+            - program_dir : can be either ingestion program or program(submission or scoring)
             - kind : either `program` or `ingestion`
         """
         # If the directory doesn't even exist, move on
@@ -609,6 +609,9 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
+                # Copy program dir content to output directory because in case of only result submission, 
+                # we need to copy the result submission files because the scoring program will use these as predictions
+                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")

--- a/src/apps/profiles/tasks.py
+++ b/src/apps/profiles/tasks.py
@@ -3,7 +3,7 @@ import logging
 from datetime import timedelta
 from django.utils.timezone import now
 from celery_config import app
-
+from django.contrib.auth import get_user_model
 from profiles.models import DeletedUser
 
 logger = logging.getLogger()
@@ -26,3 +26,28 @@ def clean_deleted_users():
     logger.info(
         "Task clean_deleted_users Completed. Duration = {:.3f} seconds".format(elapsed_time)
     )
+
+
+@app.task(queue="site-worker")
+def clean_non_activated_users():
+    try:
+        starting_time = time.process_time()
+        logger.info("Task clean_non_activated_users Started")
+
+        # Get User model
+        User = get_user_model()
+
+        # Calculate the threshold date (3 days ago)
+        three_days_ago = now() - timedelta(days=3)
+
+        # Delete users who have not activated their accounts in 3 days
+        deleted_count, _ = User.objects.filter(is_active=False, is_deleted=False, date_joined__lt=three_days_ago).delete()
+
+        logger.info(f"Deleted {deleted_count} non activated users from User table.")
+
+        elapsed_time = time.process_time() - starting_time
+        logger.info(
+            "Task clean_non_activated_users Completed. Duration = {:.3f} seconds".format(elapsed_time)
+        )
+    except Exception as e:
+        logger.exception(f"Failed to clean non-activated users\n{e}")

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -240,6 +240,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'profiles.tasks.clean_deleted_users',
         'schedule': timedelta(days=1),  # Run every 24 hours
     },
+    'clean_non_activated_users': {
+        'task': 'profiles.tasks.clean_non_activated_users',
+        'schedule': timedelta(days=1),  # Run every 24 hours
+    },
 }
 CELERY_TIMEZONE = 'UTC'
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1


### PR DESCRIPTION
@Didayolo 


# Description
Sometimes users create accounts and do not activate them. To keep our db clean we want to delete the non activated users who have created accounts but have not activated their accounts for more than 3 days. The auto-task will run every 24 hours to check for such accounts and will delete them


# Issues this PR resolves
- #1884



# A checklist for hand testing
- [x] change the time of task in `base.py` to maybe 5 minutes to test locally
```
'clean_non_activated_users': {
        'task': 'profiles.tasks.clean_non_activated_users',
        'schedule': timedelta(minutes=5),  # Run every 5 minutes
    },
```
- [x] change the time of account creation in `profiles/tasks.py` to maybe 1 minutes to test locally
```
 three_days_ago = now() - timedelta(minutes=1)
```
- [x] Create users and do not activate them, check that the `clean_non_activated_users` task runs and deletes the non-activated users




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

