### PR TITLE
User model filters - remove `deleted`

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -588,7 +588,7 @@ class Run:
         Function responsible for running program directory
 
         Args:
-            - program_dir : can be either ingestion program or program/submission
+            - program_dir : can be either ingestion program or program(submission or scoring)
             - kind : either `program` or `ingestion`
         """
         # If the directory doesn't even exist, move on
@@ -609,6 +609,9 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
+                # Copy program dir content to output directory because in case of only result submission, 
+                # we need to copy the result submission files because the scoring program will use these as predictions
+                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -8,7 +8,7 @@ class UserAdmin(admin.ModelAdmin):
     change_form_template = "admin/auth/user/change_form.html"
     change_list_template = "admin/auth/user/change_list.html"
     search_fields = ['username', 'email']
-    list_filter = ['is_staff', 'is_superuser', 'deleted', 'is_deleted', 'is_bot']
+    list_filter = ['is_staff', 'is_superuser', 'is_deleted', 'is_bot']
     list_display = ['username', 'email', 'is_staff', 'is_superuser']
 
 


### PR DESCRIPTION
@Didayolo 


# Description
This PR removes the unused `deleted` filter from the users model in the django admin interface.

Before:
<img width="294" alt="Screenshot 2025-06-18 at 5 41 54 PM" src="https://github.com/user-attachments/assets/d20a57c8-f2d0-422e-8d20-11deb8541428" />

After:
<img width="268" alt="Screenshot 2025-06-18 at 5 42 20 PM" src="https://github.com/user-attachments/assets/875cd0c1-70c9-4928-b237-9e11ac208b75" />




# Issues this PR resolves
- #1886



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

