### PR TITLE
`Datasets PR#2` Croissant metadata added

### DIFF
--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -27,6 +27,7 @@ class DataSerializer(DefaultUserCreateMixin, serializers.ModelSerializer):
             'was_created_by_competition',
             'competition',
             'file_name',
+            'license'
 
         )
         read_only_fields = (

--- a/src/templates/datasets/detail.html
+++ b/src/templates/datasets/detail.html
@@ -1,4 +1,35 @@
 {% extends "base.html" %}
+
+{% block extra_head %}
+    <!-- JSON LD Script for Dataset Search -->
+    <script type="application/ld+json">
+    {
+        "@context": {
+            "@language": "en",
+            "@vocab": "https://schema.org/",
+            "croissant": "https://mlcommons.org/croissant/1.0"
+        },
+        "conformsTo": "http://mlcommons.org/croissant/1.0",
+        "@type": "Dataset",
+        "name": "{{ object.name|escape }}",
+        "description": "{{ object.description|escape }}",
+        "url": "{{ request.build_absolute_uri }}",
+        "creator": {
+            "@type": "Person",
+            "name": "{{ object.created_by|escape }}"
+        },
+        "datePublished": "{{ object.created_when }}",
+        "license": {
+            "@type": "CreativeWork",
+            "name": "{{ object.license|escape }}"
+        },
+        "citation": "-",
+        "version": 1.0
+    }
+    </script>
+{% endblock %}
+
+
 {% block content %}
     <dataset-detail 
         id='{{ object.id }}'


### PR DESCRIPTION
# Description
This PR has updates and new features listed in the `Release 2` of the datasets issue:
- Croissant metadata is added in a json-ld script so that Google Datasets Search can search for the public datasets.
- Added a license field to the serializer to fix the issue of the license being None when a new dataset is created.


# 🚨 NOTE
Dataset version and citation are dummy for now because we don't have these fields added to the dataset model. We have to discuss about dataset version and we have to add the missing fields. I have added this point to Release 3 of the datasets issue.

# Issues this PR resolves
- #1898 -> Release 2



# A checklist for hand testing
- [x] Open dataset detail page from datasets public page, open page source and check that a smiliar script as below is there
```javascript
<script type="application/ld+json">
    {
        "@context": {
            "@language": "en",
            "@vocab": "https://schema.org/",
            "croissant": "https://mlcommons.org/croissant/1.0"
        },
        "conformsTo": "http://mlcommons.org/croissant/1.0",
        "@type": "Dataset",
        "name": "Test Dataset",
        "description": "This is a test dataset for testing croissant dataset meta data",
        "url": "http://localhost/datasets/35/",
        "creator": {
            "@type": "Person",
            "name": "ihsan"
        },
        "datePublished": "2025-10-25T17:33:31.239088Z",
        "license": {
            "@type": "CreativeWork",
            "name": "MIT"
        },
        "citation": "-",
        "version": 1.0
    }
</script>
```


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

