### PR TITLE
Include username in email

### DIFF
--- a/src/apps/competitions/emails.py
+++ b/src/apps/competitions/emails.py
@@ -10,8 +10,8 @@ def send_participation_requested_emails(participant):
         return
 
     context = {
-        'participant': participant,  
-        'user': participant.user  
+        'participant': participant,
+        'user': participant.user
     }
     # Notify Organizers
     codalab_send_mail(
@@ -37,8 +37,8 @@ def send_participation_accepted_emails(participant):
         return
 
     context = {
-        'participant': participant,  
-        'user': participant.user  
+        'participant': participant,
+        'user': participant.user
     }
     codalab_send_mail(
         context_data=context,
@@ -62,8 +62,8 @@ def send_participation_denied_emails(participant):
         return
 
     context = {
-        'participant': participant,  
-        'user': participant.user  
+        'participant': participant,
+        'user': participant.user
     }
     # Notify Organizers
     codalab_send_mail(


### PR DESCRIPTION
# Description
Add `user` to the context to have the username include in emails.

# Issues this PR resolves
- Closes #1987


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

