### PR TITLE
Update mc command from "config host add" to "alias set"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       /bin/sh -c "
       set -x;
       if [ -n \"$MINIO_ACCESS_KEY\" ] && [ -n \"$MINIO_SECRET_KEY\" ] && [ -n \"$MINIO_PORT\" ]; then
-        until /usr/bin/mc config host add minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do 
+        until /usr/bin/mc alias set minio_docker http://minio:$MINIO_PORT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY && break; do 
           echo '...waiting...' && sleep 5; 
         done;
         /usr/bin/mc mb minio_docker/$AWS_STORAGE_BUCKET_NAME || echo 'Bucket $AWS_STORAGE_BUCKET_NAME already exists.';


### PR DESCRIPTION
Mention of reviewers: @ObadaS @ihsaan-ullah 

# Description

In our `docker-compose.yml`, the `mc config` syntax is outdated (since 2022):

https://github.com/codalab/codabench/blob/dc19e4a96cffbc54fec6da644403cb22c81a6145/docker-compose.yml#L81

This PR simply replace `mc config host add` by `mc alias set`.

Reference:
- https://github.com/minio/mc/issues/3421#issuecomment-2907925507
- https://docs.min.io/enterprise/aistor-object-store/reference/cli/mc-alias/mc-alias-set/

# Issues this PR resolves
- #1926



# A checklist for hand testing
- [x] Setup a local Codabench from scratch (`create-buckets` must be called) and check that everything is working fine.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

