### PR TITLE
Add more information in submissions csv (django admin + organizer)

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -291,6 +291,7 @@ class SubmissionViewSet(ModelViewSet):
             'created_when': 'Created When',
             'status': 'Status',
             'phase_name': 'Phase',
+            'scores.0.score': 'Score',
         }
         context["header"] = [k for k in context["labels"].keys()]
         return context

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -293,6 +293,7 @@ class SubmissionViewSet(ModelViewSet):
             'phase_name': 'Phase',
             'task.name': 'Task',
             'scores.0.score': 'Score',
+            'on_leaderboard': 'On Leaderboard'
         }
         context["header"] = [k for k in context["labels"].keys()]
         return context

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -291,6 +291,7 @@ class SubmissionViewSet(ModelViewSet):
             'created_when': 'Created When',
             'status': 'Status',
             'phase_name': 'Phase',
+            'task.name': 'Task',
             'scores.0.score': 'Score',
         }
         context["header"] = [k for k in context["labels"].keys()]

--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -92,9 +92,16 @@ def SubmissionsExport_as_csv(modeladmin, request, queryset):
         headers={"Content-Disposition": 'attachment; filename="submissions.csv"'},
     )
     writer = csv.writer(response)
-    writer.writerow(["ID", "Owner", "Status", "Task", "Phase", "Queue"])
+    writer.writerow(["ID", "Owner", "Status", "Task", "Phase", "Competition Title", "Competition creation date", "Scores"])
     for obj in queryset:
-        writer.writerow([obj.id, obj.owner, obj.status, obj.task, obj.phase, obj.queue])
+        scores_list = []
+        for scores in obj.scores.all():
+            scores_list.append(scores.score)
+        if obj.task is not None:
+            if len(scores_list) == 0:
+                writer.writerow([obj.id, obj.owner, obj.status, obj.task, obj.phase, obj.phase.competition.title, obj.phase.competition.created_when, "None"])
+            else:
+                writer.writerow([obj.id, obj.owner, obj.status, obj.task, obj.phase, obj.phase.competition.title, obj.phase.competition.created_when, scores_list[0]])
     return response
 
 

--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -104,6 +104,7 @@ def SubmissionsExport_as_csv(modeladmin, request, queryset):
             "Competition creation date",
             "Queue",
             "Scores",
+            "On Leaderboard",
         ]
     )
     for obj in queryset:
@@ -124,6 +125,7 @@ def SubmissionsExport_as_csv(modeladmin, request, queryset):
                         obj.phase.competition.created_when,
                         obj.queue,
                         "None",
+                        obj.appear_on_leaderboards,
                     ]
                 )
             else:
@@ -139,6 +141,7 @@ def SubmissionsExport_as_csv(modeladmin, request, queryset):
                         obj.phase.competition.created_when,
                         obj.queue,
                         scores_list[0],
+                        obj.appear_on_leaderboards,
                     ]
                 )
     return response

--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -92,16 +92,55 @@ def SubmissionsExport_as_csv(modeladmin, request, queryset):
         headers={"Content-Disposition": 'attachment; filename="submissions.csv"'},
     )
     writer = csv.writer(response)
-    writer.writerow(["ID", "Owner", "Status", "Task", "Phase", "Competition Title", "Competition creation date", "Scores"])
+    writer.writerow(
+        [
+            "ID",
+            "Owner",
+            "Status",
+            "Submitted on",
+            "Task",
+            "Phase",
+            "Competition Title",
+            "Competition creation date",
+            "Queue",
+            "Scores",
+        ]
+    )
     for obj in queryset:
         scores_list = []
         for scores in obj.scores.all():
             scores_list.append(scores.score)
         if obj.task is not None:
             if len(scores_list) == 0:
-                writer.writerow([obj.id, obj.owner, obj.status, obj.task, obj.phase, obj.phase.competition.title, obj.phase.competition.created_when, "None"])
+                writer.writerow(
+                    [
+                        obj.id,
+                        obj.owner,
+                        obj.status,
+                        obj.created_when,
+                        obj.task,
+                        obj.phase,
+                        obj.phase.competition.title,
+                        obj.phase.competition.created_when,
+                        obj.queue,
+                        "None",
+                    ]
+                )
             else:
-                writer.writerow([obj.id, obj.owner, obj.status, obj.task, obj.phase, obj.phase.competition.title, obj.phase.competition.created_when, scores_list[0]])
+                writer.writerow(
+                    [
+                        obj.id,
+                        obj.owner,
+                        obj.status,
+                        obj.created_when,
+                        obj.task,
+                        obj.phase,
+                        obj.phase.competition.title,
+                        obj.phase.competition.created_when,
+                        obj.queue,
+                        scores_list[0],
+                    ]
+                )
     return response
 
 


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
- Added some new information in the .csv file generated in the Django Admin interface in the submission view to include competition title, creation date and submission score
- Added Score in the submission list CSV generated by the organizer

# Related issue

- Closes #1820

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

