### PR TITLE
Cancel Submission - use submission queue instead of competition queue

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -674,8 +674,10 @@ class Submission(models.Model):
                     sub.cancel(status=status)
             celery_app = app
             # If a custom queue is set, we need to fetch the appropriate celery app
-            if self.phase.competition.queue:
-                celery_app = app_for_vhost(str(self.phase.competition.queue.vhost))
+            # NOTE: We fetch the queue from submission and not from competition to be sure that we are using the correct queue
+            # Originally we were using queue from the competition (self.phase.competition.queue)
+            if self.queue:
+                celery_app = app_for_vhost(str(self.queue.vhost))
             # We need to convert the UUID given by celery into a byte like object otherwise it won't work
             celery_app.control.revoke(str(self.celery_task_id), terminate=True)
             self.status = status


### PR DESCRIPTION
# Description
Originally we were using competition queue to cancel submissions. But we know that submission can have different queue than the competition. This PR changes that and uses submission queue.


# Issues this PR resolves
- #872



# A checklist for hand testing
- [ ] We should test this on custom queue
- [ ] Run submission on `queue_1` then change the competition queue to `queue_2` and cancel the submission 



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

