### PR TITLE
Phase creation from ui with starting_kit/public_data bug fixed

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -227,8 +227,19 @@ class CompetitionViewSet(ModelViewSet):
             leaderboard.is_valid()
             leaderboard.save()
             leaderboard_id = leaderboard["id"].value
+
+            # Set leaderboard id, starting kit and public data for phases
             for phase in data['phases']:
                 phase['leaderboard'] = leaderboard_id
+
+                try:
+                    phase['public_data'] = Data.objects.filter(key=phase['public_data']['value'])[0].id
+                except TypeError:
+                    phase['public_data'] = None
+                try:
+                    phase['starting_kit'] = Data.objects.filter(key=phase['starting_kit']['value'])[0].id
+                except TypeError:
+                    phase['starting_kit'] = None
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
# Description
Creating a compeittion from UI where phase has public data or starting kit was failing because from the front end the startingkit/pub_data was sent as a dict instead of their ids. Now with this change, the dict is converted to ids just like it is done in the competition update method. 


# Issues this PR resolves
- #1801



# A checklist for hand testing
- [ ] Create a new competition using the UI, Add public data and starting kit to a new phase, check that you don't get any error. 
- [ ] When competition is created, check that the public data and starting kit are properly added to the competition.



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

