### PR TITLE
Filters added in public competitions page

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -456,6 +456,8 @@ class CompetitionSerializerSimple(serializers.ModelSerializer):
             'contact_email',
             'report',
             'is_featured',
+            'submissions_count',
+            'participants_count'
         )
 
     def get_created_by(self, obj):

--- a/src/apps/api/tests/test_public_competitions.py
+++ b/src/apps/api/tests/test_public_competitions.py
@@ -1,0 +1,202 @@
+from rest_framework.test import APIClient
+from django.test import TestCase
+from factories import (
+    UserFactory,
+    CompetitionFactory,
+    CompetitionParticipantFactory,
+)
+
+
+class PublicCompetitionsTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        # Users
+        self.user = UserFactory(username="user1")
+        self.organizer = UserFactory(username="organizer")
+        self.other_user = UserFactory(username="other")
+
+        # Login the test client
+        self.client.force_authenticate(user=self.user)
+
+        # Competitions
+        self.competition1 = CompetitionFactory(title="AI Challenge", published=True, created_by=self.organizer)
+        self.competition2 = CompetitionFactory(title="Vision Contest", published=True)
+        self.competition3 = CompetitionFactory(title="ML Challenge", published=True, created_by=self.other_user)
+
+        # Add collaborators
+        self.competition1.collaborators.add(self.user)
+
+        # Participating user
+        CompetitionParticipantFactory(user=self.user, competition=self.competition2, status="approved")
+
+        # Add submission counts and participants counts manually
+        self.competition1.submissions_count = 10
+        self.competition1.participants_count = 20
+        self.competition1.save()
+
+        self.competition2.submissions_count = 5
+        self.competition2.participants_count = 15
+        self.competition2.save()
+
+        self.competition3.submissions_count = 0
+        self.competition3.participants_count = 5
+        self.competition3.save()
+
+    def test_default_ordering(self):
+        # Send GET request to the public competitions API without any ordering parameter
+        # This should trigger the default ordering, which is by 'id' in descending order (most recent first)
+        response = self.client.get("/api/competitions/public/")
+
+        # Ensure the response status is 200 (OK)
+        self.assertEqual(response.status_code, 200)
+
+        # Extract competition IDs from the response data
+        ids = [comp["id"] for comp in response.data["results"]]
+
+        # Assert that the competition IDs are sorted in descending order
+        # This confirms that the default ordering (-id) is correctly applied
+        self.assertTrue(ids == sorted(ids, reverse=True))  # ordered by -id
+
+    def test_ordering_by_participants_count(self):
+        # Send GET request to the public competitions API with ordering set to 'popular'
+        # This should return competitions ordered by participants_count in descending order
+        response = self.client.get("/api/competitions/public/?ordering=popular")
+
+        # Check that the response status is 200 (OK)
+        self.assertEqual(response.status_code, 200)
+
+        # Extract the list of competition results from the response
+        results = response.data["results"]
+
+        # Create a list of participants_count from the results
+        participants_counts = [c["participants_count"] for c in results]
+
+        # Verify that the participants_count list is sorted in descending order
+        # This ensures the 'popular' ordering filter is applied correctly
+        self.assertEqual(participants_counts, sorted(participants_counts, reverse=True))
+
+    def test_ordering_by_submissions_count(self):
+        # Send GET request to the public competitions API with ordering by 'with_most_submissions'
+        # This should return competitions ordered by submissions_count in descending order
+        response = self.client.get("/api/competitions/public/?ordering=with_most_submissions")
+
+        # Ensure the response was successful
+        self.assertEqual(response.status_code, 200)
+
+        # Extract the results list from the response
+        results = response.data["results"]
+
+        # Get the list of submissions_count values from the returned competitions
+        submissions_counts = [c["submissions_count"] for c in results]
+
+        # Assert that the list is sorted in descending order
+        # This ensures that the ordering filter by submissions count is working correctly
+        self.assertEqual(submissions_counts, sorted(submissions_counts, reverse=True))
+
+    def test_filter_by_title_search(self):
+        # Send GET request to the public competitions API with the search query "vision"
+        # This should return only competitions with "vision" in their title (case-insensitive)
+        response = self.client.get("/api/competitions/public/?search=vision")
+
+        # Ensure the response was successful
+        self.assertEqual(response.status_code, 200)
+
+        # Extract and lowercase all returned competition titles
+        titles = [comp["title"].lower() for comp in response.data["results"]]
+
+        # Assert that every returned title contains the word "vision"
+        # This verifies that the search filter is working correctly
+        self.assertTrue(all("vision" in title for title in titles))
+
+    def test_filter_by_participating_in(self):
+        # Send GET request to the public competitions API with the filter: participating_in=true
+        # This should return competitions where the user is an approved participant
+        response = self.client.get("/api/competitions/public/?participating_in=true")
+
+        # Ensure the response was successful
+        self.assertEqual(response.status_code, 200)
+
+        # Extract the list of competition IDs from the response
+        returned_ids = [comp["id"] for comp in response.data["results"]]
+
+        # Check that the competition the user is participating in (self.competition2) is included
+        self.assertIn(self.competition2.id, returned_ids)
+
+        # Check that the competition the user is NOT participating in (self.competition1) is excluded
+        self.assertNotIn(self.competition3.id, returned_ids)  # Not participating in this
+
+    def test_filter_by_organizing(self):
+        # Send GET request to the public competitions API with the filter: organizing=true
+        # This should return competitions where the request user is the creator or a collaborator
+        response = self.client.get("/api/competitions/public/?organizing=true")
+
+        # Ensure the response is successful
+        self.assertEqual(response.status_code, 200)
+
+        # Extract all returned competition IDs from the response
+        returned_ids = [comp["id"] for comp in response.data["results"]]
+
+        # Verify that the competition created by the user (self.competition1) is present in the results
+        self.assertIn(self.competition1.id, returned_ids)
+
+        # Verify that a competition the user is not organizing (self.competition2) is not included
+        self.assertNotIn(self.competition2.id, returned_ids)  # Not organizing
+
+    def test_combined_filters(self):
+        # Send GET request to the public competitions API
+        # with both filters: participating_in=true and search="vision"
+        response = self.client.get("/api/competitions/public/?participating_in=true&search=vision")
+
+        # Ensure the response is successful
+        self.assertEqual(response.status_code, 200)
+
+        # Extract the results from the paginated response
+        results = response.data["results"]
+
+        # Expect only one competition to match both filters
+        self.assertEqual(len(results), 1)
+
+        # Confirm that the returned competition is the one the user is participating in,
+        # and whose title includes the word "vision"
+        self.assertEqual(results[0]["id"], self.competition2.id)
+
+    def test_auth_required_for_participating_in_filter(self):
+        # Log out the currently authenticated user to simulate an anonymous request
+        self.client.force_authenticate(user=None)
+
+        # Send GET request to the public competitions API with participating_in=true
+        # Expect this to fail because the user is not authenticated
+        response = self.client.get("/api/competitions/public/?participating_in=true")
+
+        # Ensure the response has status code 401 (Unauthorized)
+        self.assertEqual(response.status_code, 401)
+
+        # Confirm that the error message is included in the response
+        self.assertIn("detail", response.data)
+
+        # Confirm the error message explicitly states the reason
+        self.assertEqual(
+            response.data["detail"],
+            "Authentication required for filtering by participating in or organizing."
+        )
+
+    def test_auth_required_for_organizing_filter(self):
+        # Log out the currently authenticated user to simulate an anonymous request
+        self.client.force_authenticate(user=None)
+
+        # Send GET request to the public competitions API with organizing=true
+        # Expect this to fail because the user is not authenticated
+        response = self.client.get("/api/competitions/public/?organizing=true")
+
+        # Ensure the response has status code 401 (Unauthorized)
+        self.assertEqual(response.status_code, 401)
+
+        # Confirm that the error message is included in the response
+        self.assertIn("detail", response.data)
+
+        # Confirm the error message explicitly states the reason
+        self.assertEqual(
+            response.data["detail"],
+            "Authentication required for filtering by participating in or organizing."
+        )

