### PR TITLE
Replace Caddy with Nginx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - run:
           name: "Setup: Create directories for MinIO (cannot be made by docker for some reason)"
           command: |
+            sudo echo "127.0.0.1 minio" >> /etc/hosts
             mkdir -p var/minio/public
             mkdir -p var/minio/private
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,8 @@ jobs:
           path: tests/test-results
       - store_artifacts:
           path: dockerLogs/
+      - store_artifacts:
+          path: var/log/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: "Setup: Create directories for MinIO (cannot be made by docker for some reason)"
           command: |
-            sudo echo "127.0.0.1 minio" >> /etc/hosts
+            echo "127.0.0.1 minio" | sudo tee -a /etc/hosts
             mkdir -p var/minio/public
             mkdir -p var/minio/private
 

--- a/.env_circleci
+++ b/.env_circleci
@@ -6,12 +6,13 @@ DB_PORT=5432
 
 RABBITMQ_DEFAULT_USER=rabbit-username
 RABBITMQ_DEFAULT_PASS=rabbit-password-you-should-change
+RABBITMQ_MANAGEMENT_PORT=15672
 RABBITMQ_PORT=5672
 RABBITMQ_HOST=rabbit
 WORKER_CONNECTION_TIMEOUT=100000000 # milliseconds
 
 FLOWER_BASIC_AUTH=root:password-you-should-change
-
+FLOWER_PUBLIC_PORT=5555
 DJANGO_SETTINGS_MODULE=settings.test
 
 # Minio local storage example
@@ -26,11 +27,17 @@ AWS_SECRET_ACCESS_KEY=testsecret
 AWS_STORAGE_BUCKET_NAME=public
 AWS_STORAGE_PRIVATE_BUCKET_NAME=private
 # NOTE! port 9000 here should match $MINIO_PORT
-AWS_S3_ENDPOINT_URL=http://172.17.0.1:9000/
+AWS_S3_ENDPOINT_URL=http://minio:9000/
 AWS_QUERYSTRING_AUTH=False
 DJANGO_SUPERUSER_PASSWORD=codabench
 DJANGO_SUPERUSER_EMAIL=test@test.com
 DJANGO_SUPERUSER_USERNAME=codabench
-DOMAIN_NAME=localhost:80
 TLS_EMAIL=your@email.com
 SUBMISSIONS_API_URL=http://django:8000/api
+
+# -----------------------------------------------------------------------------
+# Nginx settings
+# -----------------------------------------------------------------------------
+HTTPS=False
+RATE_LIMIT=100
+DOMAIN_NAME=localhost

--- a/.env_circleci
+++ b/.env_circleci
@@ -39,5 +39,5 @@ SUBMISSIONS_API_URL=http://django:8000/api
 # Nginx settings
 # -----------------------------------------------------------------------------
 HTTPS=False
-RATE_LIMIT=100
+RATE_LIMIT=10000
 DOMAIN_NAME=localhost

--- a/.env_circleci
+++ b/.env_circleci
@@ -39,5 +39,6 @@ SUBMISSIONS_API_URL=http://django:8000/api
 # Nginx settings
 # -----------------------------------------------------------------------------
 HTTPS=False
-RATE_LIMIT=10000
+RATE_LIMIT=100
 DOMAIN_NAME=localhost
+DATABASE_ACCESS=True

--- a/.env_sample
+++ b/.env_sample
@@ -1,6 +1,3 @@
-# Use openssl rand -hex 32 to generate this secret key, or generate it however you want and copy it here
-SECRET_KEY=
-
 # For local setup and debug
 DEBUG=False
 

--- a/.env_sample
+++ b/.env_sample
@@ -1,15 +1,23 @@
+# Use openssl rand -hex 32 to generate this secret key, or generate it however you want and copy it here
+SECRET_KEY=
+
 # For local setup and debug
 DEBUG=False
 
+# -----------------------------------------------------------------------------
 # Database
+# -----------------------------------------------------------------------------
 DB_HOST=db
 DB_NAME=postgres
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_PORT=5432
 
+# -----------------------------------------------------------------------------
+# Django
+# -----------------------------------------------------------------------------
 DJANGO_SETTINGS_MODULE=settings.develop
-ALLOWED_HOSTS=localhost,example.com
+ALLOWED_HOSTS=localhost,
 SUBMISSIONS_API_URL=http://django:8000/api
 MAX_EXECUTION_TIME_LIMIT=600 # time limit for the default queue (in seconds)
 
@@ -19,12 +27,11 @@ MAX_EXECUTION_TIME_LIMIT=600 # time limit for the default queue (in seconds)
 HTTPS=False
 RATE_LIMIT=5
 DOMAIN_NAME=localhost
