### PR TITLE
Revert change on Containerfile

### DIFF
--- a/packaging/container/Containerfile
+++ b/packaging/container/Containerfile
@@ -1,18 +1,3 @@
-# Stage 1: Node.js builder
-FROM node:lts-alpine3.23 AS builder
-
-WORKDIR /app
-
-COPY package.json package-lock.json* ./
-COPY src/static ./src/static
-
-RUN npm install \
-    && export PATH=./node_modules/.bin:$PATH \
-    && npm run build-stylus \
-    && npm run build-riot \
-    && npm run concat-riot
-
-# Stage 2: Python/Django
 FROM almalinux:10-minimal
 
 RUN microdnf install -y tar gzip
@@ -31,11 +16,4 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --all-extras --frozen
 
 WORKDIR /app
-
-COPY src ./src
-COPY manage.py ./
-
-# Copy built static files from Node builder
-COPY --from=builder /app/src/static ./src/static
-
 ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
# Description

This PR revert the

The change in `Containerfile` from #2055 PR are causing some troubles:

- It makes the build 10 times slower 
- The build fails on pre-production server with the following error:

```sh
 => ERROR [django builder 5/5] RUN npm install     && export PATH=./node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin     && npm run build-stylus     && npm run build-  81.4s
 => [compute_worker 3/6] COPY compute_worker/pyproject.toml compute_worker/uv.lock compute_worker/celery_config.py compute_worker/compute_worker.py ./                                                 0.1s
 => [django stage-1 3/9] RUN curl -LsSf https://astral.sh/uv/install.sh | sh && microdnf remove -y tar gzip && microdnf clean all                                                                      2.7s
 => [compute_worker 4/6] RUN curl -LsSf https://astral.sh/uv/install.sh | sh && microdnf remove -y tar gzip && microdnf clean all                                                                      2.7s 
 => [django stage-1 4/9] COPY pyproject.toml uv.lock ./                                                                                                                                                0.1s 
 => [compute_worker 5/6] RUN uv sync --frozen                                                                                                                                                          4.7s 
 => [django stage-1 5/9] RUN uv sync --all-extras --frozen                                                                                                                                             8.8s 
 => [compute_worker 6/6] COPY src/settings/logs_loguru.py /.venv/bin                                                                                                                                   0.7s 
 => [compute_worker] exporting to image                                                                                                                                                                3.4s 
 => => exporting layers                                                                                                                                                                                3.4s 
 => => writing image sha256:df32d92ce8d218c86fb8c3d810818e07839eb4f88447e5ccdd5b8f2ec17870ec                                                                                                           0.0s 
 => => naming to docker.io/library/codabench-compute_worker                                                                                                                                            0.0s 
 => [django stage-1 6/9] WORKDIR /app                                                                                                                                                                  0.1s 
 => [django stage-1 7/9] COPY src ./src                                                                                                                                                                0.8s 
 => [compute_worker] resolving provenance for metadata file                                                                                                                                            0.0s 
 => [django stage-1 8/9] COPY manage.py ./                                                                                                                                                             0.1s 
------                                                                                                                                                                                                      
 > [django builder 5/5] RUN npm install     && export PATH=./node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin     && npm run build-stylus     && npm run build-riot     && npm run concat-riot:                                                                                                                                                                                           
81.05 npm error Exit handler never called!
81.05 npm error This is an error with npm itself. Please report this error at:
81.05 npm error   <https://github.com/npm/cli/issues>
81.05 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-03-17T23_12_06_423Z-debug-0.log
81.27 
81.27 > competitions-v2@0.0.1 build-stylus
81.27 > stylus --compress --sourcemap-inline < src/static/stylus/index.styl > src/static/generated/output.css
81.27 
81.32 sh: stylus: not found
```

### We need either:
- To fix it (maybe by fixing a stable version instead of `node:lts-alpine3.23`)
- To revert it (with the current PR) 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

