### PR TITLE
Option added to download all participants

### DIFF
--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -213,14 +213,17 @@
             $(self.refs.email_modal).modal('hide')
         }
 
-        // Download participants in csv file
+        // Function to download participants in csv file
         self.download_participants_csv = () => {
+            // Show warning when there is no participant
             if (!self.participants || self.participants.length === 0) {
                 toastr.warning('No participants to download')
                 return
             }
 
+            // prepare csv header
             const headers = ['ID', 'Username', 'Email', 'Is Bot', 'Status'];
+            // prepare csv rows
             const rows = self.participants.map(p => [
                 p.id,
                 p.username,
@@ -229,10 +232,12 @@
                 p.status
             ]);
 
+            // prepare csv content using header and rows
             const csvContent = [headers, ...rows]
                 .map(e => e.map(v => `"${(v ?? '').toString().replace(/"/g, '""')}"`).join(','))
                 .join('\n')
 
+            // Download prepared csv as `participants.csv`
             const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
             const url = URL.createObjectURL(blob)
             const link = document.createElement("a")

--- a/src/static/riot/competitions/detail/participant_manager.tag
+++ b/src/static/riot/competitions/detail/participant_manager.tag
@@ -16,7 +16,16 @@
             <input type="checkbox" ref="participant_show_deleted" onchange="{ update_participants.bind(this, undefined) }">
             <label>Show deleted accounts</label>
         </div>
-        <div class="ui blue icon button" onclick="{show_email_modal.bind(this, undefined)}"><i class="envelope icon"></i> Email all participants</div>
+        <div style="margin-top: 1em;">
+            <!--  Email all participants button  -->
+            <div class="ui blue icon button" onclick="{show_email_modal.bind(this, undefined)}">
+                <i class="envelope icon"></i> Email all participants
+            </div>
+            <!--  Download all participants button  -->
+            <div class="ui blue icon button" onclick="{download_participants_csv}">
+                <i class="download icon"></i> Download all participants
+            </div>
+        </div>
         <table class="ui celled striped table">
             <thead>
             <tr>
@@ -202,6 +211,36 @@
 
         self.close_email_modal = () => {
             $(self.refs.email_modal).modal('hide')
+        }
+
+        // Download participants in csv file
+        self.download_participants_csv = () => {
+            if (!self.participants || self.participants.length === 0) {
+                toastr.warning('No participants to download')
+                return
+            }
+
+            const headers = ['ID', 'Username', 'Email', 'Is Bot', 'Status'];
+            const rows = self.participants.map(p => [
+                p.id,
+                p.username,
+                p.email,
+                p.is_bot ? 'Yes' : 'No',
+                p.status
+            ]);
+
+            const csvContent = [headers, ...rows]
+                .map(e => e.map(v => `"${(v ?? '').toString().replace(/"/g, '""')}"`).join(','))
+                .join('\n')
+
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+            const url = URL.createObjectURL(blob)
+            const link = document.createElement("a")
+            link.setAttribute("href", url)
+            link.setAttribute("download", "participants.csv")
+            document.body.appendChild(link)
+            link.click()
+            document.body.removeChild(link)
         }
 
     </script>


### PR DESCRIPTION
# Description
This PR adds an option to allow competition organizers to download a list of all participants

Participants tab now has a new `download all participants` button.
<img width="946" alt="Screenshot 2025-07-03 at 5 12 12 PM" src="https://github.com/user-attachments/assets/359675c2-658f-4894-904c-98e43ea02631" />

When you click this button you get a csv like this: [participants.csv](https://github.com/user-attachments/files/21036885/participants.csv)


# Issues this PR resolves
- #1470




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

