### PR TITLE
ENV - added / at the end of the url

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -71,7 +71,7 @@ AWS_STORAGE_PRIVATE_BUCKET_NAME=private
 AWS_S3_ENDPOINT_URL=http://minio:9000/
 AWS_QUERYSTRING_AUTH=False
 # Optional URL rewriting in compute worker, format: FROM | TO
-#WORKER_BUNDLE_URL_REWRITE=http://localhost:9000|http://minio:9000
+#WORKER_BUNDLE_URL_REWRITE=http://localhost:9000/|http://minio:9000/
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description
Added `/` to the end of the url in env sample. Without this change the url is incorrect when used in the compute worker


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

