### PR TITLE
Put back copy of submission files into prediction output in compute worker

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -609,6 +609,9 @@ class Run:
                 logger.info(
                     "Program directory missing metadata, assuming it's going to be handled by ingestion"
                 )
+                # Copy submission files into prediction output
+                # This is useful for results submissions but wrongly uses storage
+                shutil.copytree(program_dir, self.output_dir)
                 return
             else:
                 raise SubmissionException("Program directory missing 'metadata.yaml/metadata'")


### PR DESCRIPTION
# Mention of reviewer

@ihsaan-ullah 

# Description

Put back copy of submission files into prediction output in compute worker

It was remove to try to solve #1833 (PR #1841) but broke results submissions.

This PR revert back this change. We need in the future to move the duplication in scoring program instead of ingestion program to avoid using storage wrongly.


# A checklist for hand testing
- [x] Test code submissions
- [x] Test results submissions
- [x] Check that submissions files are visible inside the "output from prediction step"


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

