### PR TITLE
Made competition container and temp folder names more readable

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -323,13 +323,13 @@ class Run:
     """
 
     def __init__(self, run_args):
-        self.runRelatedName = (
+        self.run_related_name = (
             f"uPK-{run_args['user_pk']}_sID-{run_args['id']}"
         )
         # Directories for the run
         self.watch = True
         self.completed_program_counter = 0
-        self.root_dir = tempfile.mkdtemp(prefix=f'{self.runRelatedName}__', dir=BASE_DIR)
+        self.root_dir = tempfile.mkdtemp(prefix=f'{self.run_related_name}__', dir=BASE_DIR)
         self.bundle_dir = os.path.join(self.root_dir, "bundles")
         self.input_dir = os.path.join(self.root_dir, "input")
         self.output_dir = os.path.join(self.root_dir, "output")
@@ -352,8 +352,8 @@ class Run:
         self.stdout, self.stderr, self.ingestion_stdout, self.ingestion_stderr = (
             self._get_stdout_stderr_file_names(run_args)
         )
-        self.ingestion_container_name = f"ingestion_{self.runRelatedName}"
-        self.program_container_name = f"scoring_{self.runRelatedName}"
+        self.ingestion_container_name = f"ingestion_{self.run_related_name}"
+        self.program_container_name = f"scoring_{self.run_related_name}"
         self.program_data = run_args.get("program_data")
         self.ingestion_program_data = run_args.get("ingestion_program")
         self.input_data = run_args.get("input_data")


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Changed the naming of the temporary folder created by the compute worker as well as the competition container to be more descriptive (now contains the User PK and Submission ID as prefix and suffix respectively, as well as ingestion or scoring as prefix for the competition container name)

This might also fix an issue where the ingestion container was not launching successfully, which means that the scoring fails because the prediction file is never created (the old `uuid` naming scheme might have made it so that the competition container would fail to launch sometimes)

# Examples
## Folder 
<img width="321" height="30" alt="image" src="https://github.com/user-attachments/assets/07f4412f-01f0-40d9-9c6a-6cfd58cd11c6" />

uPK = User PK

sID = Submission ID

This replaces the `tmp` prefix that was on all old folder creation

## Competition Container
### Ingestion
<img width="234" height="32" alt="image" src="https://github.com/user-attachments/assets/560799fa-9297-47a4-9267-5a19e7764e36" />


### Scoring
<img width="220" height="25" alt="image" src="https://github.com/user-attachments/assets/f22eb113-2da2-4a72-b197-be4eb18eb005" />

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