--- a/src/static/riot/competitions/public-list.tag
+++ b/src/static/riot/competitions/public-list.tag
@@ -1,240 +1,405 @@
 <public-list>
-    <h1>Public Benchmarks and Competitions</h1>
-    <div class="pagination-nav"> 
-        <button show="{competitions.previous}" onclick="{handle_ajax_pages.bind(this, -1)}" class="float-left ui inline button active">Back</button>
-        <button hide="{competitions.previous}" disabled="disabled" class="float-left ui inline button disabled">Back</button>
-        { current_page } of {Math.ceil(competitions.count/competitions.page_size)}
-        <button show="{competitions.next}" onclick="{handle_ajax_pages.bind(this, 1)}" class="float-right ui inline button active">Next</button>
-        <button hide="{competitions.next}" disabled="disabled" class="float-right ui inline button disabled">Next</button>
+  <!-- Title -->
+  <h1 class="page-title">Public Benchmarks and Competitions</h1>
+
+  <!-- Two-column layout -->
+  <div class="content-container">
+
+    <!-- Filters -->
+    <div class="filters-panel">
+        <!-- Filters main heading   -->
+        <h3>Filters</h3>
+
+        <!--  Search by title filter  -->
+        <div class="filter-group">
+            <label class="filter-label" for="search-title"><strong>Search by Title</strong></label>
+            <input type="text" id="search-title" oninput="{on_title_input}" placeholder="Enter title...">
+        </div>
+
+        <!-- Order by filter   -->
+        <div class="filter-group">
+            <strong class="filter-label">Order By</strong>
+            <label><input type="radio" name="order" value="popular" onchange="{set_ordering}"> Most popular first</label>
+            <label><input type="radio" name="order" value="recent" onchange="{set_ordering}"> Recently added first</label>
+            <label><input type="radio" name="order" value="with_most_submissions" onchange="{set_ordering}"> With most submissions first</label>
+        </div>
+
+        <!-- Your competitions filters   -->
+        <div class="filter-group">
+            <strong class="filter-label">Your Competitions</strong>
+            <label><input type="checkbox" onchange="{toggle_participating}"> Participating In</label>
+            <label><input type="checkbox" onchange="{toggle_organizing}"> Organizing</label>
+        </div>
+
+        <!--  Clear filters  -->
+        <div class="filter-group" show="{should_show_clear_filters()}">
+            <button class="clear-filters-btn" onclick="{clear_all_filters}">Clear All Filters</button>
+        </div>
     </div>
