### PR TITLE
Fix leaderboard ordering by date

### DIFF
--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -57,7 +57,11 @@
             </td>
             <td if="{submission.organization === null}"><a href="{submission.slug_url}">{ submission.owner }</a></td>
             <td if="{submission.organization !== null}"><a href="{submission.organization.url}">{ submission.organization.name }</a></td>
-            <td>{ pretty_date(submission.created_when) }</td>
+            <td data-sort="{ sort_date_value(submission.created_when) }"
+                data-sort-value="{ sort_date_value(submission.created_when) }"
+            >
+                { pretty_date(submission.created_when) }
+            </td>
             <td>{submission.id}</td>
             <td each="{ column in filtered_columns }">
                 <a if="{column.title == 'Detailed Results'}" href="detailed_results/{get_detailed_result_submisison_id(column, submission)}" target="_blank" class="eye-icon-link">
@@ -87,6 +91,12 @@
             } else {
                 return ''
             }
+        }
+
+        self.sort_date_value = function (date_string) {
+            if (!date_string) return 0
+            const dt = luxon.DateTime.fromISO(date_string)
+            return dt.isValid ? dt.toMillis() : 0
         }
        
         self.bold_class = function(column, submission){


### PR DESCRIPTION
# Description

Fix the ordering of the leaderboard rows by date.

<img width="363" height="603" alt="Capture d’écran 2026-02-28 à 03 19 22" src="https://github.com/user-attachments/assets/8c23bf09-f07b-4f55-8e38-939e101f5274" />

<img width="357" height="563" alt="Capture d’écran 2026-02-28 à 03 19 14" src="https://github.com/user-attachments/assets/9db21a00-8d59-43aa-81ca-762826b54aa6" />


# Issues this PR resolves
- Closes #1947



# A checklist for hand testing
- [x] Have many rows on the leaderboard
- [x] Sort by date by clicking (asc or desc)


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