-
-
-# SSL style domain definition
 TLS_EMAIL=your@email.com
-# DOMAIN_NAME=example.com:443
 
+# -----------------------------------------------------------------------------
+# RabbitMQ
+# -----------------------------------------------------------------------------
 RABBITMQ_HOST=rabbit
 RABBITMQ_DEFAULT_USER=rabbit-username
 RABBITMQ_DEFAULT_PASS=rabbit-password-you-should-change
@@ -32,11 +39,17 @@ RABBITMQ_MANAGEMENT_PORT=15672
 RABBITMQ_PORT=5672
 WORKER_CONNECTION_TIMEOUT=100000000 # milliseconds
 
-FLOWER_PUBLIC_PORT=5555
 
+# -----------------------------------------------------------------------------
+# Flower
+# -----------------------------------------------------------------------------
+FLOWER_PUBLIC_PORT=5555
 FLOWER_BASIC_AUTH=root:password-you-should-change
 
-SELENIUM_HOSTNAME=selenium
+
+# -----------------------------------------------------------------------------
+# Email Settings
+# -----------------------------------------------------------------------------
 
 # Uncomment to enable email settings
 #EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
@@ -74,21 +87,6 @@ AWS_QUERYSTRING_AUTH=False
 #WORKER_BUNDLE_URL_REWRITE=http://localhost:9000/|http://minio:9000/
 
 
-# -----------------------------------------------------------------------------
-# Limit for re-running submission
-# This is used to limit users to rerun submissions
-# on default queue when number of submissions are < RERUN_SUBMISSION_LIMIT
-# -----------------------------------------------------------------------------
-RERUN_SUBMISSION_LIMIT=30
-
-
-# -----------------------------------------------------------------------------
-# Enable or disbale regular email sign-in an sign-up
-# -----------------------------------------------------------------------------
-ENABLE_SIGN_UP=True
-ENABLE_SIGN_IN=True
-
-
 # # S3 storage example
 # STORAGE_TYPE=s3
 # AWS_ACCESS_KEY_ID=12312312312312312331223
@@ -110,6 +108,20 @@ ENABLE_SIGN_IN=True
 # GS_PUBLIC_BUCKET_NAME=public
 # GS_PRIVATE_BUCKET_NAME=private
 # GOOGLE_APPLICATION_CREDENTIALS=/app/certs/google-storage-api.json
+
+# -----------------------------------------------------------------------------
+# Limit for re-running submission
+# This is used to limit users to rerun submissions
+# on default queue when number of submissions are < RERUN_SUBMISSION_LIMIT
+# -----------------------------------------------------------------------------
+RERUN_SUBMISSION_LIMIT=30
+
+
+# -----------------------------------------------------------------------------
+# Enable or disbale regular email sign-in an sign-up
+# -----------------------------------------------------------------------------
+ENABLE_SIGN_UP=True
+ENABLE_SIGN_IN=True
 
 
 # -----------------------------------------------------------------------------

--- a/.env_sample
+++ b/.env_sample
@@ -13,8 +13,13 @@ ALLOWED_HOSTS=localhost,example.com
 SUBMISSIONS_API_URL=http://django:8000/api
 MAX_EXECUTION_TIME_LIMIT=600 # time limit for the default queue (in seconds)
 
-# Local domain definition
-DOMAIN_NAME=localhost:80
+# -----------------------------------------------------------------------------
+# Nginx settings
+# -----------------------------------------------------------------------------
+HTTPS=False
+RATE_LIMIT=5
+DOMAIN_NAME=localhost
+
 
 # SSL style domain definition
 TLS_EMAIL=your@email.com
@@ -26,9 +31,6 @@ RABBITMQ_DEFAULT_PASS=rabbit-password-you-should-change
 RABBITMQ_MANAGEMENT_PORT=15672
 RABBITMQ_PORT=5672
 WORKER_CONNECTION_TIMEOUT=100000000 # milliseconds
-#RABBITMQ_HTTP_PROXY=http://proxy-example:3128
-#RABBITMQ_HTTPS_PROXY=http://proxy-example:3128
-#RABBITMQ_NO_PROXY=localhost,172.0.0.0/8
 
 FLOWER_PUBLIC_PORT=5555
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ caddy_data/
 home_page_counters.json
 my-postgres.conf
 tests/config/state.json
-
+state.json
+certs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,24 +2,37 @@ services:
   #----------------------------------------------------------------------------------------------------
   #   Web Services
   #----------------------------------------------------------------------------------------------------
-  caddy:
-    image: caddy:2.11.1
+  nginx:
+    image: nginx:latest
     env_file: .env
     environment:
-      - ACME_AGREE=true
+      - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
+    command: ["nginx", "-g", "daemon off;"]
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
       - ./src/staticfiles:/var/www/django/static
-      - ./caddy_data:/data
-      - ./caddy_config:/config
-      - ./var/log/caddy:/var/log/
       - ./maintenance_mode/:/srv
+      - ./certsNginx:/var/cache/nginx/acme-letsencrypt
+      - ./nginx/:/etc/nginx/templates/
+      - ./var/log/nginx/:/var/log/nginx
     restart: unless-stopped
     ports:
       - 80:80
       - 443:443
+      - 8000:8000
+      - 5432:5432
+      - ${RABBITMQ_MANAGEMENT_PORT:-15672}:15672
+      - ${RABBITMQ_PORT}:5672
+      - ${MINIO_PORT}:9000
+      - ${FLOWER_PUBLIC_PORT:-5555}:5555
     depends_on:
       - django
+      - minio
+      - rabbit
+      - site_worker
+      - db
+    networks:
+      - frontend
+      - backend
 
   django:
     container_name: django
@@ -39,7 +52,7 @@ services:
       - ./var/logs:/app/logs
     restart: unless-stopped
     ports:
-      - 8000:8000
+      - 8000
     depends_on:
       - db
       - rabbit
@@ -50,6 +63,8 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+    networks:
+      - backend
 
 
   #----------------------------------------------------------------------------------------------------
@@ -62,12 +77,14 @@ services:
       - ./var/minio:/export
     restart: unless-stopped
     ports:
-      - $MINIO_PORT:9000
+      - 9000
     env_file: .env
     healthcheck:
       test: ["CMD", "curl", "-I", "http://minio:9000/minio/health/live"]
       interval: 5s
       retries: 5
+    networks:
+      - backend
   createbuckets:
     image: minio/mc:RELEASE.2025-07-21T05-28-08Z
     depends_on:
@@ -92,6 +109,8 @@ services:
       fi;
       exit 0;
       "
+    networks:
+      - backend
 
   #----------------------------------------------------------------------------------------------------
   #   Local development helper, rebuilds RiotJS/Stylus on change
@@ -109,7 +128,6 @@ services:
         max-size: "20m"
         max-file: "5"
 
-
   #----------------------------------------------------------------------------------------------------
   #   Database Service
   #
@@ -125,7 +143,7 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr", "-c", "config_file=/etc/postgresql/postgresql.conf"]
     ports:
-      - 5432:5432
+      - 5432
     volumes:
       - ./var/postgres:/var/lib/postgresql/18/:delegated
       - ./backups:/app/backups
@@ -135,6 +153,8 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+    networks:
+      - backend
 
   #----------------------------------------------------------------------------------------------------
   #   Rabbitmq & Flower monitoring tool
@@ -150,13 +170,9 @@ services:
     # containers being destroyed..!
     hostname: rabbit
     env_file: .env
-    environment:
-      - http_proxy=${RABBITMQ_HTTP_PROXY}
-      - https_proxy=${RABBITMQ_HTTPS_PROXY}
-      - no_proxy=${RABBITMQ_NO_PROXY}
     ports:
-      - ${RABBITMQ_MANAGEMENT_PORT:-15672}:15672
-      - ${RABBITMQ_PORT}:5672
+      - 15672
+      - 5672
     volumes:
       - ./var/rabbit:/var/lib/rabbitmq
     restart: unless-stopped
@@ -164,6 +180,8 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+    networks:
+      - backend
 
   flower:
     container_name: flower
@@ -173,13 +191,15 @@ services:
       - CELERY_BROKER_URL=pyamqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}//
     restart: unless-stopped
     ports:
-      - ${FLOWER_PUBLIC_PORT:-5555}:5555
+      - 5555
     depends_on:
       - rabbit
     logging:
         options:
             max-size: "20m"
             max-file: "5"
+    networks:
+      - backend
 
   #----------------------------------------------------------------------------------------------------
   #   Redis
@@ -188,12 +208,14 @@ services:
     container_name: redis
     image: redis
     ports:
-      - 6379:6379
+      - 6379
     restart: unless-stopped
     logging:
       options:
         max-size: "20m"
         max-file: "5"
+    networks:
+      - backend
 
   #----------------------------------------------------------------------------------------------------
   #   Celery Service
@@ -221,6 +243,8 @@ services:
           # Limit memory substantially here so we see any problems that may
           # appear on Heroku ahead of time
           memory: 256M
+    networks:
+      - backend
 
   compute_worker:
     command: ["celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"]