-    <div id="loading" class="loading-indicator" show="{!competitions}">
+
+    <!-- Competitions -->
+    <div class="list-panel">
+
+      <div id="loading" class="loading-indicator" show="{!competitions}">
         <div class="spinner"></div>
-    </div>
-    <div each="{competition in competitions.results}">
-            <div class="tile-wrapper">
-                <div class="ui square tiny bordered image img-wrapper">
-                    <img src="{competition.logo_icon ? competition.logo_icon : competition.logo}" loading="lazy">
-                </div>
-                <a class="link-no-deco" href="../{competition.id}">
-                    <div class="comp-info">
-                        <h4 class="heading">
-                            {competition.title}
-                        </h4>
-                        <p class="comp-description">
-                            { pretty_description(competition.description)}
-                        </p>
-                        <p class="organizer">
-                            <em>Organized by: <strong>{competition.created_by}</strong></em>
-                        </p>
-                    </div>
-                </a>
-                <div class="comp-stats">
-                    {pretty_date(competition.created_when)}
-                    <div if="{!competition.reward && ! competition.report}" class="ui divider"></div>
-                    <div>
-                        <span if="{competition.reward}"><img width="30" height="30" src="/static/img/trophy.png"></span>
-                        <span if="{competition.report}"><a href="{competition.report}" target="_blank"><img width="30" height="30" src="/static/img/paper.png"></span></a>
-                    </div>
-                    <strong>{competition.participants_count}</strong> Participants
-                </div>
+      </div>
+
+      <div each="{competition in competitions.results}">
+        <div class="tile-wrapper">
+          <div class="ui square tiny bordered image img-wrapper">
+            <img src="{competition.logo_icon ? competition.logo_icon : competition.logo}" loading="lazy">
+          </div>
+          <a class="link-no-deco" href="../{competition.id}">
+            <div class="comp-info">
+              <h4 class="heading">{competition.title}</h4>
+              <p class="comp-description">{ pretty_description(competition.description) }</p>
+              <p class="organizer"><em>Organized by: <strong>{competition.created_by}</strong></em></p>
             </div>
