### PR TITLE
File size for submissions clarified

### DIFF
--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -78,7 +78,14 @@ class DataDetailSerializer(serializers.ModelSerializer):
     created_by = serializers.CharField(source='created_by.username', read_only=True)
     owner_display_name = serializers.SerializerMethodField()
     competition = serializers.SerializerMethodField()
+    file_size = serializers.SerializerMethodField()
     value = serializers.CharField(source='key', required=False)
+
+    # These fields will be conditionally returned for type == SUBMISSION only
+    submission_file_size = serializers.SerializerMethodField()
+    prediction_file_size = serializers.SerializerMethodField()
+    scoring_file_size = serializers.SerializerMethodField()
+    detailed_file_size = serializers.SerializerMethodField()
 
     class Meta:
         model = Data
@@ -96,10 +103,71 @@ class DataDetailSerializer(serializers.ModelSerializer):
             'value',
             'was_created_by_competition',
             'in_use',
-            'file_size',
             'competition',
             'file_name',
+            'file_size',
+            'submission_file_size',
+            'prediction_file_size',
+            'scoring_file_size',
+            'detailed_file_size',
         )
+
+    def to_representation(self, instance):
+        """
+        Called automatically by DRF when serializing a model instance to JSON.
+
+        This method customizes the serialized output of the DataDetailSerializer.
+        Specifically, it removes detailed file size fields when the data type is not 'SUBMISSION'. 
+
+        Example: For input_data or scoring_program types, submission-related fields 
+        are not relevant and will be excluded from the output.
+        """
+        # First, generate the default serialized representation using the parent method
+        rep = super().to_representation(instance)
+
+        # If this data object is NOT of type 'submission', remove the following fields
+        if instance.type != Data.SUBMISSION:
+            # These fields are only meaningful for submission-type data
+            rep.pop('submission_file_size', None)
+            rep.pop('prediction_file_size', None)
+            rep.pop('scoring_file_size', None)
+            rep.pop('detailed_file_size', None)
+
+        # Return the final customized representation
+        return rep
+
+    def get_file_size(self, obj):
+        # Check if the data object is of type 'SUBMISSION'
+        if obj.type == Data.SUBMISSION:
+            # Start with the base file size of the data file itself (if present)
+            total_size = obj.file_size or 0
+
+            # Loop through all submissions that use this data
+            for submission in obj.submission.all():
+                # Add the size of the prediction result file (if any)
+                total_size += submission.prediction_result_file_size or 0
+                # Add the size of the scoring result file (if any)
+                total_size += submission.scoring_result_file_size or 0
+                # Add the size of the detailed result file (if any)
+                total_size += submission.detailed_result_file_size or 0
+
+            # Return the combined size of data file and all associated result files
+            return total_size
+
+        # For non-submission data types, just return the file size as-is
+        return obj.file_size
+
+    def get_submission_file_size(self, obj):
+        return obj.file_size or 0
+
+    def get_prediction_file_size(self, obj):
+        return sum([s.prediction_result_file_size or 0 for s in obj.submission.all()])
+
+    def get_scoring_file_size(self, obj):
+        return sum([s.scoring_result_file_size or 0 for s in obj.submission.all()])
+
+    def get_detailed_file_size(self, obj):
+        return sum([s.detailed_result_file_size or 0 for s in obj.submission.all()])
 
     def get_competition(self, obj):
         if obj.competition:

--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -83,9 +83,9 @@ class DataDetailSerializer(serializers.ModelSerializer):
 
     # These fields will be conditionally returned for type == SUBMISSION only
     submission_file_size = serializers.SerializerMethodField()
-    prediction_file_size = serializers.SerializerMethodField()
-    scoring_file_size = serializers.SerializerMethodField()
-    detailed_file_size = serializers.SerializerMethodField()
+    prediction_result_file_size = serializers.SerializerMethodField()
+    scoring_result_file_size = serializers.SerializerMethodField()
+    detailed_result_file_size = serializers.SerializerMethodField()
 
     class Meta:
         model = Data
@@ -107,9 +107,9 @@ class DataDetailSerializer(serializers.ModelSerializer):
             'file_name',
             'file_size',
             'submission_file_size',
-            'prediction_file_size',
-            'scoring_file_size',
-            'detailed_file_size',
+            'prediction_result_file_size',
+            'scoring_result_file_size',
+            'detailed_result_file_size',
         )
 
     def to_representation(self, instance):
@@ -129,9 +129,9 @@ class DataDetailSerializer(serializers.ModelSerializer):
         if instance.type != Data.SUBMISSION:
             # These fields are only meaningful for submission-type data
             rep.pop('submission_file_size', None)
-            rep.pop('prediction_file_size', None)
-            rep.pop('scoring_file_size', None)
-            rep.pop('detailed_file_size', None)
+            rep.pop('prediction_result_file_size', None)
+            rep.pop('scoring_result_file_size', None)
+            rep.pop('detailed_result_file_size', None)
 
         # Return the final customized representation
         return rep
@@ -160,13 +160,13 @@ class DataDetailSerializer(serializers.ModelSerializer):
     def get_submission_file_size(self, obj):
         return obj.file_size or 0
 
