### PR TITLE
Cleanup - remaining references of chahub removed

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -467,8 +467,6 @@ def unpack_competition(status_pk):
             status.status = CompetitionCreationTaskStatus.FINISHED
             status.resulting_competition = competition
             status.save()
-            # call again, to make sure phases get sent to chahub
-            competition.save()
             logger.info("Competition saved!")
             status.dataset.name += f" - {competition.title}"
             status.dataset.save()

--- a/src/static/riot/datasets/management.tag
+++ b/src/static/riot/datasets/management.tag
@@ -384,7 +384,7 @@
             delete metadata.data_file  // dont send this with metadata
 
             if (metadata.is_public === 'on') {
-                var public_confirm = confirm("Creating a public dataset means this will be sent to Chahub and publicly available on the internet. Are you sure you wish to continue?")
+                var public_confirm = confirm("You are creating a public dataset. Are you sure you wish to continue?")
                 if (!public_confirm) {
                     return
                 }

--- a/src/static/riot/submissions/resource_submissions.tag
+++ b/src/static/riot/submissions/resource_submissions.tag
@@ -381,7 +381,7 @@
             delete metadata.data_file  // dont send this with metadata
 
             if (metadata.is_public === 'on') {
-                var public_confirm = confirm("Creating a public submission means this will be sent to Chahub and publicly available on the internet. Are you sure you wish to continue?")
+                var public_confirm = confirm("You are creating a public submission. Are you sure you wish to continue?")
                 if (!public_confirm) {
                     return
                 }


### PR DESCRIPTION
# Description
Some points were left in the chahub cleanup. This PR removes the remaining references


# Issues this PR resolves
- #2081




# A checklist for hand testing
- [x] Test carefully competiiton creation becasue this PR has removed a `.save()` from competition creation.



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