-    </div>
-    <div class="pagination-nav" hide="{(competitions.count < 10)}">
+          </a>
+          <div class="comp-stats">
+            {pretty_date(competition.created_when)}
+            <div if="{!competition.reward && ! competition.report}" class="ui divider"></div>
+            <div>
+              <span if="{competition.reward}"><img width="30" height="30" src="/static/img/trophy.png"></span>
+              <span if="{competition.report}"><a href="{competition.report}" target="_blank"><img width="30" height="30" src="/static/img/paper.png"></a></span>
+            </div>
+            <strong>{competition.participants_count}</strong> Participants
+          </div>
+        </div>
+      </div>
+
+      <div class="pagination-nav" hide="{(competitions.count < 20)}">
         <button show="{competitions.previous}" onclick="{handle_ajax_pages.bind(this, -1)}" class="float-left ui inline button active">Back</button>
         <button hide="{competitions.previous}" disabled="disabled" class="float-left ui inline button disabled">Back</button>
         { current_page } of {Math.ceil(competitions.count/competitions.page_size)}
         <button show="{competitions.next}" onclick="{handle_ajax_pages.bind(this, 1)}" class="float-right ui inline button active">Next</button>
         <button hide="{competitions.next}" disabled="disabled" class="float-right ui inline button disabled">Next</button>
+      </div>
     </div>
-<script>
+  </div>
+
+  <script>
     var self = this
+    self.seach_timer = null
     self.competitions = {}
 
+    // Filters state dictionary to keep track of which filters to apply
+    self.filter_state = {
+        search: '',
+        ordering: '',
+        participating_in: false,
+        organizing: false
+    }
+    // Function to set search title (triggered when title is typed in the text box)
+    self.on_title_input = function(e) {
+        const value = e.target.value
+        self.filter_state.search = value
+        self.update()
+
+        if (self.search_timer) {
+            clearTimeout(self.search_timer)
+        }
+
+        self.search_timer = setTimeout(() => {
+            self.update_competitions_list(1)
+        }, 1000)  // wait 1 second after user stops typing
+    }
+    // Function to set ordering (triggered when a radio button is clicked)
+    self.set_ordering = function (e) {
+        self.filter_state.ordering = e.target.value
+        self.update()
+        self.update_competitions_list(1)
+    }
+    // Function to toggle participating (triggered when the checkbox is checked/uncheked)
+    self.toggle_participating = function(e) {
+        self.filter_state.participating_in = e.target.checked
+        self.update()
+        self.update_competitions_list(1)
+    }
+    // Function to toggle organizing (triggered when the checkbox is checked/uncheked)
+    self.toggle_organizing = function(e) {
+        self.filter_state.organizing = e.target.checked
+        self.update()
+        self.update_competitions_list(1)
+    }
+
+    // Function that decides to show clear filter button or not
+    self.should_show_clear_filters = function () {
+        const { search, ordering, participating_in, organizing } = self.filter_state
+        return search || ordering || participating_in || organizing
+    }
+    // Function to clear all filters
+    self.clear_all_filters = function() {
+        self.filter_state = {
+            search: '',
+            ordering: '',
+            participating_in: false,
+            organizing: false
+        }
+
+        // Clear inputs
+        document.getElementById('search-title').value = ''
+        document.querySelectorAll('input[name="order"]').forEach(r => r.checked = false)
+        document.querySelectorAll('input[type="checkbox"]').forEach(c => c.checked = false)
+
+        // Call list update
+        self.update_competitions_list(1)
+    }
+
+
     self.one("mount", function () {
-        self.update_competitions_list(self.get_url_page_number_or_default())
+        const urlParams = new URLSearchParams(window.location.search)
+
+        // Check if ordering is set in the URL (e.g., ?ordering=popular)
+        if (urlParams.has("ordering")) {
+            const ordering = urlParams.get("ordering")
+            if (["popular", "recent"].includes(ordering)) {
+            self.filter_state.ordering = ordering
+
+            // Set the corresponding radio button as checked
+            const radio = document.querySelector(`input[name="order"][value="${ordering}"]`)
+            if (radio) radio.checked = true
+            }
+        }
+        
+      self.update_competitions_list(self.get_url_page_number_or_default())
     })
 
