### PR TITLE
Make Dockerfile.compute_worker more robust

### DIFF
--- a/Dockerfile.compute_worker
+++ b/Dockerfile.compute_worker
@@ -4,8 +4,7 @@ FROM --platform=linux/amd64 fedora:43
 ENV PYTHONUNBUFFERED=1
 
 # Install Python
-RUN dnf -y update && \
-    dnf install -y python3.9 && \
+RUN dnf -y --refresh install python3.9 curl && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 


### PR DESCRIPTION
# Description

Replace `dnf update` by `--refresh` for more robust build.

Removing `dnf update` avoids pulling a moving, mirror-dependent full system upgrade at build time and limits the build to a deterministic package install with fresh metadata only.


# Issues this PR resolves
- Closes #2173


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

