### PR TITLE
Docs - Email updated to `info@codabench.org`

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -31,7 +31,7 @@ This Code of Conduct applies to all interactions related to this project, includ
 
 ## 5. Reporting Issues
 
-If you witness or experience any behavior that violates this Code of Conduct, please report it to **info@codalab.org**. All reports will be reviewed and handled confidentially.
+If you witness or experience any behavior that violates this Code of Conduct, please report it to **info@codabench.org**. All reports will be reviewed and handled confidentially.
 
 ## 6. Enforcement
 
@@ -49,7 +49,7 @@ This Code of Conduct is adapted from the [Contributor Covenant](https://www.cont
 ---
 
 ### Questions?
-If you have any questions or concerns, please reach out to **info@codalab.org**.
+If you have any questions or concerns, please reach out to **info@codabench.org**.
 
 
 

--- a/documentation/docs/Newsletters_Archive/CodaLab-in-2024.md
+++ b/documentation/docs/Newsletters_Archive/CodaLab-in-2024.md
@@ -52,7 +52,7 @@ Keep in touch and give us feedback on your experience on Codabench !
 Reminder on our communication tools:
 
 - Join our [google forum](https://groups.google.com/g/codalab-competitions) to emphasize your competitions and events
-- Contact us for any question: info@codalab.org
+- Contact us for any question: info@codabench.org
 - Write an issue on [github](https://github.com/codalab/codabench) about interesting suggestions
 
 Please cite one of these papers when working with our platforms:

--- a/documentation/docs/contact-us.md
+++ b/documentation/docs/contact-us.md
@@ -2,4 +2,4 @@
 - If you wish to get in touch with the community, you can use the [Google Groups](https://groups.google.com/g/codalab-competitions).
 - In case of emergency
 
-[Send us an email :e-mail:](mailto:info@codalab.org){ .md-button .md-button--primary}
+[Send us an email :e-mail:](mailto:info@codabench.org){ .md-button .md-button--primary}


### PR DESCRIPTION
# Description
This PR updates the email from info@codalab to `info@codabench.org` in the docs pages



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [ ] ~CircleCi tests are passing~
- [x] Ready to merge

