### PR TITLE
Fix auto-migration to next phase

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -153,7 +153,6 @@ class Competition(models.Model):
                 created_by_migration=current_phase,
                 participant=submission.participant,
                 phase=next_phase,
-                task=submission.task,
                 owner=submission.owner,
                 data=submission.data,
             )


### PR DESCRIPTION
# Description

Previously, the phase migration returned `N/a` scores on the leaderboard. The problem was that the submission was actually run on a task from the previous phase.

This simple change fixes:
- Scores displayed on leaderboard
- Submission migrated run on the right task(s)


# Issues this PR resolves
- Point **2. c)** of #1540 


# A checklist for hand testing
- [x] Make a leaderboard submission
- [x] Set up the next phase to change soon and enable "auto-migrate to this phase"
- [x] Wait and check that the submission run and is displayed well on leaderboard

If the auto-migration is not triggered, you can enter inside Django container, shell_plus, and run:
```python
from competitions.tasks import manual_migration
manual_migration(<FIRST_PHASE_ID>)
```


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

