### PR TITLE
Support for Multiple Domain names (instance behind reverse proxy)

### DIFF
--- a/documentation/docs/Developers_and_Administrators/How-to-deploy-Codabench-on-your-server.md
+++ b/documentation/docs/Developers_and_Administrators/How-to-deploy-Codabench-on-your-server.md
@@ -440,3 +440,6 @@ Caddyfile :
     }
     reverse_proxy @min_bucket minio:{$MINIO_PORT}
 ```
+
+## Codabench Instance behind a reverse proxy
+If you put your instance behind a reverse proxy and want that proxy to contact the instance via http or https, your `DOMAIN_NAME` might not be reachable from the outside. In this case, you can set `DOMAIN_NAME` as your internal domain name, used by the reverse proxy, and `EXTERNAL_DOMAIN_NAME` as the domain name that is known on external networks (like the internet).

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -19,15 +19,21 @@ USE_X_FORWARDED_HOST = True
 csrf_https_domain = "https://" + os.environ.get("DOMAIN_NAME").split(':')[0]
 csrf_http_domain = "http://" + os.environ.get("DOMAIN_NAME").split(':')[0]
 
-CSRF_TRUSTED_ORIGINS = [csrf_https_domain, csrf_http_domain]
-CSRF_ALLOWED_ORIGINS = [csrf_https_domain, csrf_http_domain]
+if os.environ.get("EXTERNAL_DOMAIN_NAME", "") != "":
+    csrf_https_external_domain = "https://" + os.environ.get("EXTERNAL_DOMAIN_NAME", "").split(':')[0]
+    csrf_http_external_domain = "http://" + os.environ.get("EXTERNAL_DOMAIN_NAME", "").split(':')[0]
+    CSRF_TRUSTED_ORIGINS = [csrf_https_domain, csrf_http_domain, csrf_https_external_domain, csrf_http_external_domain]
+    CSRF_ALLOWED_ORIGINS = [csrf_https_domain, csrf_http_domain, csrf_https_external_domain, csrf_http_external_domain]
 
-SITE_ID = 1
+    DOMAIN_NAME = os.environ.get('EXTERNAL_DOMAIN_NAME').split(':')[0]
+else:
+    CSRF_TRUSTED_ORIGINS = [csrf_https_domain, csrf_http_domain]
+    CSRF_ALLOWED_ORIGINS = [csrf_https_domain, csrf_http_domain]
+
+    DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost').split(':')[0]
 
 SITE_DOMAIN = os.environ.get('SITE_DOMAIN', 'http://localhost')
-DOMAIN_NAME = os.environ.get('DOMAIN_NAME', 'localhost').split(':')[0]
-
-SELENIUM_HOSTNAME = os.environ.get("SELENIUM_HOSTNAME", "localhost")
+SITE_ID = 1
 
 
 THIRD_PARTY_APPS = (


### PR DESCRIPTION
# Description
If the instance is deployed behind a reverse proxy, which then proxies the requests via HTTPS, there can be some errors related to CSRF which are fixed in this PR.

If the DOMAIN_NAME is not the same as the external domain name for the website, some things like emails will use an unknown domain name as the URL, this PR fixes this.

To fix these problems, use the new `EXTERNAL_DOMAIN_NAME` variable in the .env, setting it to the domain name that is available externally while keeping the `DOMAIN_NAME` locally accessible.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