-    def get_prediction_file_size(self, obj):
+    def get_prediction_result_file_size(self, obj):
         return sum([s.prediction_result_file_size or 0 for s in obj.submission.all()])
 
-    def get_scoring_file_size(self, obj):
+    def get_scoring_result_file_size(self, obj):
         return sum([s.scoring_result_file_size or 0 for s in obj.submission.all()])
 
-    def get_detailed_file_size(self, obj):
+    def get_detailed_result_file_size(self, obj):
         return sum([s.detailed_result_file_size or 0 for s in obj.submission.all()])
 
     def get_competition(self, obj):

--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -117,9 +117,9 @@ class DataDetailSerializer(serializers.ModelSerializer):
         Called automatically by DRF when serializing a model instance to JSON.
 
         This method customizes the serialized output of the DataDetailSerializer.
-        Specifically, it removes detailed file size fields when the data type is not 'SUBMISSION'. 
+        Specifically, it removes detailed file size fields when the data type is not 'SUBMISSION'.
 
-        Example: For input_data or scoring_program types, submission-related fields 
+        Example: For input_data or scoring_program types, submission-related fields
         are not relevant and will be excluded from the output.
         """
         # First, generate the default serialized representation using the parent method

--- a/src/apps/api/views/datasets.py
+++ b/src/apps/api/views/datasets.py
@@ -52,8 +52,15 @@ class DataViewSet(ModelViewSet):
 
             # filter datasets and programs
             if is_dataset:
-                qs = qs.filter(~Q(type=Data.SUBMISSION))
-                qs = qs.exclude(Q(type=Data.COMPETITION_BUNDLE))
+                qs = qs.filter(type__in=[
+                    Data.INPUT_DATA,
+                    Data.PUBLIC_DATA,
+                    Data.REFERENCE_DATA,
+                    Data.INGESTION_PROGRAM,
+                    Data.SCORING_PROGRAM,
+                    Data.STARTING_KIT,
+                    Data.SOLUTION
+                ])
 
             # filter bundles
             if is_bundle:

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -138,15 +138,15 @@
                 </tr>
                 <tr>
                     <td>Prediction result:</td>
-                    <td>{pretty_bytes(selected_row.prediction_file_size)}</td>
+                    <td>{pretty_bytes(selected_row.prediction_result_file_size)}</td>
                 </tr>
                 <tr>
                     <td>Scoring result:</td>
-                    <td>{pretty_bytes(selected_row.scoring_file_size)}</td>
+                    <td>{pretty_bytes(selected_row.scoring_result_file_size)}</td>
                 </tr>
                 <tr>
                     <td>Detailed result:</td>
-                    <td>{pretty_bytes(selected_row.detailed_file_size)}</td>
+                    <td>{pretty_bytes(selected_row.detailed_result_file_size)}</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -125,6 +125,31 @@
                     {selected_row.description}
                 </div>
             </virtual>
+            <table class="ui compact basic table">
+                <thead>
+                <tr>
+                    <th colspan=2>File Sizes</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td style="width: 180px;">Submission:</td>
+                    <td>{pretty_bytes(selected_row.submission_file_size)}</td>
+                </tr>
+                <tr>
+                    <td>Prediction result:</td>
+                    <td>{pretty_bytes(selected_row.prediction_file_size)}</td>
+                </tr>
+                <tr>
+                    <td>Scoring result:</td>
+                    <td>{pretty_bytes(selected_row.scoring_file_size)}</td>
+                </tr>
+                <tr>
+                    <td>Detailed result:</td>
+                    <td>{pretty_bytes(selected_row.detailed_file_size)}</td>
+                </tr>
+                </tbody>
+            </table>
         </div>
         <div class="actions">
             <button show="{selected_row.created_by === CODALAB.state.user.username}"


### PR DESCRIPTION
# Description
This PR has the following updates
- In resource submissions tab now submission size is a sum of the actual submission size, prediction, scoring, detailed results size
- By clicking on submission, the UI now shows details about the file sizes.
- Datasets API queryset updated to clearly show what is included when datasets and programs filter is used
- NOTE 1: Submission shown in the resource table are actually datasets and NOT actual submissions.  
- NOTE 2: one dataset(data object) can be used by multiple submissions, so the file size shown is a sum of all the submissions file sizes. Please check the serializer updates to understand this. 
- The serializer used for submissions and datasets is one that is why if dataset type is not `SUBMISSION` then the irrelevant fields are removed. I tried to add minimum changes to this serializer for nwo. In the future when we want to review APIs, we can design separate APIs for submissions and datasets.

### Screenshots
File size submissions tab
<img width="1143" height="412" alt="Screenshot 2025-07-12 at 5 01 28 PM" src="https://github.com/user-attachments/assets/3626c807-f0c9-4017-9907-3c96d4e7978a" />

File sizes in submission detail
<img width="926" height="517" alt="Screenshot 2025-07-12 at 5 01 16 PM" src="https://github.com/user-attachments/assets/14712d72-485a-4f5d-922c-23836ee582c7" />



# Issues this PR resolves
- #1924



# A checklist for hand testing
- [x] upload submissions and check that the total size and individual file sizes (prediction, scoring, detailed result) are correct.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

