### PR TITLE
Remove validation logic from tasks.py

### DIFF
--- a/src/apps/api/views/tasks.py
+++ b/src/apps/api/views/tasks.py
@@ -53,7 +53,8 @@ class TaskViewSet(ModelViewSet):
             # the public task to the user and hence we check the `retrieve` action
             if self.request.query_params.get('public') or self.action == 'retrieve':
                 task_filter |= Q(is_public=True)
-            # Set validated to False. This logic is never used in the software.
+            # Removed the "task validation" process (https://github.com/codalab/codabench/pull/1962)
+            # We now always set "validated" to False. The "task validation" was only partly implemented and never used.
             qs = qs.filter(task_filter)
             qs = qs.annotate(validated=Value(False, output_field=BooleanField()))
         return qs.order_by('-created_when').distinct()


### PR DESCRIPTION
@ObadaS @ihsaan-ullah 

# Description

Remove the "task validation" logic that is never used and makes the platform very slow.

This patch should be including in release 1.20.0.

Maybe in the future we can remove the "validated" field.

# Checklist
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

