### PR TITLE
Display competitions' start date instead of upload date

### DIFF
--- a/src/apps/api/serializers/competitions.py
+++ b/src/apps/api/serializers/competitions.py
@@ -458,6 +458,7 @@ class CompetitionSerializerSimple(serializers.ModelSerializer):
     created_by = serializers.CharField(source='created_by.username', read_only=True)
     owner_display_name = serializers.SerializerMethodField()
     participants_count = serializers.IntegerField(read_only=True)
+    first_phase_start = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = Competition
@@ -467,6 +468,7 @@ class CompetitionSerializerSimple(serializers.ModelSerializer):
             'created_by',
             'owner_display_name',
             'created_when',
+            'first_phase_start',
             'published',
             'participants_count',
             'logo',
@@ -477,8 +479,7 @@ class CompetitionSerializerSimple(serializers.ModelSerializer):
             'contact_email',
             'report',
             'is_featured',
-            'submissions_count',
-            'participants_count'
+            'submissions_count'
         )
 
     def get_created_by(self, obj):

--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -102,6 +102,13 @@ class Competition(models.Model):
     def all_organizers(self):
         return [self.created_by] + list(self.collaborators.all())
 
+    @property
+    def first_phase_start(self):
+        first_phase = self.phases.filter(index=0).first()
+        if first_phase and first_phase.start:
+            return first_phase.start
+        return self.created_when
+
     def user_has_admin_permission(self, user):
         if isinstance(user, int):
             try:

--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -18,7 +18,7 @@
                             <tr>
                                 <th>Name</th>
                                 <th width="100">Type</th>
-                                <th width="125">Uploaded...</th>
+                                <th width="125">Uploaded</th>
                                 <th width="50px">Publish</th>
                                 <th width="50px">Edit</th>
                                 <th width="50px">Delete</th>
@@ -61,7 +61,7 @@
                             <thead>
                             <tr>
                                 <th>Name</th>
-                                <th width="125px">Uploaded...</th>
+                                <th width="125px">Uploaded</th>
                             </tr>
                             </thead>
                             <tbody>

--- a/src/static/riot/competitions/public-list.tag
+++ b/src/static/riot/competitions/public-list.tag
@@ -75,7 +75,7 @@
             </div>
           </a>
           <div class="comp-stats">
-            {pretty_date(competition.created_when)}
+            {pretty_date(competition.first_phase_start)}
             <div if="{!competition.reward && ! competition.report}" class="ui divider"></div>
             <div>
               <span if="{competition.reward}"><img width="30" height="30" src="/static/img/trophy.png"></span>

--- a/src/static/riot/competitions/tile/competition_tile.tag
+++ b/src/static/riot/competitions/tile/competition_tile.tag
@@ -19,7 +19,7 @@
             </div>
             </a>
             <div class="comp-stats" id="compStats">
-                {pretty_date(created_when)}
+                {pretty_date(first_phase_start)}
                 <div if="{!reward && !report}" class="ui divider"></div>
                 <div>
                     <span if="{reward}"><img width="30" height="30" src="/static/img/trophy.png"></span>

--- a/src/static/riot/profiles/profile_detail.tag
+++ b/src/static/riot/profiles/profile_detail.tag
@@ -51,7 +51,7 @@
                                 </div>
                             </a>
                             <div class="comp-stats">
-                                {pretty_date(competition.created_when)}
+                                {pretty_date(competition.first_phase_start)}
                                 <div if="{!competition.reward && ! competition.report}" class="ui divider"></div>
                                 <div>
                                 <span if="{competition.reward}"><img width="30" height="30" src="/static/img/trophy.png"></span>


### PR DESCRIPTION
# Description
Display competitions' start date instead of upload date in:
- Homepage
- Public benchmarks list
- Profile page

# Issues this PR resolves
- Closes #1815


# A checklist for hand testing
- [x] Check that the date display is right


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