@@ -249,3 +273,10 @@ services:
       options:
         max-size: "20m"
         max-file: "5"
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./src/staticfiles:/var/www/django/static
       - ./maintenance_mode/:/srv
-      - ./certsNginx:/var/cache/nginx/acme-letsencrypt
+      - ./nginx/certs/:/var/cache/nginx/acme-letsencrypt
       - ./nginx/:/etc/nginx/templates/
       - ./var/log/nginx/:/var/log/nginx
     restart: unless-stopped
@@ -282,4 +282,4 @@ services:
 networks:
   frontend:
   backend:
-    #internal: true
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,16 @@ services:
   #   Web Services
   #----------------------------------------------------------------------------------------------------
   nginx:
-    image: nginx:latest
+    image: nginx:alpine
     env_file: .env
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
     command: ["nginx", "-g", "daemon off;"]
     volumes:
-      - ./src/staticfiles:/var/www/django/static
-      - ./maintenance_mode/:/srv
+      - ./src/staticfiles:/var/www/django/static:ro
+      - ./maintenance_mode/:/srv:ro
+      - ./nginx/:/etc/nginx/templates/:ro
       - ./nginx/certs/:/var/cache/nginx/acme-letsencrypt
-      - ./nginx/:/etc/nginx/templates/
       - ./var/log/nginx/:/var/log/nginx
     restart: unless-stopped
     ports:
@@ -22,14 +22,8 @@ services:
       - 5432:5432
       - ${RABBITMQ_MANAGEMENT_PORT:-15672}:15672
       - ${RABBITMQ_PORT}:5672
-      - ${MINIO_PORT}:9000
+      - ${MINIO_PORT:-9000}:9000
       - ${FLOWER_PUBLIC_PORT:-5555}:5555
-    depends_on:
-      - django
-      - minio
-      - rabbit
-      - site_worker
-      - db
     networks:
       - frontend
       - backend
@@ -65,6 +59,7 @@ services:
         max-file: "5"
     networks:
       - backend
+      - frontend
 
 
   #----------------------------------------------------------------------------------------------------
@@ -81,7 +76,7 @@ services:
       - 9001
     env_file: .env
     environment:
-      MINIO_BROWSER_REDIRECT_URL: "http://localhost/console"
+      MINIO_BROWSER_REDIRECT_URL: "http://${DOMAIN_NAME}/console"
     healthcheck:
       test: ["CMD", "curl", "-I", "http://minio:9000/minio/health/live"]
       interval: 5s
@@ -150,7 +145,7 @@ services:
     volumes:
       - ./var/postgres:/var/lib/postgresql/18/:delegated
       - ./backups:/app/backups
-      - ./my-postgres.conf:/etc/postgresql/postgresql.conf
+      - ./my-postgres.conf:/etc/postgresql/postgresql.conf:ro
     restart: unless-stopped
     logging:
       options:
@@ -260,7 +255,7 @@ services:
       - django
       - rabbit
     volumes:
-      - ./compute_worker:/app
+      - ./compute_worker:/app:ro
       - ${HOST_DIRECTORY:-/tmp/codabench}:/codabench
       # Actual connection back to docker parent to run things
       - /var/run/docker.sock:/var/run/docker.sock
@@ -278,6 +273,7 @@ services:
         max-file: "5"
     networks:
       - backend
+      - frontend
 
 networks:
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,13 +72,16 @@ services:
   #----------------------------------------------------------------------------------------------------
   minio:
     image: minio/minio:RELEASE.2025-04-22T22-12-26Z
-    command: server /export
+    command: server /export --console-address ":9001"
     volumes:
       - ./var/minio:/export
     restart: unless-stopped
     ports:
       - 9000
+      - 9001
     env_file: .env
+    environment:
+      MINIO_BROWSER_REDIRECT_URL: "http://localhost/console"
     healthcheck:
       test: ["CMD", "curl", "-I", "http://minio:9000/minio/health/live"]
       interval: 5s
@@ -279,4 +282,4 @@ services:
 networks:
   frontend:
   backend:
-    internal: true
+    #internal: true

--- a/nginx/extra/anti_scrapper.conf.template
+++ b/nginx/extra/anti_scrapper.conf.template
@@ -2,11 +2,6 @@
 limit_req_status 429;
 limit_req zone=scraperlimit burst=25 nodelay;
 
