### PR TITLE
Changed domain name setting to not show example.com but the actual domain name defined in the .env

### DIFF
--- a/src/apps/profiles/views.py
+++ b/src/apps/profiles/views.py
@@ -96,7 +96,7 @@ def activateEmail(request, user, to_email):
     mail_subject = 'Activate your user account.'
     message = render_to_string('profiles/emails/template_activate_account.html', {
         'username': user.username,
-        'domain': get_current_site(request).domain,
+        'domain': settings.DOMAIN_NAME,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': account_activation_token.make_token(user),
         'protocol': 'https' if request.is_secure() else 'http'


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Changed domain name setting to not show example.com but the actual domain name defined in the .env.
Now, the correct domain name will be shown in the Django logs as well as in emails sent.


# Issues this PR resolves
#1917 (partial)



# A checklist for hand testing
- [ ] Create an account
- [ ] Check the Django container logs link that is generated for the newly created account

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

