### PR TITLE
Quota Cleanup - Do not delete public data and starting kit

### DIFF
--- a/src/apps/api/tests/test_cleanup.py
+++ b/src/apps/api/tests/test_cleanup.py
@@ -56,8 +56,7 @@ class CleanUpTests(APITestCase):
             DataFactory(created_by=user, type=Data.INGESTION_PROGRAM),
             DataFactory(created_by=user, type=Data.SCORING_PROGRAM),
             DataFactory(created_by=user, type=Data.INPUT_DATA),
-            DataFactory(created_by=user, type=Data.REFERENCE_DATA),
-            DataFactory(created_by=user, type=Data.PUBLIC_DATA)
+            DataFactory(created_by=user, type=Data.REFERENCE_DATA)
         ]
 
         self.client.login(username='test_user', password='test_user')

--- a/src/apps/api/views/quota.py
+++ b/src/apps/api/views/quota.py
@@ -18,10 +18,13 @@ def user_quota_cleanup(request):
     ).count()
 
     # Get Unused datasets and programs count
+    # Exclude Submission, Competition Bundle, Public Data, Starting Kit
     unused_datasets_programs = Data.objects.filter(
         Q(created_by=request.user) &
         ~Q(type=Data.SUBMISSION) &
-        ~Q(type=Data.COMPETITION_BUNDLE)
+        ~Q(type=Data.COMPETITION_BUNDLE) &
+        ~Q(type=Data.PUBLIC_DATA) &
+        ~Q(type=Data.STARTING_KIT)
     ).exclude(
         Q(task_ingestion_programs__isnull=False) |
         Q(task_input_datas__isnull=False) |
@@ -81,10 +84,13 @@ def delete_unused_tasks(request):
 @api_view(['DELETE'])
 def delete_unused_datasets(request):
     try:
+        # Exclude Submission, Competition Bundle, Public Data, Starting Kit
         Data.objects.filter(
             Q(created_by=request.user) &
             ~Q(type=Data.SUBMISSION) &
-            ~Q(type=Data.COMPETITION_BUNDLE)
+            ~Q(type=Data.COMPETITION_BUNDLE) &
+            ~Q(type=Data.PUBLIC_DATA) &
+            ~Q(type=Data.STARTING_KIT)
         ).exclude(
             Q(task_ingestion_programs__isnull=False) |
             Q(task_input_datas__isnull=False) |


### PR DESCRIPTION
# Description
In quota cleanup, UNUSED public data and starting kits were also deleted. Now these unused resources will not show up in the cleanup statistics and will not be deleted using "Delete Unused datasets and programs"


# Issues this PR resolves
- #2277


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