-location /robots.txt {
-    autoindex off;
-    alias /etc/nginx/templates/robots.txt;
-}
-
 # Deny access to bots
 # Block user agents that tend to be scrapers and badly behaved bots
 if ($bad_bot = 1) {

--- a/nginx/extra/anti_scrapper.conf.template
+++ b/nginx/extra/anti_scrapper.conf.template
@@ -1,0 +1,19 @@
+# Rate limit error code (429) and definition (allow for bursts of 25 requests to load static images etc) and block immediately after the rate limit is applied to an IP
+limit_req_status 429;
+limit_req zone=scraperlimit burst=25 nodelay;
+
+location /robots.txt {
+    autoindex off;
+    alias /etc/nginx/templates/robots.txt;
+}
+
+# Deny access to bots
+# Block user agents that tend to be scrapers and badly behaved bots
+if ($bad_bot = 1) {
+    return 444 "? beep boop ?";
+}
+
+# No scrapers
+if ($scraper = 1) {
+    return 418 "?";
+}

--- a/nginx/extra/base_django.conf.template
+++ b/nginx/extra/base_django.conf.template
@@ -1,6 +1,7 @@
 charset utf-8;
-client_max_body_size 10480m;
-client_body_buffer_size 32m;
+client_max_body_size 0;
+proxy_buffering off;
+proxy_request_buffering off;
 sendfile on;
 gzip on;
 

--- a/nginx/extra/base_django.conf.template
+++ b/nginx/extra/base_django.conf.template
@@ -1,0 +1,23 @@
+charset utf-8;
+client_max_body_size 10480m;
+client_body_buffer_size 32m;
+sendfile on;
+gzip on;
+
+location ~ /static/(.*) {
+    autoindex off;
+    access_log off;
+    include /etc/nginx/mime.types;
+    root /var/www/django/;
+}
+location ~ /media/(.*) {
+    autoindex off;
+    access_log off;
+    include /etc/nginx/mime.types;
+    root /var/www/django;
+}
+location /favicon.ico {
+    autoindex off;
+    access_log off;
+    alias /var/www/django/static/img/favicon.ico;
+}

--- a/nginx/extra/block_map.conf.template
+++ b/nginx/extra/block_map.conf.template
@@ -1,0 +1,33 @@
+limit_req_zone $binary_remote_addr zone=scraperlimit:10m rate=${RATE_LIMIT}r/s;
+
+# Block bad bots
+map $http_user_agent $bad_bot {
+    default 0;
+    ~*(?i)(JikeSpider) 1;
+    ~*(?i)(proximic) 1;
+    ~*(?i)(Sosospider) 1;
+    ~*(?i)(Baiduspider) 1;
+    ~*(?i)(Twitterbot) 1;
+    ~*(?i)(SemrushBot) 1;
+    ~*(?i)(^AIBOT) 1;
+    ~*(?i)(^BunnySlippers) 1;
+    ~*(?i)(^Cegbfeieh) 1;
+    ~*(?i)(^CheeseBot) 1;
+}
+
+# Block scrappers
+map $http_user_agent $scraper {
+    default 0;
+    ~*(?i)(Google-Extended) 1;
+    ~*(?i)(Applebot-Extended) 1;
+    ~*(?i)(anthropic-ai) 1;
+    ~*(?i)(ClaudeBot) 1;
+    ~*(?i)(Claude-Web) 1;
+    ~*(?i)(GPTBot) 1;
+    ~*(?i)(Omgili) 1;
+    ~*(?i)(FacebookBot) 1;
+    ~*(?i)(node-fetch) 1;
+    ~*(?i)(Timpibot) 1;
+    # If you don't provide a User-Agent, you can go away
+    ~*(^-$) 1;
+}

--- a/nginx/extra/maintenance.conf.template
+++ b/nginx/extra/maintenance.conf.template
@@ -1,0 +1,5 @@
+error_page 503 @maintenance;
+location @maintenance {
+    root /srv;
+    try_files $uri /maintenance.html =503;
+}

--- a/nginx/http/flower.conf.template
+++ b/nginx/http/flower.conf.template
@@ -1,0 +1,7 @@
+server { 
+    listen ${FLOWER_PUBLIC_PORT};
+    location / {
+        proxy_pass http://flower:5555;
+    }
+    
+}

--- a/nginx/http/flower.conf.template
+++ b/nginx/http/flower.conf.template
@@ -3,5 +3,4 @@ server {
     location / {
         proxy_pass http://flower:5555;
     }
-    
 }

--- a/nginx/http/minio.conf.template
+++ b/nginx/http/minio.conf.template
@@ -17,16 +17,4 @@ server {
 
         proxy_pass http://minio:9000;
     }
-
-    location /console/ {
-        rewrite ^/console/(.*)$ /$1 break;
-
-        # To support websocket
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-
-        chunked_transfer_encoding off;
-        proxy_pass http://minio;
-    }
 }

