### PR TITLE
Fixing bug with different HOST_DIRECTORY

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -884,15 +884,15 @@ class Run:
         # Take our list of paths and smash 'em together
         path = os.path.join(*paths)
 
+        # Create if necessary
+        os.makedirs(path, exist_ok=True)
+
         # pull front of path, which points to the location inside the container
         path = path[len(BASE_DIR) :]
 
         # add host to front, so when we run commands in the container on the host they
         # can be seen properly
         path = os.path.join(HOST_DIRECTORY, path)
-
-        # Create if necessary
-        os.makedirs(path, exist_ok=True)
 
         return path
 

--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -925,15 +925,15 @@ class Run:
         # Take our list of paths and smash 'em together
         path = os.path.join(*paths)
 
+        # Create if necessary
+        os.makedirs(path, exist_ok=True)
+
         # pull front of path, which points to the location inside the container
         path = path[len(Settings.BASE_DIR):]
 
         # add host to front, so when we run commands in the container on the host they
         # can be seen properly
         path = os.path.join(Settings.HOST_DIRECTORY, path)
-
-        # Create if necessary
-        os.makedirs(path, exist_ok=True)
 
         return path
 


### PR DESCRIPTION
Original PR from @jbehley: #2311

# Description

This is again a pull request with the (only) necessary changes to allow a different HOST_DIRECTORY`. 

In our setup, we want to have a different HOST_DIRECTORY than `/codabench`. Note that the problem does not occur if the directory on host and inside the container are `/codabench`.

Let's say we have `HOST_DIRECTORY = /home/codabench/` and the desired directory is `/codabench/data/temp/`. Then `makedirs` will try to create `/home/codabench/data/temp` inside the container, which leads to an error.

Btw, we run the worker with podman and with the change it runs now since quite some time with over 350 submissions.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