-    self.handle_ajax_pages = function (num){
+    self.handle_ajax_pages = function (num) {
         $('.pagination-nav > button').prop('disabled', true)
         self.update_competitions_list(self.get_url_page_number_or_default() + num)
     }
 
     self.update_competitions_list = function (num) {
-        self.current_page = num;
-        $('#loading').show(); // Show the loading indicator
-        $('.pagination-nav').hide(); // Hide pagination navigation
 
-        // Function to handle successful data retrieval
+        self.current_page = num;
+        $('#loading').show();
+        $('.pagination-nav').hide();
+
         function handleSuccess(response) {
             self.competitions = response;
-            $('#loading').hide(); // Hide the loading indicator
-            $('.pagination-nav').show(); // Show pagination navigation
+            $('#loading').hide();
+            $('.pagination-nav').show();
             history.pushState("", document.title, "?page=" + self.current_page);
             $('.pagination-nav > button').prop('disabled', false);
             self.update();
         }
-        // Fetch data using AJAX call
-        return CODALAB.api.get_public_competitions({"page": self.current_page})
-            .fail(function (response) {
-                $('#loading').hide(); // Hide the loading indicator
-                $('.pagination-nav').show(); // Show pagination navigation
-                toastr.error("Could not load competition list");
-            })
-            .done(handleSuccess);
-        
+
+        return CODALAB.api.get_public_competitions({ 
+            "page": self.current_page,
+            "search": self.filter_state.search,
+            "ordering": self.filter_state.ordering,
+            "participating_in": self.filter_state.participating_in,
+            "organizing": self.filter_state.organizing
+        })
+        .fail(function (resp) {
+            $('#loading').hide()
+            $('.pagination-nav').show()
+
+            let message = "Could not load competition list"
+            if (resp.responseJSON && resp.responseJSON.detail) {
+                message = resp.responseJSON.detail
+            } else if (resp.responseText) {
+                try {
+                    const json = JSON.parse(resp.responseText)
+                    if (json.detail) {
+                        message = json.detail
+                    }
+                } catch (_) {
+                    // fallback to raw text if not JSON
+                    message = resp.responseText;
+                }
+            }
+            toastr.error(message)
+        })
+        .done(handleSuccess);
     };
 
-
     self.get_array_length = function (arr) {
-        if(arr === undefined){
-            return 0
-        }
-        return arr.length
+        return arr === undefined ? 0 : arr.length
     }
 
     self.pretty_date = function (date_string) {
-        if (!!date_string) {
-            return luxon.DateTime.fromISO(date_string).toLocaleString(luxon.DateTime.DATE_FULL)
-        } else {
-            return ''
-        }
+        return !!date_string ? luxon.DateTime.fromISO(date_string).toLocaleString(luxon.DateTime.DATE_FULL) : ''
     }
 
-    self.pretty_description = function(description){
-        return description.substring(0,120) + (description.length > 120 ? '...' : '') || ''
+    self.pretty_description = function (description) {
+        return description.substring(0, 120) + (description.length > 120 ? '...' : '') || ''
     }
 
-    self.get_url_page_number_or_default = function (){
-        let queryString = window.location.search
-        let urlParams = new URLSearchParams(queryString)
-        if(urlParams.has('page')){
+    self.get_url_page_number_or_default = function () {
+        let urlParams = new URLSearchParams(window.location.search)
+        if (urlParams.has('page')) {
             let pagenum = parseInt(urlParams.get('page'))
-            if(pagenum < 1){
-                history.pushState("test", document.title, "?page="+1)
-                return 1
-            } else {
-                return pagenum
-            }
+        if (pagenum < 1) {
+            history.pushState("test", document.title, "?page=1")
+            return 1
         } else {
-            history.pushState("test", document.title, "?page="+1)
+            return pagenum
+        }
+        } else {
+            history.pushState("test", document.title, "?page=1")
             return 1
         }
     }
 
-    $(window).on('popstate', function (event) {
+    $(window).on('popstate', function () {
         self.update_competitions_list(self.get_url_page_number_or_default())
     })
+  </script>
 
-
-</script>
-
-<style type="text/stylus">
+  <style type="text/stylus">
     public-list
-        width 100%
-    :scope
-        display block
-        margin-bottom 5px
+      width 100%
 
-    .pagination-nav
-        padding 10px 0
-        width 100%
-        text-align center
+    :scope
+      display block
+      margin-bottom 5px
+
+    .page-title
+      margin 0 0 20px 0
+      font-size 24px
+      font-weight bold
+      color #1b1b1b
+
+    .content-container
+      display flex
+      width 100%
+
+    .filters-panel
+      width 250px
+      flex-shrink 0
+      border 1px solid #ddd
+      padding 10px
+      margin-right 10px
+      margin-left 0 !important
+      background #f9f9f9
+
+        input[type="text"]
+            width 100%
+            padding 5px
+            margin 5px 0 15px 0
+            border 1px solid #ddd
+            border-radius 4px
+
+        input[type="radio"],
+        input[type="checkbox"]
+            margin-right 5px
+
+    .filter-group
         margin-bottom 20px
 
-    .float-left
-        float left
+    .filter-label
+        font-size 14px
+        font-weight bold
+        display block
+        margin-bottom 8px
 
-    .float-right
-        float right
-
-    .center
-        margin auto
-
-    .link-no-deco
-        all unset
-        text-decoration none
-        cursor pointer
-        width 100%
-
-    .tile-wrapper
-        border solid 1px gainsboro
-        display inline-flex
-        //grid-template-columns 0.1fr 3fr 1.3fr
-
-        min-width 425px
-        background-color #fff
-        transition all 75ms ease-in-out
-        color #909090
-        width 100%
+    .filter-group label
+        display block
+        font-size 13px
         margin-bottom 6px
 
-    .tile-wrapper:hover
-        box-shadow 0 3px 4px -1px #9c9c9c
-        transition all 75ms ease-in-out
-        background-color #e8e8e8
-        border solid 1px #b9b9b9
+    .list-panel
+      flex-grow 1
 
-        .comp-stats
-            background-color #344d5e
-            transition background-color 75ms ease-in-out
+    .pagination-nav
+      padding 10px 0
+      width 100%
+      text-align center
+      margin-bottom 20px
+
+    .float-left
+      float left
+
+    .float-right
+      float right
+
+    .center
+      margin auto
+
+    .link-no-deco
+      all unset
+      text-decoration none
+      cursor pointer
+      width 100%
+
+    .tile-wrapper
+      border solid 1px gainsboro
+      display inline-flex
+      min-width 425px
+      background-color #fff
+      transition all 75ms ease-in-out
+      color #909090
+      width 100%
+      margin-bottom 6px
+
+    .tile-wrapper:hover
+      box-shadow 0 3px 4px -1px #9c9c9c
+      transition all 75ms ease-in-out
+      background-color #e8e8e8
+      border solid 1px #b9b9b9
+
+      .comp-stats
+        background-color #344d5e
+        transition background-color 75ms ease-in-out
 
     .img-wrapper
-        padding 5px
-        align-self center
+      padding 5px
+      align-self center
 
-        img
-            max-height 60px !important
-            max-width 60px !important
-            margin 0 auto
+      img
+        max-height 60px !important
+        max-width 60px !important
+        margin 0 auto
 
     .comp-info
-        width calc(100% - 140px - 80px)
+      width calc(100% - 140px - 80px)
 
     .comp-info .heading
-        text-align left
-        padding 5px
-        color #1b1b1b
-        margin-bottom 0
+      text-align left
+      padding 5px
+      color #1b1b1b
+      margin-bottom 0
 
     .comp-info .comp-description
-        text-align: left;
-        font-size 13px
-        line-height 1.15em
-        margin 0.35em
-
-    .comp-stats
-        background #405e73
-        color #e8e8e8
-        padding 10px
-        text-align center
-        font-size 12px
-        width 140px
+      text-align left
+      font-size 13px
+      line-height 1.15em
+      margin 0.35em
 
     .organizer
-        font-size 13px
-        text-align left
-        margin 0.35em
+      font-size 13px
+      text-align left
+      margin 0.35em
+
+    .comp-stats
+      background #405e73
+      color #e8e8e8
+      padding 10px
+      text-align center
+      font-size 12px
+      width 140px
 
     .loading-indicator
-        display flex
-        align-items center
-        padding 20px
-        width 100%
-        margin: 0 auto;
+      display flex
+      align-items center
+      padding 20px
+      width 100%
+      margin 0 auto
 
     .spinner
-        border 4px solid rgba(0,0,0,.1)
-        width 36px
-        height 36px
-        border-radius 50%
-        border-top-color #3498db
-        animation spin 1s ease-in-out infinite
+      border 4px solid rgba(0,0,0,.1)
+      width 36px
+      height 36px
+      border-radius 50%
+      border-top-color #3498db
+      animation spin 1s ease-in-out infinite
 
     @keyframes spin
-        0%
-            transform rotate(0deg)
-        100%
-            transform rotate(360deg)
-</style>
-
+      0%
+        transform rotate(0deg)
+      100%
+        transform rotate(360deg)
+  </style>
 </public-list>

--- a/src/static/riot/competitions/tile/front_page_competitions.tag
+++ b/src/static/riot/competitions/tile/front_page_competitions.tag
@@ -13,7 +13,7 @@
                 </div>
             </div>
             <competition-tile each="{popular_competitions}"></competition-tile>
-            <a class="show-more" href="/competitions/public/">Show more</a>
+            <a class="show-more" href="/competitions/public/?ordering=popular">Show more</a>
         </div>
 
         <div class="eight wide column">
@@ -29,7 +29,7 @@
                 </div>
             </div>
             <competition-tile each="{recent_competitions}"></competition-tile>
-            <a class="show-more" href="/competitions/public/">Show more</a>
+            <a class="show-more" href="/competitions/public/?ordering=recent">Show more</a>
         </div>
     </div>
 


### PR DESCRIPTION
# Description
This PR has the following changes:
- add filters to the public competition page (search title --- order based on recent, popular, submissions --- show comps you are organizing or participating in)
- activate the concerned filters when you click Show more button for Recent or Popular benchmarks on the home page
- tests added for public competitions

# Screenshots
Filter page 
<img width="1234" alt="Screenshot 2025-06-25 at 5 48 00 PM" src="https://github.com/user-attachments/assets/8418b1e8-6e3e-41fa-ab93-563f5dfa3f96" />

Error when user is not loggedin and tries to use `participaitng in` and `organizing` filters
<img width="408" alt="Screenshot 2025-06-25 at 5 48 07 PM" src="https://github.com/user-attachments/assets/266f8a9f-8dcc-4690-ab8e-ea675d8099bc" />


# Issues this PR resolves
- #1895 -> Filters



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

