### PR TITLE
Group the submission logs into dynamic tabs

### DIFF
--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -37,96 +37,35 @@
         </div>
     </div>
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}logs" hide="{opts.hide_output}">
-        <div class="ui grid">
-            <div class="three wide column">
-                <div class="ui fluid vertical secondary menu">
-                    <div class="active submission-modal item" data-tab="{admin_: submission.admin}prediction">
-                        Prediction Logs
-                    </div>
-                    <div class="submission-modal item" data-tab="{admin_: submission.admin}scoring">
-                        Scoring Logs
-                    </div>
-                </div>
-            </div>
-            <div class="thirteen wide column">
-                <div class="ui active tab" data-tab="{admin_: submission.admin}prediction">
-                    <div class="ui top attached inverted pointing menu">
-                        <div class="active submission-modal item" data-tab="{admin_: submission.admin}p_stdout">
-                            stdout
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}p_stderr">
-                            stderr
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}p_ingest_stdout">
-                            Ingestion stdout
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}p_ingest_stderr">
-                            Ingestion stderr
-                        </div>
-                    </div>
-
-                    <div class="ui active bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}p_stdout">
-                        <!--
-                        todo: something like:
-                            <pre>{ logs.prediction_stdout ? logs.prediction_stdout : "Empty Logs"}</pre>
-                            so log files don't look empty
-                        -->
-                        <pre>{ logs.prediction_stdout }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}p_stderr">
-                        <pre>{ logs.prediction_stderr }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}p_ingest_stdout">
-                        <pre>{ logs.prediction_ingestion_stdout }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}p_ingest_stderr">
-                        <pre>{ logs.prediction_ingestion_stderr }</pre>
-                    </div>
-                </div>
-                <div class="ui tab" data-tab="{admin_: submission.admin}scoring">
-                    <div class="ui top attached inverted pointing menu">
-                        <div class="active submission-modal item" data-tab="{admin_: submission.admin}s_stdout">
-                            stdout
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}s_stderr">
-                            stderr
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}s_ingest_stdout">
-                            Ingestion stdout
-                        </div>
-                        <div class="submission-modal item" data-tab="{admin_: submission.admin}s_ingest_stderr">
-                            Ingestion stderr
-                        </div>
-                    </div>
-
-                    <div class="ui active bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}s_stdout">
-                        <pre>{ logs.scoring_stdout }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}s_stderr">
-                        <pre>{ logs.scoring_stderr }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}s_ingest_stdout">
-                        <pre>{ logs.scoring_ingestion_stdout }</pre>
-                    </div>
-
-                    <div class="ui bottom attached inverted segment tab log"
-                         data-tab="{admin_: submission.admin}s_ingest_stderr">
-                        <pre>{ logs.scoring_ingestion_stderr }</pre>
-                    </div>
-                </div>
-            </div>
+        <div class="ui top attached inverted pointing menu">
+        <div class="active submission-modal item" data-tab="{admin_: submission.admin}log_ing_out">
+            Ingestion output
+        </div>
+        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_ing_err">
+            Ingestion errors
+        </div>
+        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_score_out">
+            Scoring output
+        </div>
+        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_score_err">
+            Scoring errors
+        </div>
+        </div>
+        <div class="ui active bottom attached inverted segment tab log"
+            data-tab="{admin_: submission.admin}log_ing_out">
+        <pre class="{empty: isEmpty(logs.prediction_ingestion_stdout)}">{ showLog(logs.prediction_ingestion_stdout) }</pre>
+        </div>
+        <div class="ui bottom attached inverted segment tab log"
+            data-tab="{admin_: submission.admin}log_ing_err">
+        <pre class="{empty: isEmpty(logs.prediction_ingestion_stderr)}">{ showLog(logs.prediction_ingestion_stderr) }</pre>
+        </div>
+        <div class="ui bottom attached inverted segment tab log"
+            data-tab="{admin_: submission.admin}log_score_out">
+        <pre class="{empty: isEmpty(logs.scoring_stdout)}">{ showLog(logs.scoring_stdout) }</pre>
+        </div>
+        <div class="ui bottom attached inverted segment tab log"
+            data-tab="{admin_: submission.admin}log_score_err">
+        <pre class="{empty: isEmpty(logs.scoring_stderr)}">{ showLog(logs.scoring_stderr) }</pre>
         </div>
     </div>
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}fact_sheet">
@@ -147,6 +86,11 @@
         self.logs = {}
         self.leaderboards = []
         self.columns = []
