### PR TITLE
Fix leaderboard columns and title

### DIFF
--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -28,7 +28,7 @@
         </tr>
         <tr class="task-row">
             <th>Task:</th>
-            <th colspan=4></th>
+            <th colspan=3></th>
             <th each="{ task in filtered_tasks }" class="center aligned" colspan="{ task.colWidth }">{ task.name }</th>
         </tr>
         <tr>
@@ -254,10 +254,10 @@
             color #8c8c8c
         .index-column
             min-width 55px
-        .leaderboard-title
-            position absolute
-            left 50%
-            transform translate(-50%, 50%)
+        .leaderboard-title 
+            position: absolute
+            left: 50%
+            transform: translate(-50%, -50%)
         .ui.table > thead > tr.task-row > th
             background-color: #e8f6ff !important
         .eye-icon-link


### PR DESCRIPTION
# Description

Fix the problem of alignment of the columns (probably caused by #1912) and the leaderboard title that was displayed too low.

Now it looks this way:

<img width="948" height="160" alt="Capture d’écran 2025-08-18 à 14 08 49" src="https://github.com/user-attachments/assets/5cb0cd0e-c44f-4fb5-babc-97d28cf80688" />

# Issues this PR resolves
- closes #1861
- closes #1976



# A checklist for hand testing
- [x] Observe leaderboards and confirm they are correctly displayed



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

