### PR TITLE
Enable different HOST_DIRECTORY

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -593,7 +593,7 @@ class Run:
                     for line in resp:
                         if isinstance(line, dict) and line.get("error"):
                             raise DockerImagePullException(line["error"])
-                        show_progress(line, progress)
+                        show_progress(line, progress, tasks)
                     break  # Break if the loop is successful to exit "with Progress() as progress"
 
             except (docker.errors.APIError, Exception) as pull_error:


### PR DESCRIPTION
#  Brief Description

As we need a different host_directory not located in `/codabench`, but a different path due to mounting points, e.g., `/other/path/codabench`, we run into the problem that the worker raised a permission exception. As the directories are created inside the container of the worker, we identified the problem as not using the right location.

Thus, this PR should make it possible to have a different directory on the host.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