--- a/nginx/http/minio.conf.template
+++ b/nginx/http/minio.conf.template
@@ -10,11 +10,37 @@ server {
     proxy_request_buffering off;
 
     location / {
+        include extra/anti_scrapper.conf;
+
         # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
         proxy_pass http://minio:9000;
+    }
+
+    # MinIO console
+    location /console/ {
+        include extra/anti_scrapper.conf;
+
+        rewrite ^/console/(.*)$ /$1 break;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        # This is necessary to pass the correct IP to be hashed
+        real_ip_header X-Real-IP;
+        proxy_connect_timeout 300;
+
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        chunked_transfer_encoding off;
+        proxy_pass http://minio:9001;
     }
 }

--- a/nginx/http/minio.conf.template
+++ b/nginx/http/minio.conf.template
@@ -1,0 +1,32 @@
+server {
+    listen ${MINIO_PORT};
+    # To allow special characters in headers
+    ignore_invalid_headers off;
+    # Allow any size file to be uploaded.
+    # Set to a value such as 1000m; to restrict file size to a specific value
+    client_max_body_size 0;
+    # To disable buffering
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    location / {
+        # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        chunked_transfer_encoding off;
+
+        proxy_pass http://minio:9000;
+    }
+
+    location /console/ {
+        rewrite ^/console/(.*)$ /$1 break;
+
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        chunked_transfer_encoding off;
+        proxy_pass http://minio;
+    }
+}

