### PR TITLE
Submission Upload - uploading non zip error improved

### DIFF
--- a/src/apps/api/serializers/datasets.py
+++ b/src/apps/api/serializers/datasets.py
@@ -46,12 +46,19 @@ class DataSerializer(DefaultUserCreateMixin, serializers.ModelSerializer):
         return is_public
 
     def validate(self, attrs):
+        # Check for duplicate name
         if 'name' in attrs:
             existing_lookup = Data.objects.filter(name=attrs['name'], created_by=self.context['request'].user)
             if self.instance:
                 existing_lookup = existing_lookup.exclude(pk=self.instance.pk)
             if existing_lookup.exists():
                 raise ValidationError("You already have a dataset by this name, please delete that dataset or rename this one")
+
+        # Validate file type
+        request_sassy_file_name = attrs.get('request_sassy_file_name')
+        if request_sassy_file_name and not request_sassy_file_name.endswith('.zip'):
+            raise ValidationError("Only zip files are allowed!")
+
         return attrs
 
     def create(self, validated_data):

--- a/src/apps/api/serializers/submissions.py
+++ b/src/apps/api/serializers/submissions.py
@@ -8,7 +8,6 @@ from rest_framework.exceptions import PermissionDenied
 
 from api.mixins import DefaultUserCreateMixin
 from api.serializers import leaderboards
-# from api.serializers.profiles import SimpleOrganizationSerializer
 from api.serializers.tasks import TaskSerializer
 from api.serializers.submission_leaderboard import SubmissionScoreSerializer
 from competitions.models import Submission, SubmissionDetails, CompetitionParticipant, Phase

--- a/src/apps/api/tests/test_datasets.py
+++ b/src/apps/api/tests/test_datasets.py
@@ -30,8 +30,8 @@ class DatasetAPITests(APITestCase):
         resp = self.client.post(reverse("data-list"), {
             'name': 'Test!',
             'type': Data.COMPETITION_BUNDLE,
-            'request_sassy_file_name': faker.file_name(),
-            'file_name': faker.file_name(),
+            'request_sassy_file_name': faker.file_name(extension='.zip'),
+            'file_name': faker.file_name(extension='.zip'),
             'file_size': 1000,
         })
 
@@ -42,7 +42,7 @@ class DatasetAPITests(APITestCase):
         resp = self.client.put(reverse("data-detail", args=(self.existing_dataset.pk,)), {
             'name': 'Test!',
             'type': Data.COMPETITION_BUNDLE,
-            'request_sassy_file_name': faker.file_name(),
+            'request_sassy_file_name': faker.file_name(extension='.zip'),
             'file_size': 1000,
         })
         assert resp.status_code == 200
@@ -77,8 +77,8 @@ class DatasetAPITests(APITestCase):
         resp = self.client.post(reverse("data-list"), {
             'name': 'new-file-test',
             'type': Data.COMPETITION_BUNDLE,
-            'request_sassy_file_name': faker.file_name(),
-            'file_name': faker.file_name(),
+            'request_sassy_file_name': faker.file_name(extension='.zip'),
+            'file_name': faker.file_name(extension='.zip'),
             'file_size': file_size,
         })
 
@@ -90,11 +90,27 @@ class DatasetAPITests(APITestCase):
         resp = self.client.post(reverse("data-list"), {
             'name': 'new-file-test',
             'type': Data.COMPETITION_BUNDLE,
-            'request_sassy_file_name': faker.file_name(),
+            'request_sassy_file_name': faker.file_name(extension='.zip'),
             'file_name': faker.file_name(),
             'file_size': file_size,
         })
         assert resp.status_code == 201
+
+    def test_dataset_api_rejects_non_zip_files(self):
+        self.client.login(username='creator', password='creator')
+
+        # Attempt to upload a non-zip file
+        resp = self.client.post(reverse("data-list"), {
+            'name': 'non-zip-test',
+            'type': Data.COMPETITION_BUNDLE,
+            'request_sassy_file_name': faker.file_name(extension='.py'),
+            'file_name': faker.file_name(extension='.py'),
+            'file_size': 1000,
+        })
+
+        assert resp.status_code == 400
+        assert "non_field_errors" in resp.data
+        assert resp.data["non_field_errors"][0] == "Only zip files are allowed!"
 
 
 class DatasetDetailTests(TestCase):


### PR DESCRIPTION
# Description
Uploading non zip file was giving 403 error without any description. Now the error will show that zip file is required
<img width="330" height="102" alt="Screenshot 2026-03-18 at 6 17 05 PM" src="https://github.com/user-attachments/assets/014f1a03-ee50-41d2-8832-24ee3f305d96" />



# Issues this PR resolves
- #2248



# A checklist for hand testing
- [x] to upload a non zip file from the UI, inspect the code and remove allow=zip from the file upload input


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

