### PR TITLE
Add restart policy to compute_worker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,6 +226,7 @@ services:
       - ${HOST_DIRECTORY:-/tmp/codabench}:/codabench
       # Actual connection back to docker parent to run things
       - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
     env_file: .env
     environment:
       - BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//


### PR DESCRIPTION
Sometimes compute_worker crashes. Add automatic restart to handle failures.