### PR TITLE
Submission delete API bug fixed. More restrictions added

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -179,11 +179,27 @@ class SubmissionViewSet(ModelViewSet):
         return super(SubmissionViewSet, self).create(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
+        """
+        - If a user is owner of a submission and submission is not on the leaderboard, user can delete the submission using the delete API
+        - If a user is either super user or admin of the competition of the submission, user can delete the submission
+        - If user is neither owner nor admin, user cannot delete the submission
+        """
         submission = self.get_object()
 
-        if request.user != submission.owner and not self.has_admin_permission(request.user, submission):
-            raise PermissionDenied("Cannot interact with submission you did not make")
+        is_owner = request.user == submission.owner
+        is_super_user_or_competition_admin = self.has_admin_permission(request.user, submission)
 
+        # If user is neither owner nor super user/admin
+        # return permission denied
+        if not is_owner and not is_super_user_or_competition_admin:
+            raise PermissionDenied("You do not have permission to delete this submission!")
+
+        # If user is owner but submission is on the leaderboard
+        # return permission denied
+        if is_owner and submission.leaderboard:
+            raise PermissionDenied("You cannot delete a leaderboard submission!")
+
+        # Otherwise, delete the submission
         self.perform_destroy(submission)
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
# Description
users were able to delete leaderboard submissions using the API. Now that is fixed


# Issues this PR resolves
- #1819



# A checklist for hand testing
- [ ] check that super user or competition admin can delete any submission even on the leaderboard
- [ ] check that owners can only delete their submissions that are not on the leaderboard
- [ ] check that other users cannot delete someone else submissions


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

