### PR TITLE
Submission Score - show primary column score and use precision set for the column

### DIFF
--- a/src/apps/api/serializers/submission_leaderboard.py
+++ b/src/apps/api/serializers/submission_leaderboard.py
@@ -8,10 +8,15 @@ from api.serializers.profiles import SimpleOrganizationSerializer
 class SubmissionScoreSerializer(serializers.ModelSerializer):
     index = serializers.IntegerField(source='column.index', read_only=True)
     column_key = serializers.CharField(source='column.key', read_only=True)
+    precision = serializers.IntegerField(source='column.precision', read_only=True)
+    is_primary = serializers.SerializerMethodField()
 
     class Meta:
         model = SubmissionScore
-        fields = ('id', 'index', 'score', 'column_key')
+        fields = ('id', 'index', 'score', 'column_key', 'precision', 'is_primary')
+
+    def get_is_primary(self, obj):
+        return obj.column.index == obj.column.leaderboard.primary_index
 
 
 class SubmissionLeaderBoardSerializer(serializers.ModelSerializer):

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -641,8 +641,12 @@
 
         self.get_score = function (submission) {
             try {
-                return parseFloat(submission.scores[0].score).toFixed(2)
-
+                // Look for a primary score, fallback to the first score if not found
+                let score_obj = _.find(submission.scores, s => s.is_primary) || submission.scores[0]
+                if (score_obj) {
+                    return parseFloat(score_obj.score).toFixed(score_obj.precision || 0)
+                }
+                return ""
             } catch {
                 return ""
             }


### PR DESCRIPTION
# Description
Originally in the submission panel, the score shown was the first score in the scores list and the decimal places were fixed to `2`. This PR updates the logic to show the primary column score set in the leaderboard settings and use the precision (decimal places) set for the primary column

In my test case, I have set precision to `5`.
<img width="1180" height="258" alt="Screenshot 2026-04-02 at 7 22 47 AM" src="https://github.com/user-attachments/assets/40358800-7eff-470c-95e0-b28baddcfe0a" />




# Issues this PR resolves
- This is a feature required for FAIR Universe but is also useful for all users.



# A checklist for hand testing
- [x] upload a bundle that has multiple scores. Play with primary column and precision value to see that correct score with correct precision is shown in the submission panel
- [x] You can also use this [example_bundle.zip](https://github.com/user-attachments/files/26425536/example_bundle.zip). This bundle has only scoring that outputs two random scores. You can submit any zip file as submission.



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

