### PR TITLE
Add settings to allow SES email backend to be used

### DIFF
--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -541,8 +541,7 @@ EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', True)
 AWS_DEFAULT_REGION = os.environ.get('AWS_DEFAULT_REGION')
 AWS_SES_REGION_NAME = os.environ.get('AWS_SES_REGION_NAME', AWS_DEFAULT_REGION)
 SERVER_EMAIL = os.environ.get('SERVER_EMAIL', 'noreply@codabench.org')
-# Default from email to SERVER_EMAIL if not set, as some email backends require a from email to be set
-DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', SERVER_EMAIL)
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'noreply@codabench.org')
 
 CONTACT_EMAIL = os.environ.get('CONTACT_EMAIL', 'info@codabench.org')
 


### PR DESCRIPTION
Add settings that allow email backend to be set to `django_ses.SESBackend`

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