+
+        // Check if logs are empty
+        self.isEmpty = (v) => v == null || (typeof v === "string" && v.trim().length === 0)
+        self.nonEmpty = (v) => !self.isEmpty(v)
+        self.showLog = (v) => self.nonEmpty(v) ? v : "No logs for this tab."
 
         self.get_score_details = function (column) {
             try {
@@ -246,10 +190,16 @@
         #downloads thead tr th, #downloads tbody tr td
             font-size 16px !important
 
-        .inverted, textarea
-            color: white
-            background: #1b1c1d
-            width: 100%
-            height: 98%
+        pre.empty 
+            opacity 0.7 
+
+        .log
+            color white
+            background #1b1c1d
+
+        .log textarea
+            width 100%
+            height 98%
+
     </style>
 </submission-modal>

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -80,11 +80,6 @@
         self.leaderboards = []
         self.columns = []
 
-        // OLD helpers - Check if logs are empty
-        //self.isEmpty = (v) => v == null || (typeof v === "string" && v.trim().length === 0)
-        //self.nonEmpty = (v) => !self.isEmpty(v)
-        //self.showLog = (v) => self.nonEmpty(v) ? v : "No logs for this tab."
-
         // Logs helpers
         self.normalizeLog = (v) => {
             if (v == null) return v

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -158,7 +158,8 @@
                                 self.rebuildLogTabs()
                                 self.update()
                                 setTimeout(() => {
-                                    $(self.root).find('.ui.top.attached.menu .item').tab()
+                                    //$(self.root).find('.ui.top.attached.menu .item').tab()
+                                    $('.ui.top.attached.menu .item').tab()
                                 }, 0)
                             })
                     })
@@ -202,6 +203,11 @@
 
         CODALAB.events.on('submission_clicked', () => {
             self.submission = opts.submission
+            // reset per-submission state
+            self.logs = {}
+            self.logTabs = []
+            self.activeLogTabId = null
+            // update
             self.update()
             self.update_submission_details()
             let path = self.submission.admin ? 'admin_downloads' : 'downloads'

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -40,10 +40,9 @@
     <!-- Logs -->
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}logs" hide="{opts.hide_output}">
         <div class="ui top attached inverted pointing menu" if="{logTabs.length > 0}">
-            <div each="{tab in logTabs}"
-                class="submission-modal item {active: tab.fullTabId === activeLogTabId}"
-                data-tab="{tab.fullTabId}"
-                onclick="{() => { activeLogTabId = tab.fullTabId }}">
+            <div each="{tab, i in logTabs}"
+                class="submission-modal item {active: i === 0}"
+                data-tab="{tab.fullTabId}">
                 {tab.label}
             </div>
         </div>
@@ -52,10 +51,10 @@
             <pre class="empty">No logs available for this submission.</pre>
         </div>
         <!-- Dynamic tabs -->
-        <div each="{tab in logTabs}"
-            class="ui bottom attached inverted segment tab log {active: tab.fullTabId === activeLogTabId}"
+        <div each="{tab, i in logTabs}"
+            class="ui bottom attached inverted segment tab log {active: i === 0}"
             data-tab="{tab.fullTabId}">
-            <pre class="{empty: isEmpty(tab.content)}">{ showLog(tab.content) }</pre>
+            <pre class="{empty: is_empty(tab.content)}">{ show_log(tab.content) }</pre>
         </div>
     </div>
     <!-- Fact sheet -->
@@ -82,8 +81,8 @@
         self.columns = []
 
         // Logs helpers
-        self.nonEmpty = (v) => !self.isEmpty(v)
-        self.showLog = (v) => self.nonEmpty(v) ? self.normalizeLog(v) : "No logs for this tab."
+        self.non_empty = (v) => !self.is_empty(v)
+        self.show_log = (v) => self.non_empty(v) ? self.normalizeLog(v) : "No logs for this tab."
         self.normalizeLog = (v) => {
             if (v == null) return v
             if (Array.isArray(v)) return v.join('\n')
@@ -92,16 +91,15 @@
             }
             return String(v)
         }
