### PR TITLE
Git - added autogenerated files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ src/static/generated/*
 db.sqlite3
 
 celerybeat-schedule
+celerybeat-schedule-shm
+celerybeat-schedule-wal
 celerybeat-schedule.db
 package-lock.json
 artifacts/
@@ -44,3 +46,4 @@ caddy_data/
 home_page_counters.json
 my-postgres.conf
 tests/config/state.json
+


### PR DESCRIPTION
# Description
Celery is generating new files that are not added to `.gitignore`
- celerybeat-schedule-shm
- celerybeat-schedule-wal



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

