### PR TITLE
Server status available for competition organizers and queue collaborators

### DIFF
--- a/src/apps/pages/views.py
+++ b/src/apps/pages/views.py
@@ -59,8 +59,8 @@ class ServerStatusView(TemplateView):
                     Q(owner=user) |
                     Q(phase__competition__created_by=user) |
                     Q(phase__competition__collaborators=user) |
-                    Q(phase__competition__queue__owner=user, phase__competition__queue__isnull=False) |
-                    Q(phase__competition__queue__organizers=user, phase__competition__queue__isnull=False)
+                    Q(queue__owner=user, queue__isnull=False) |
+                    Q(queue__organizers=user, queue__isnull=False)
                 ).distinct()
             else:
                 qs = Submission.objects.filter(is_soft_deleted=False)


### PR DESCRIPTION
# Description

Now, for normal users, the server status list:
- this user's own submissions
- submissions running on competitions where the user is owner or organizer
- submissions running on queue where the user is owner or collaborator


# Issues this PR resolves
- Closes #2045


# A checklist for hand testing
- [x] Make submissions on default queue and on custom queue by the competition owner and by a separate user (participant)
- [x] Check the server status for both users - the participant should only be able to see their own submissions
- [x] Make the participant collaborator of the custom queue. All submissions on that queue should appear
- [x] Make the participant co-organizer of the challenge. All submissions on the challenge (on all queues) should appear


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