-        self.isEmpty = (v) => {
+        self.is_empty = (v) => {
             v = self.normalizeLog(v)
             return v == null || (typeof v === "string" && v.trim().length === 0)
         }
 
         // Dynamic tabs state
         self.logTabs = []
-        self.activeLogTabId = null
 
-        self.rebuildLogTabs = () => {
+        self.rebuild_log_tabs = () => {
             const prefix = self.submission && self.submission.admin ? 'admin_' : ''
             const candidates = [
             { key:'p_stdout', label:'Prediction output', content: self.logs.prediction_stdout },
@@ -116,16 +114,11 @@
 
             // Keep only non empty tabs
             self.logTabs = candidates
-                .filter(t => !self.isEmpty(t.content))
+                .filter(t => !self.is_empty(t.content))
                 .map(t => ({
                     ...t,
                     fullTabId: `${prefix}${t.key}`
                 }))
-            // Select a valid tab as active
-            const stillValid = self.logTabs.find(t => t.fullTabId === self.activeLogTabId)
-            if (!stillValid) {
-                self.activeLogTabId = self.logTabs.length ? self.logTabs[0].fullTabId : null
-            }
         }
 
         self.get_score_details = function (column) {
@@ -140,7 +133,7 @@
         }
         self.update_submission_details = () => {
             self.logs = {}
-            self.rebuildLogTabs()
+            self.rebuild_log_tabs()
             self.update()
             CODALAB.api.get_submission_details(self.submission.id)
                 .done(function (data) {
@@ -151,19 +144,25 @@
                     self.detailed_result = data.detailed_result
                     self.fact_sheet_answers = data.fact_sheet_answers
 
-                    _.forEach(data.logs, (item) => {
-                        $.get(item.data_file)
-                            .done(function (content) {
-                                self.logs[item.name] = content
-                                self.rebuildLogTabs()
-                                self.update()
-                                setTimeout(() => {
-                                    //$(self.root).find('.ui.top.attached.menu .item').tab()
-                                    $('.ui.top.attached.menu .item').tab()
-                                }, 0)
-                            })
+                    const requests = data.logs.map(item =>
+                    $.get(item.data_file)
+                        .done(content => { self.logs[item.name] = content })
+                        .fail(() => { self.logs[item.name] = "" })
+                    )
+                    // When all log files are done loading:
+                    $.when.apply($, requests).always(() => {
+                    self.rebuild_log_tabs()
+                    self.update()
+                    setTimeout(() => {
+                        const $items = $(self.root).find('.ui.top.attached.menu .item')
+                        $items.tab()
+                        // pick the first tab deterministically
+                        if (self.logTabs.length) {
+                        $items.tab('change tab', self.logTabs[0].fullTabId)
+                        }
+                    }, 0)
                     })
-                    self.rebuildLogTabs()
+                    self.rebuild_log_tabs()
                     self.update()
                     if (self.submission.admin) {
                         _.forEach(data.leaderboards, (leaderboard) => {

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -6,6 +6,7 @@
         <div class="submission-modal item" data-tab="admin" if="{submission.admin}">ADMIN</div>
         <div class="submission-modal item" data-tab="{admin_: submission.admin}fact_sheet">FACT SHEET ANSWERS</div>
     </div>
+    <!-- Downloads -->
     <div class="ui tab active modal-tab" data-tab="{admin_: submission.admin}downloads">
         <div class="ui relaxed centered grid">
             <div class="ui fifteen wide column">
@@ -36,50 +37,42 @@
             </div>
         </div>
     </div>
+    <!-- Logs -->
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}logs" hide="{opts.hide_output}">
-        <div class="ui top attached inverted pointing menu">
-        <div class="active submission-modal item" data-tab="{admin_: submission.admin}log_ing_out">
-            Ingestion output
+        <div class="ui top attached inverted pointing menu" if="{logTabs.length > 0}">
+            <div each="{tab in logTabs}"
+                class="submission-modal item {active: tab.fullTabId === activeLogTabId}"
+                data-tab="{tab.fullTabId}">
+                {tab.label}
+            </div>
         </div>
-        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_ing_err">
-            Ingestion errors
+        <!-- If no logs -->
+        <div class="ui bottom attached inverted segment tab log active" if="{logTabs.length === 0}">
+            <pre class="empty">No logs available for this submission.</pre>
         </div>
-        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_score_out">
-            Scoring output
-        </div>
-        <div class="submission-modal item" data-tab="{admin_: submission.admin}log_score_err">
-            Scoring errors
-        </div>
-        </div>
-        <div class="ui active bottom attached inverted segment tab log"
-            data-tab="{admin_: submission.admin}log_ing_out">
-        <pre class="{empty: isEmpty(logs.prediction_ingestion_stdout)}">{ showLog(logs.prediction_ingestion_stdout) }</pre>
-        </div>
-        <div class="ui bottom attached inverted segment tab log"
-            data-tab="{admin_: submission.admin}log_ing_err">
-        <pre class="{empty: isEmpty(logs.prediction_ingestion_stderr)}">{ showLog(logs.prediction_ingestion_stderr) }</pre>
-        </div>
-        <div class="ui bottom attached inverted segment tab log"
-            data-tab="{admin_: submission.admin}log_score_out">
-        <pre class="{empty: isEmpty(logs.scoring_stdout)}">{ showLog(logs.scoring_stdout) }</pre>
-        </div>
-        <div class="ui bottom attached inverted segment tab log"
-            data-tab="{admin_: submission.admin}log_score_err">
-        <pre class="{empty: isEmpty(logs.scoring_stderr)}">{ showLog(logs.scoring_stderr) }</pre>
+        <!-- Dynamic tabs -->
+        <div each="{tab in logTabs}"
+            class="ui bottom attached inverted segment tab log {active: tab.fullTabId === activeLogTabId}"
+            data-tab="{tab.fullTabId}">
+            <pre class="{empty: isEmpty(tab.content)}">{ showLog(tab.content) }</pre>
         </div>
     </div>
+    <!-- Fact sheet -->
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}fact_sheet">
         <div class="ui inverted segment log">
             <textarea name="fact-sheet" id="fact_sheet" ref="fact_sheet_text_area">{ JSON.stringify(fact_sheet_answers, null, 2) }</textarea>
         </div>
         <div class="ui button green" onclick="{update_fact_sheet.bind(this)}">Save</div>
     </div>
+    <!-- Visualization -->
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}graph" show="{opts.show_visualization && (!opts.hide_output || submission.admin)}">
         <iframe src="{detailed_result}" class="graph-frame" show="{detailed_result}"></iframe>
     </div>
+    <!-- Admin -->
     <div class="ui tab leaderboard-tab" data-tab="admin" if="{submission.admin}">
         <submission-scores leaderboards="{leaderboards}"></submission-scores>
     </div>
+
     <script>
         var self = this
         self.submission = {}
@@ -87,10 +80,76 @@
         self.leaderboards = []
         self.columns = []
 
-        // Check if logs are empty
-        self.isEmpty = (v) => v == null || (typeof v === "string" && v.trim().length === 0)
+        // OLD helpers - Check if logs are empty
+        //self.isEmpty = (v) => v == null || (typeof v === "string" && v.trim().length === 0)
+        //self.nonEmpty = (v) => !self.isEmpty(v)
+        //self.showLog = (v) => self.nonEmpty(v) ? v : "No logs for this tab."
+
+        // Logs helpers
+        self.normalizeLog = (v) => {
+            if (v == null) return v
+            if (Array.isArray(v)) return v.join('\n')
+            if (typeof v === "object") {
+                try { return JSON.stringify(v, null, 2) } catch { return String(v) }
+            }
+            return String(v)
+        }
+        self.isEmpty = (v) => {
+            v = self.normalizeLog(v)
+            return v == null || (typeof v === "string" && v.trim().length === 0)
+        }
         self.nonEmpty = (v) => !self.isEmpty(v)
-        self.showLog = (v) => self.nonEmpty(v) ? v : "No logs for this tab."
+        self.showLog = (v) => self.nonEmpty(v) ? self.normalizeLog(v) : "No logs for this tab."
+        self.getLog = (...keys) => {
+            for (const k of keys) {
+                const v = self.normalizeLog(self.logs[k])
+                if (!self.isEmpty(v)) return v
+            }
+            return null
+        }
+
+        // Dynamic tabs state
+        self.logTabs = []
+        self.activeLogTabId = null
+
+        self.rebuildLogTabs = () => {
+            const prefix = self.submission && self.submission.admin ? 'admin_' : ''
+            const candidates = [
+                {
+                    key: 'log_ing_out',
+                    label: 'Ingestion output',
+                    content: self.getLog('prediction_ingestion_stdout', 'prediction_stdout')
+                },
+                {
+                    key: 'log_ing_err',
+                    label: 'Ingestion errors',
+                    content: self.getLog('prediction_ingestion_stderr', 'prediction_stderr')
+                },
+                {
+                    key: 'log_score_out',
+                    label: 'Scoring output',
+                    content: self.getLog('scoring_stdout', 'scoring_ingestion_stdout')
+                },
+                {
+                    key: 'log_score_err',
+                    label: 'Scoring errors',
+                    content: self.getLog('scoring_stderr', 'scoring_ingestion_stderr')
+                },
+            ]
+
+            // Keep only non empty tabs
+            self.logTabs = candidates
+                .filter(t => !self.isEmpty(t.content))
+                .map(t => ({
+                    ...t,
+                    fullTabId: `${prefix}${t.key}`
+                }))
+            // Select a valid tab as active
+            const stillValid = self.logTabs.find(t => t.fullTabId === self.activeLogTabId)
+            if (!stillValid) {
+                self.activeLogTabId = self.logTabs.length ? self.logTabs[0].fullTabId : null
+            }
+        }
 
         self.get_score_details = function (column) {
             try {
@@ -116,9 +175,20 @@
                         $.get(item.data_file)
                             .done(function (content) {
                                 self.logs[item.name] = content
+                                self.rebuildLogTabs()
                                 self.update()
+                                // Rebind Semantic UI tabs after DOM update
+                                setTimeout(() => {
+                                    // init tabs inside the LOGS menu
+                                    $('.ui.top.attached.menu .item').tab()
+                                    if (self.activeLogTabId) {
+                                        $('.ui.top.attached.menu .item').tab('change tab', self.activeLogTabId)
+                                    }
+                                }, 0)
                             })
                     })
+                    self.rebuildLogTabs()
+                    self.update()
                     if (self.submission.admin) {
                         _.forEach(data.leaderboards, (leaderboard) => {
                             _.map(leaderboard.columns, (column) => {

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -81,6 +81,8 @@
         self.columns = []
 
         // Logs helpers
+        self.nonEmpty = (v) => !self.isEmpty(v)
+        self.showLog = (v) => self.nonEmpty(v) ? self.normalizeLog(v) : "No logs for this tab."
         self.normalizeLog = (v) => {
             if (v == null) return v
             if (Array.isArray(v)) return v.join('\n')
@@ -93,15 +95,6 @@
             v = self.normalizeLog(v)
             return v == null || (typeof v === "string" && v.trim().length === 0)
         }
-        self.nonEmpty = (v) => !self.isEmpty(v)
-        self.showLog = (v) => self.nonEmpty(v) ? self.normalizeLog(v) : "No logs for this tab."
-        self.getLog = (...keys) => {
-            for (const k of keys) {
-                const v = self.normalizeLog(self.logs[k])
-                if (!self.isEmpty(v)) return v
-            }
-            return null
-        }
 
         // Dynamic tabs state
         self.logTabs = []
@@ -110,26 +103,14 @@
         self.rebuildLogTabs = () => {
             const prefix = self.submission && self.submission.admin ? 'admin_' : ''
             const candidates = [
-                {
-                    key: 'log_ing_out',
-                    label: 'Ingestion output',
-                    content: self.getLog('prediction_ingestion_stdout', 'prediction_stdout')
-                },
-                {
-                    key: 'log_ing_err',
-                    label: 'Ingestion errors',
-                    content: self.getLog('prediction_ingestion_stderr', 'prediction_stderr')
-                },
-                {
-                    key: 'log_score_out',
-                    label: 'Scoring output',
-                    content: self.getLog('scoring_stdout', 'scoring_ingestion_stdout')
-                },
-                {
-                    key: 'log_score_err',
-                    label: 'Scoring errors',
-                    content: self.getLog('scoring_stderr', 'scoring_ingestion_stderr')
-                },
+            { key:'p_stdout', label:'Prediction output', content: self.logs.prediction_stdout },
+            { key:'p_stderr', label:'Prediction errors', content: self.logs.prediction_stderr },
+            { key:'p_ing_out', label:'Ingestion output', content: self.logs.prediction_ingestion_stdout },
+            { key:'p_ing_err', label:'Ingestion errors', content: self.logs.prediction_ingestion_stderr },
+            { key:'s_stdout', label:'Scoring output', content: self.logs.scoring_stdout },
+            { key:'s_stderr', label:'Scoring errors', content: self.logs.scoring_stderr },
+            { key:'s_ing_out', label:'Scoring ingestion output', content: self.logs.scoring_ingestion_stdout },
+            { key:'s_ing_err', label:'Scoring ingestion errors', content: self.logs.scoring_ingestion_stderr },
             ]
 
             // Keep only non empty tabs

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -42,7 +42,8 @@
         <div class="ui top attached inverted pointing menu" if="{logTabs.length > 0}">
             <div each="{tab in logTabs}"
                 class="submission-modal item {active: tab.fullTabId === activeLogTabId}"
-                data-tab="{tab.fullTabId}">
+                data-tab="{tab.fullTabId}"
+                onclick="{() => { activeLogTabId = tab.fullTabId }}">
                 {tab.label}
             </div>
         </div>
@@ -138,6 +139,9 @@
             }
         }
         self.update_submission_details = () => {
+            self.logs = {}
+            self.rebuildLogTabs()
+            self.update()
             CODALAB.api.get_submission_details(self.submission.id)
                 .done(function (data) {
                     self.leaderboards = data.leaderboards
@@ -153,13 +157,8 @@
                                 self.logs[item.name] = content
                                 self.rebuildLogTabs()
                                 self.update()
-                                // Rebind Semantic UI tabs after DOM update
                                 setTimeout(() => {
-                                    // init tabs inside the LOGS menu
-                                    $('.ui.top.attached.menu .item').tab()
-                                    if (self.activeLogTabId) {
-                                        $('.ui.top.attached.menu .item').tab('change tab', self.activeLogTabId)
-                                    }
+                                    $(self.root).find('.ui.top.attached.menu .item').tab()
                                 }, 0)
                             })
                     })
@@ -206,7 +205,7 @@
             self.update()
             self.update_submission_details()
             let path = self.submission.admin ? 'admin_downloads' : 'downloads'
-            $('.menu .submission-modal.item').tab('change tab', path)
+            $('.ui.large.green.pointing.menu .submission-modal.item').tab('change tab', path)
         })
     </script>
 
@@ -225,7 +224,7 @@
 
         .file-download
             margin-top 25px !important
-            margin-botton 25px !important
+            margin-bottom 25px !important
 
         .graph-frame
             height 100%

--- a/src/static/riot/competitions/detail/submission_modal.tag
+++ b/src/static/riot/competitions/detail/submission_modal.tag
@@ -39,10 +39,11 @@
     </div>
     <!-- Logs -->
     <div class="ui tab modal-tab" data-tab="{admin_: submission.admin}logs" hide="{opts.hide_output}">
-        <div class="ui top attached inverted pointing menu" if="{logTabs.length > 0}">
+        <div class="ui top attached inverted pointing menu" if="{logTabs.length > 0}" ref="log_tabs_menu">
             <div each="{tab, i in logTabs}"
-                class="submission-modal item {active: i === 0}"
-                data-tab="{tab.fullTabId}">
+                class="submission-modal item {active: tab.fullTabId === activeLogTabId || (!activeLogTabId && i === 0)}"
+                data-tab="{tab.fullTabId}"
+                onclick="{() => activeLogTabId = tab.fullTabId}">
                 {tab.label}
             </div>
         </div>
@@ -52,7 +53,7 @@
         </div>
         <!-- Dynamic tabs -->
         <div each="{tab, i in logTabs}"
-            class="ui bottom attached inverted segment tab log {active: i === 0}"
+            class="ui bottom attached inverted segment tab log {active: tab.fullTabId === activeLogTabId || (!activeLogTabId && i === 0)}"
             data-tab="{tab.fullTabId}">
             <pre class="{empty: is_empty(tab.content)}">{ show_log(tab.content) }</pre>
         </div>
@@ -117,8 +118,12 @@
                 .filter(t => !self.is_empty(t.content))
                 .map(t => ({
                     ...t,
-                    fullTabId: `${prefix}${t.key}`
+                    fullTabId: `${prefix}sub_${self.submission.id}_${t.key}`
                 }))
+
+            if (!self.activeLogTabId || !self.logTabs.find(t => t.fullTabId === self.activeLogTabId)) {
+                self.activeLogTabId = self.logTabs.length ? self.logTabs[0].fullTabId : null
+            }
         }
 
         self.get_score_details = function (column) {
@@ -154,11 +159,11 @@
                     self.rebuild_log_tabs()
                     self.update()
                     setTimeout(() => {
-                        const $items = $(self.root).find('.ui.top.attached.menu .item')
+                        if (!self.refs.log_tabs_menu) return
+                        const $items = $(self.refs.log_tabs_menu).find('.item')
                         $items.tab()
-                        // pick the first tab deterministically
                         if (self.logTabs.length) {
-                        $items.tab('change tab', self.logTabs[0].fullTabId)
+                            $items.tab('change tab', self.activeLogTabId || self.logTabs[0].fullTabId)
                         }
                     }, 0)
                     })


### PR DESCRIPTION
# Description

- Group and rename tabs (dynamic instead of 2x4)
- Message when no logs

### Old interface
<img width="1158" height="390" alt="Capture d’écran 2026-02-17 à 19 39 07" src="https://github.com/user-attachments/assets/b89d4926-6827-4e70-b8ed-04a5aebcb488" />

### New interface

<img width="829" height="490" alt="Capture d’écran 2026-02-25 à 14 26 53" src="https://github.com/user-attachments/assets/84688bce-9f6e-48a0-910e-adf0815220f6" />

<img width="877" height="447" alt="Capture d’écran 2026-02-25 à 14 31 22" src="https://github.com/user-attachments/assets/7f1f6252-eacd-4946-bd70-81e4207a3fd1" />


# Issues this PR resolves
- Closes #1931



# A checklist for hand testing
- [x] Open submissions logs and check the tab
- [x] Check for code submission, result submission, when no logs, when failure
- [x] Check multi-task case


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

