### PR TITLE
EMAIL - reintroduced DEFAULT_FROM_EMAIL

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -45,6 +45,7 @@ SELENIUM_HOSTNAME=selenium
 #EMAIL_HOST_PASSWORD=pass
 #EMAIL_PORT=587
 #EMAIL_USE_TLS=True
+#DEFAULT_FROM_EMAIL="Codabench <noreply@example.com>"
 #SERVER_EMAIL=noreply@example.com
 
 # Contact Email

--- a/src/apps/forums/helpers.py
+++ b/src/apps/forums/helpers.py
@@ -15,7 +15,7 @@ def send_mail(context=None, from_email=None, html_file=None, text_file=None, sub
     :param subject: Email's subject.
     :param to_email: Recipient's email.
     """
-    from_email = from_email if from_email else settings.SERVER_EMAIL
+    from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
 
     context["site"] = Site.objects.get_current()
 

--- a/src/apps/profiles/helpers.py
+++ b/src/apps/profiles/helpers.py
@@ -15,7 +15,7 @@ def send_mail(context=None, from_email=None, html_file=None, text_file=None, sub
     :param subject: Email's subject.
     :param to_email: Recipient's email.
     """
-    from_email = from_email if from_email else settings.SERVER_EMAIL
+    from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
 
     context["site"] = Site.objects.get_current()
 

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -544,6 +544,7 @@ EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = os.environ.get('EMAIL_PORT', 587)
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', True)
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'Codabench <noreply@codabench.org>')
 SERVER_EMAIL = os.environ.get('SERVER_EMAIL', 'noreply@codabench.org')
 
 CONTACT_EMAIL = os.environ.get('CONTACT_EMAIL', 'info@codabench.org')

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 
 
 def codalab_send_mail(context_data, to_email, html_file, text_file, subject, from_email=None):
-    from_email = from_email if from_email else settings.SERVER_EMAIL
+    from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
 
     context_data["site"] = Site.objects.get_current()
 
@@ -40,7 +40,7 @@ def sanitize(content):
 
 
 def codalab_send_markdown_email(subject, markdown_content, recipient_list, from_email=None):
-    from_email = from_email if from_email else settings.SERVER_EMAIL
+    from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
     html_message = markdown.markdown(markdown_content)
     # message = sanitize(markdown_content)
     # html_message = sanitize(markdown.markdown(message))


### PR DESCRIPTION
# Description
This PR reintroduces `DEFAULT_FROM_EMAIL`. We were using it before but then we decided to use `SERVER_EMAIL`.  Django uses `SERVER_EMAIL` to send emails to admins and managers (not configured in our project)


# Issues this PR resolves
- #2216



# A checklist for hand testing
- [ ] Test on codabench test
- [ ] Sync .env with the changes


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

