### PR TITLE
clamp length of competition search results description

### DIFF
--- a/src/static/stylus/base_template.styl
+++ b/src/static/stylus/base_template.styl
@@ -252,6 +252,12 @@ body.pushable>.pusher
     max-height 25em !important
     overflow-y scroll !important
 
+#site-wide-competition-search .description
+    display -webkit-box
+    -webkit-box-orient vertical
+    -webkit-line-clamp 5
+    overflow hidden
+
 /* --------------------------------------------------------------------------------------
  Modals
  */


### PR DESCRIPTION
# @ mention of reviewers
...


# Description
Clamp the description of competition search results to n lines because they took too much space.

Unlike the description clamping in `<competition-tile>`, this uses purely css. Although the used css properties seem not well supported, it seems that they are actually.


# Issues this PR resolves
#1902 (issue title is misleading though)



# A checklist for hand testing
- [ ] (Ideally with older browser) Check that the text is clamped and ends with ellipsis


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

