### PR TITLE
Allow custom domain to be used with public S3 bucket

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -72,6 +72,8 @@ AWS_S3_ENDPOINT_URL=http://minio:9000/
 AWS_QUERYSTRING_AUTH=False
 # Optional URL rewriting in compute worker, format: FROM | TO
 #WORKER_BUNDLE_URL_REWRITE=http://localhost:9000|http://minio:9000
+# Optional custom domain for public bucket, e.g. if you have a CDN in front of your S3 storage
+#AWS_S3_PUBLIC_CUSTOM_DOMAIN=<your-domain.com>
 
 
 # -----------------------------------------------------------------------------

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -386,6 +386,7 @@ if STORAGE_IS_S3:
                 "use_ssl": os.environ.get('S3_USE_SIGV4', 'true').lower() == 'true',
                 "querystring_auth": os.environ.get('AWS_QUERYSTRING_AUTH'),
                 "default_acl": os.environ.get('AWS_DEFAULT_ACL'),
+                "custom_domain": os.environ.get("AWS_S3_PUBLIC_CUSTOM_DOMAIN", ""),
             },
         },
         "bundle": {
@@ -473,6 +474,7 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 AWS_STORAGE_PRIVATE_BUCKET_NAME = os.environ.get('AWS_STORAGE_PRIVATE_BUCKET_NAME')
 AWS_S3_CALLING_FORMAT = os.environ.get('AWS_S3_CALLING_FORMAT', 'boto.s3.connection.OrdinaryCallingFormat')
 AWS_S3_ENDPOINT_URL = os.environ.get('AWS_S3_ENDPOINT_URL', '')
+AWS_S3_PUBLIC_CUSTOM_DOMAIN = os.environ.get('AWS_S3_PUBLIC_CUSTOM_DOMAIN', '')
 AWS_DEFAULT_ACL = None  # Uses buckets security access policies
 AWS_QUERYSTRING_AUTH = os.environ.get(
     # This stops signature/auths from appearing in saved URLs

--- a/src/utils/storage.py
+++ b/src/utils/storage.py
@@ -12,6 +12,7 @@ if settings.STORAGE_IS_S3:
 
         class PublicStorageClass(S3Boto3Storage):
             bucket_name = getattr(settings, "AWS_STORAGE_BUCKET_NAME", None)
+            custom_domain = getattr(settings, "AWS_S3_PUBLIC_CUSTOM_DOMAIN", "")
 
         class PrivateStorageClass(S3Boto3Storage):
             bucket_name = getattr(settings, "AWS_STORAGE_PRIVATE_BUCKET_NAME", None)


### PR DESCRIPTION
This allows a S3 bucket to be put behind CloudFront which is considered best practice.

@ihsaan-ullah 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

