### PR TITLE
Submission CSV - added submission id and filename fileds to submission csv

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -263,6 +263,8 @@ class SubmissionViewSet(ModelViewSet):
         # The CSV renderer will only include these fields in context["header"]
         # Human names for the fields
         context["labels"] = {
+            'id': 'Submission ID',
+            'filename': 'File Name',
             'owner': 'Owner',
             'created_when': 'Created When',
             'status': 'Status',


### PR DESCRIPTION
# Description
When downloading submissions csv as a competition admin/organizer, the csv was missing submission id and filenam. Now these two fileds are added to the csv

Example screenshot from the new downloaded csv
<img width="559" height="73" alt="Screenshot 2026-01-28 at 2 36 06 PM" src="https://github.com/user-attachments/assets/e11931d9-5d7f-4b55-ab0f-4e64fce6ce49" />


# Issues this PR resolves
- #2123 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