--- a/nginx/http/rabbit_console.conf.template
+++ b/nginx/http/rabbit_console.conf.template
@@ -1,0 +1,6 @@
+server {
+    listen ${RABBITMQ_MANAGEMENT_PORT};
+    location / {
+        proxy_pass http://rabbit:15672;
+    }
+}

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -47,6 +47,7 @@ http {
     acme_issuer letsencrypt {
         uri         https://acme-v02.api.letsencrypt.org/directory;
         contact   ${EMAIL};
+        #ssl_trusted_certificate /path/to/root_ca.crt;
         state_path  /var/cache/nginx/acme-letsencrypt;
 
         accept_terms_of_service;
@@ -92,7 +93,6 @@ http {
 
             proxy_pass http://django:8000;
         }
-        # MinIO console
         include extra/maintenance.conf;
 
     }

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -9,117 +9,128 @@ events {
 error_log /var/log/nginx/error.log warn;
 
 stream {
+    resolver 127.0.0.11 ipv6=off;
     log_format proxy '$remote_addr [$time_local] '
-                 '$protocol $status $bytes_sent $bytes_received '
-                 '$session_time "$upstream_addr" '
-                 '"$upstream_bytes_sent" "$upstream_bytes_received" "$upstream_connect_time"';
+                '$protocol $status $bytes_sent $bytes_received '
+                '$session_time "$upstream_addr" '
+                '"$upstream_bytes_sent" "$upstream_bytes_received" "$upstream_connect_time"';
     access_log /var/log/nginx/stream_access.log proxy buffer=32k flush=5s;
     error_log /var/log/nginx/stream_error.log warn;
-    # Rabbit and Database connections
+
+    map "" $database_access {
+        default ${DATABASE_ACCESS};
+    }
+    map $database_access $backend {
+        default no_access;
+        "True" db:5432;
+    }
+    # Rabbit and Database
     include stream/rabbit.conf;
     include stream/database.conf;
 }
 
 http {
-access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
+    access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
 
-# Includes MinIO, Rabbit (console)
-include http/*;
-# Scrapper protection
-include extra/block_map.conf;
+    # Scrapper protection
+    include extra/block_map.conf;
 
-server_tokens off;
+    # Includes MinIO, Rabbit (console)
+    include http/flower.conf;
+    include http/minio.conf;
+    include http/rabbit_console.conf;
 
-# Necessary for ACME to work inside Docker
-resolver 127.0.0.11 ipv6=off;
-acme_issuer letsencrypt {
-    uri         https://acme-v02.api.letsencrypt.org/directory;
-    contact   ${EMAIL};
-    state_path  /var/cache/nginx/acme-letsencrypt;
+    server_tokens off;
 
-    accept_terms_of_service;
-}
-acme_shared_zone zone=ngx_acme_shared:1M;
+    # Necessary for ACME to work inside Docker
+    resolver 127.0.0.11 ipv6=off;
+    acme_issuer letsencrypt {
+        uri         https://acme-v02.api.letsencrypt.org/directory;
+        contact   ${EMAIL};
+        state_path  /var/cache/nginx/acme-letsencrypt;
 
-
-# Default server catchall for misconfigured machines trying to access the site
-server {
-    server_name _;
-    listen *:80 default_server deferred;
-    return 444;
-}
-
-# HTTP for the main instance
-server {
-    set $force_https ${HTTPS};
-    listen 80;
-    server_name ${DOMAIN_NAME};
-
-    include extra/base_django.conf;
-    include extra/anti_scrapper.conf;
-    location / {
-        if ($force_https ~* "true") {
-            return 301 https://$host$request_uri;
-        }
-        if (-f /srv/maintenance.on) {
-            return 503;
-        }
-        
-        proxy_intercept_errors on;
-        proxy_redirect off;
-        proxy_buffering off;
-        # To support websocket
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        
-        proxy_pass http://django:8000;
+        accept_terms_of_service;
     }
-    # MinIO console
-    location /console/ {
-        rewrite ^/console/(.*)$ /$1 break;
+    acme_shared_zone zone=ngx_acme_shared:1M;
 
-        # To support websocket
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
 
-        chunked_transfer_encoding off;
-        proxy_pass http://minio:9001;
+    # Default server catchall for misconfigured machines trying to access the site
+    server {
+        server_name _;
+        listen *:80 default_server deferred;
+        return 444;
     }
-    include extra/maintenance.conf;
 
-}
+    # HTTP for the main instance
+    server {
+        set $force_https ${HTTPS};
+        listen 80;
+        server_name ${DOMAIN_NAME};
 
-# HTTPS for the main instance
-server {
-    listen 443 ssl;
-    server_name ${DOMAIN_NAME};
+        include extra/base_django.conf;
+        include extra/anti_scrapper.conf;
 
-    acme_certificate letsencrypt;
-    ssl_certificate       $acme_certificate;
-    ssl_certificate_key   $acme_certificate_key;
-    # do not parse the certificate on each request
-    ssl_certificate_cache max=2;
-    
-    include extra/base_django.conf;
-    include extra/anti_scrapper.conf;
-    
-    location / {
-        if (-f /srv/maintenance.on) {
-            return 503;
+        location /robots.txt {
+            autoindex off;
+            alias /etc/nginx/templates/robots.txt;
         }
-        
-        proxy_intercept_errors on;
-        proxy_redirect off;
-        proxy_buffering off;
-        # To support websocket
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        location / {
+            if ($force_https ~* "true") {
+                return 301 https://$host$request_uri;
+            }
+            if (-f /srv/maintenance.on) {
+                return 503;
+            }
 
-        proxy_pass http://django:8000;
+            proxy_intercept_errors on;
+            proxy_redirect off;
+            proxy_buffering off;
+            # To support websocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+
+            proxy_pass http://django:8000;
+        }
+        # MinIO console
+        include extra/maintenance.conf;
+
     }
-    include extra/maintenance.conf;
-}
+
+    # HTTPS for the main instance
+    server {
+        listen 443 ssl;
+        server_name ${DOMAIN_NAME};
+
+        acme_certificate letsencrypt;
+        ssl_certificate       $acme_certificate;
+        ssl_certificate_key   $acme_certificate_key;
+        # do not parse the certificate on each request
+        ssl_certificate_cache max=2;
+
+        include extra/base_django.conf;
+        include extra/anti_scrapper.conf;
+
+        location /robots.txt {
+            autoindex off;
+            alias /etc/nginx/templates/robots.txt;
+        }
+
+        location / {
+            if (-f /srv/maintenance.on) {
+                return 503;
+            }
+
+            proxy_intercept_errors on;
+            proxy_redirect off;
+            proxy_buffering off;
+            # To support websocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+
+            proxy_pass http://django:8000;
+        }
+        include extra/maintenance.conf;
+    }
 }

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -75,6 +75,18 @@ server {
         
         proxy_pass http://django:8000;
     }
+    # MinIO console
+    location /console/ {
+        rewrite ^/console/(.*)$ /$1 break;
+
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        chunked_transfer_encoding off;
+        proxy_pass http://minio:9001;
+    }
     include extra/maintenance.conf;
 
 }

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -1,0 +1,113 @@
+user nginx;
+load_module modules/ngx_http_acme_module.so;
+worker_rlimit_nofile 65535;
+worker_processes  auto;
+events {
+    worker_connections  4096;
+}
+
+error_log /var/log/nginx/error.log warn;
+
+stream {
+    log_format proxy '$remote_addr [$time_local] '
+                 '$protocol $status $bytes_sent $bytes_received '
+                 '$session_time "$upstream_addr" '
+                 '"$upstream_bytes_sent" "$upstream_bytes_received" "$upstream_connect_time"';
+    access_log /var/log/nginx/stream_access.log proxy buffer=32k flush=5s;
+    error_log /var/log/nginx/stream_error.log warn;
+    # Rabbit and Database connections
+    include stream/rabbit.conf;
+    include stream/database.conf;
+}
+
+http {
+access_log /var/log/nginx/access.log combined buffer=32k flush=5s;
+
+# Includes MinIO, Rabbit (console)
+include http/*;
+# Scrapper protection
+include extra/block_map.conf;
+
+server_tokens off;
+
+# Necessary for ACME to work inside Docker
+resolver 127.0.0.11 ipv6=off;
+acme_issuer letsencrypt {
+    uri         https://acme-v02.api.letsencrypt.org/directory;
+    contact   ${EMAIL};
+    state_path  /var/cache/nginx/acme-letsencrypt;
+
+    accept_terms_of_service;
+}
+acme_shared_zone zone=ngx_acme_shared:1M;
+
+
+# Default server catchall for misconfigured machines trying to access the site
+server {
+    server_name _;
+    listen *:80 default_server deferred;
+    return 444;
+}
+
+# HTTP for the main instance
+server {
+    set $force_https ${HTTPS};
+    listen 80;
+    server_name ${DOMAIN_NAME};
+
+    include extra/base_django.conf;
+    include extra/anti_scrapper.conf;
+    location / {
+        if ($force_https ~* "true") {
+            return 301 https://$host$request_uri;
+        }
+        if (-f /srv/maintenance.on) {
+            return 503;
+        }
+        
+        proxy_intercept_errors on;
+        proxy_redirect off;
+        proxy_buffering off;
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        
+        proxy_pass http://django:8000;
+    }
+    include extra/maintenance.conf;
+
+}
+
+# HTTPS for the main instance
+server {
+    listen 443 ssl;
+    server_name ${DOMAIN_NAME};
+
+    acme_certificate letsencrypt;
+    ssl_certificate       $acme_certificate;
+    ssl_certificate_key   $acme_certificate_key;
+    # do not parse the certificate on each request
+    ssl_certificate_cache max=2;
+    
+    include extra/base_django.conf;
+    include extra/anti_scrapper.conf;
+    
+    location / {
+        if (-f /srv/maintenance.on) {
+            return 503;
+        }
+        
+        proxy_intercept_errors on;
+        proxy_redirect off;
+        proxy_buffering off;
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        proxy_pass http://django:8000;
+    }
+    include extra/maintenance.conf;
+}
+}

--- a/nginx/robots.txt
+++ b/nginx/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/nginx/stream/database.conf.template
+++ b/nginx/stream/database.conf.template
@@ -1,4 +1,4 @@
 server {
     listen 5432;
-    proxy_pass db:5432;
+    proxy_pass $backend;
 }

--- a/nginx/stream/database.conf.template
+++ b/nginx/stream/database.conf.template
@@ -1,0 +1,4 @@
+server {
+    listen 5432;
+    proxy_pass db:5432;
+}

--- a/nginx/stream/rabbit.conf.template
+++ b/nginx/stream/rabbit.conf.template
@@ -1,0 +1,4 @@
+server {
+    listen ${RABBITMQ_PORT};
+    proxy_pass rabbit:5672;
+}

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -15,6 +15,6 @@ dependencies = [
 [tool.pytest.ini_options]
 # Use localhost as default host
 # addopts = --base-url=localhost --headed --browser webkit --browser firefox --browser chromium --numprocesses 2
-addopts = "--base-url=http://localhost:8000 --browser firefox --screenshot only-on-failure --full-page-screenshot"
+addopts = "--base-url=http://localhost --browser firefox --screenshot only-on-failure --full-page-screenshot"
 log_cli = "true"
 log_cli_level = "INFO"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,7 @@ data = toml.load("config/config.toml")
 def test_auth(browser: Browser) -> None:
     context = browser.new_context()
     page = context.new_page()
-    page.goto("http://localhost:8000")
+    page.goto("http://localhost")
     page.get_by_role("link", name="Login").click()
     page.get_by_role("textbox", name="username or email").click()
     page.get_by_role("textbox", name="username or email").fill(


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
- Replace Caddy with Nginx, allowing us to route every connection through it (like rabbit, minio, postgres) instead of only HTTP(S) connections
- Add anti-scrapping measures
- Add robots.txt file
- Closed all the external ports of the containers except Nginx. Everything must go through Nginx now.
- Made all containers (except Nginx, Django, Compute Worker and Builder) unable to access the outside world.
- Add rate limit

# Manual Intervention
There are some new environment variable that will be needed in the .env file
```
HTTPS=False # Or True
RATE_LIMIT=5
```

If your `DOMAIN_NAME` contains :  you will need to remove it.
For example, `localhost:80` becomes `localhost`

# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

