### PR TITLE
Fix BestModeStrategy to exclude soft-deleted and non-finished submissions

### DIFF
--- a/src/apps/leaderboards/strategies.py
+++ b/src/apps/leaderboards/strategies.py
@@ -84,7 +84,10 @@ class BestModeStrategy(BaseModeStrategy):
         primary_col = leaderboard.columns.get(index=leaderboard.primary_index)
         ordering = [f'{"-" if primary_col.sorting == "desc" else ""}primary_col']
 
-        submissions = Submission.objects.filter(phase=phase, owner=owner) \
+        submissions = Submission.objects.filter(phase=phase,
+                                                owner=owner,
+                                                is_soft_deleted=False,
+                                                status=Submission.FINISHED) \
             .select_related('owner').prefetch_related('scores') \
             .annotate(primary_col=Sum('scores__score', filter=Q(scores__column=primary_col)))
 


### PR DESCRIPTION
# @ mention of reviewers
@ihsaan-ullah 

# A brief description of the purpose of the changes contained in this PR.
This PR ensures that `BestModeStrategy`, used for publishing results on the leaderboard by forcing the best result, only picks up submissions that have finished (and may have a score attached) and are not soft deleted.

# Issues this PR resolves
Fixes #2044
Fixes #1284 (failed submissions are now discarded, blocking n/a scores associated with failed submissions).
Fixes #1840
Fixes #2057

# A checklist for hand testing
- [ ] Create a leaderboard with "Force best" strategy
- [ ] Create a submission, it should pop up on the leaderboard, as it's the only one
- [ ] Soft delete it, it should disappear from the leaderboard but still count towards the daily/per-person limit
- [ ] Reupload the same submission (or upload a submission with a worse score), this should now be present on the leaderboard

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer

