### PR TITLE
Compute worker monitoring for organizers and collaborators. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "django-cors-headers==4.9.0",
     "nh3==0.3.3",
     "configobj==5.0.9",
+    "black>=26.3.1",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "nh3==0.3.3",
     "configobj==5.0.9",
     "black>=26.3.1",
+    "redis-cli>=1.0.1",
 ]
 
 [tool.uv]

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -39,9 +39,7 @@ from queues.models import Queue
 from rest_framework.exceptions import ValidationError
 from tasks.models import Task
 
-from celery_config import app
-from celery_config import app as celery_app
-from celery_config import app_for_vhost
+from celery_config import app, app_for_vhost
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
 from utils.worker_utils import (
@@ -53,7 +51,7 @@ from utils.worker_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
+celery_app = app
 r = get_redis_connection("default")
 
 COMPETITION_FIELDS = [
@@ -906,7 +904,7 @@ def _broadcast_worker_state(payload):
     )
 
 
-@app.task(queue="site-worker", soft_time_limit=120)  # 60 → 120
+@app.task(queue="site-worker", soft_time_limit=120)
 def refresh_compute_worker_health():
     known_queue_names = known_compute_queue_names()
     broker_sources = []
@@ -933,7 +931,7 @@ def refresh_compute_worker_health():
         inspected_brokers.add(broker_url)
 
         try:
-            # timeout=5 au lieu de 10 : 4 appels × 5s × N brokers reste raisonnable
+            # timeout=5 : 4 appels × 5s × N brokers
             inspector = broker_app.control.inspect(timeout=5)
             if inspector is None:
                 logger.warning(
@@ -985,11 +983,12 @@ def refresh_compute_worker_health():
                 ),
             )
             _broadcast_worker_state(payload)
-            logger.info(
-                "[WORKER-HEALTH] source=%s worker=%s status=%s jobs=%d queues=%s",
-                source_name,
-                worker_name,
-                status,
-                running_jobs,
-                sorted(queue_names),
-            )
+            #   Logs about CW health HERE
+            # logger.info(
+            #     "[WORKER-HEALTH] source=%s worker=%s status=%s jobs=%d queues=%s",
+            #     source_name,
+            #     worker_name,
+            #     status,
+            #     running_jobs,
+            #     sorted(queue_names),
+            # )

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -43,6 +43,7 @@ from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 r = get_redis_connection("default")
@@ -933,9 +934,8 @@ def refresh_compute_worker_health():
         if not is_compute_worker:
             continue
 
-        running_jobs = (
-            len(active.get(worker_name, []))
-            + len(reserved.get(worker_name, []))
+        running_jobs = len(active.get(worker_name, [])) + len(
+            reserved.get(worker_name, [])
         )
         status = "busy" if running_jobs > 0 else "available"
 
@@ -957,12 +957,14 @@ def refresh_compute_worker_health():
         r.hset(
             WORKERS_REGISTRY_KEY,
             worker_name,
-            json.dumps({
-                "hostname": worker_name,
-                "status": status,
-                "running_jobs": running_jobs,
-                "last_seen": payload["timestamp"],
-            }),
+            json.dumps(
+                {
+                    "hostname": worker_name,
+                    "status": status,
+                    "running_jobs": running_jobs,
+                    "last_seen": payload["timestamp"],
+                }
+            ),
         )
 
         _broadcast_worker_state(payload)

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -8,7 +8,6 @@ import urllib.parse
 import zipfile
 from datetime import datetime, timedelta
 from io import BytesIO
-from queues.models import Queue
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import oyaml as yaml
@@ -36,6 +35,7 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 from django_redis import get_redis_connection
 from leaderboards.models import Leaderboard
+from queues.models import Queue
 from rest_framework.exceptions import ValidationError
 from tasks.models import Task
 
@@ -906,38 +906,10 @@ def _broadcast_worker_state(payload):
     )
 
 
-def _get_broker_host(broker_url):
-    if not broker_url or "@" not in broker_url:
-        return None
-    try:
-        return broker_url.split("@", 1)[1].split("/", 1)[0].split(":", 1)[0]
-    except Exception:
-        return None
-
-
-def _resolve_broker_url(celery_app, broker_url):
-    if not broker_url:
-        return broker_url
-
-    if "@localhost:" not in broker_url:
-        return broker_url
-
-    default_broker = celery_app.conf.broker_url
-    default_host = _get_broker_host(default_broker)
-
-    if not default_host or default_host == "localhost":
-        return broker_url
-
-    return broker_url.replace("@localhost:", f"@{default_host}:")
-
-
-@app.task(queue="site-worker", soft_time_limit=60)
+@app.task(queue="site-worker", soft_time_limit=120)  # 60 → 120
 def refresh_compute_worker_health():
-
     known_queue_names = known_compute_queue_names()
     broker_sources = []
-
-    # Broker par défaut — app déjà configurée
     broker_sources.append(("default", celery_app.conf.broker_url, celery_app))
 
     private_queues = (
@@ -961,7 +933,8 @@ def refresh_compute_worker_health():
         inspected_brokers.add(broker_url)
 
         try:
-            inspector = broker_app.control.inspect(timeout=10)
+            # timeout=5 au lieu de 10 : 4 appels × 5s × N brokers reste raisonnable
+            inspector = broker_app.control.inspect(timeout=5)
             if inspector is None:
                 logger.warning(
                     "Celery inspect returned None for broker=%s", source_name

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -2,18 +2,18 @@ import asyncio
 import json
 import logging
 import os
-from queue import Queue
 import re
 import traceback
+import urllib.parse
 import zipfile
 from datetime import datetime, timedelta
 from io import BytesIO
+from queues.models import Queue
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import oyaml as yaml
 import requests
 from asgiref.sync import async_to_sync
-from celery._state import app_or_default
 from channels.layers import get_channel_layer
 from competitions.models import (
     Competition,
@@ -40,9 +40,15 @@ from rest_framework.exceptions import ValidationError
 from tasks.models import Task
 
 from celery_config import app
-from utils.worker_utils import extract_queue_names, known_compute_queue_names, is_compute_worker
+from celery_config import app as celery_app
+from celery_config import app_for_vhost
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
+from utils.worker_utils import (
+    extract_queue_names,
+    is_compute_worker,
+    known_compute_queue_names,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +242,7 @@ def _send_to_compute_worker(submission, is_scoring):
         # many submissions to be scored while we're waiting for results
         priority = 10 if is_scoring else 0
         if submission.phase.competition.queue:
-            celery_app = app_or_default()
+            celery_app = celery_app.conf.broker_url()
             with celery_app.connection() as new_connection:
                 new_connection.virtual_host = str(
                     submission.phase.competition.queue.vhost
@@ -916,7 +922,7 @@ def _resolve_broker_url(celery_app, broker_url):
     if "@localhost:" not in broker_url:
         return broker_url
 
-    default_broker = getattr(celery_app.conf, "broker_url", None)
+    default_broker = celery_app.conf.broker_url
     default_host = _get_broker_host(default_broker)
 
     if not default_host or default_host == "localhost":
@@ -927,13 +933,12 @@ def _resolve_broker_url(celery_app, broker_url):
 
 @app.task(queue="site-worker", soft_time_limit=60)
 def refresh_compute_worker_health():
-    celery_app = app_or_default()
-    known_queue_names = known_compute_queue_names()
 
+    known_queue_names = known_compute_queue_names()
     broker_sources = []
-    default_broker = getattr(celery_app.conf, "broker_url", None)
-    if default_broker:
-        broker_sources.append(("default", default_broker))
+
+    # Broker par défaut — app déjà configurée
+    broker_sources.append(("default", celery_app.conf.broker_url, celery_app))
 
     private_queues = (
         Queue.objects.filter(competitions__isnull=False)
@@ -942,29 +947,25 @@ def refresh_compute_worker_health():
         .distinct()
     )
     for queue in private_queues:
-        broker_url = _resolve_broker_url(celery_app, queue.broker_url)
-        if broker_url:
-            broker_sources.append((queue.name, broker_url))
+        if not queue.broker_url:
+            continue
+        parsed = urllib.parse.urlparse(queue.broker_url)
+        vhost = parsed.path
+        broker_url = urllib.parse.urljoin(celery_app.conf.broker_url, vhost)
+        broker_sources.append((queue.name, broker_url, app_for_vhost(vhost)))
 
     inspected_brokers = set()
-    for source_name, broker_url in broker_sources:
+    for source_name, broker_url, broker_app in broker_sources:
         if broker_url in inspected_brokers:
             continue
         inspected_brokers.add(broker_url)
 
-        broker_app = celery_app.__class__(
-            "worker-monitor",
-            broker=broker_url,
-        )
-        broker_app.conf.update(
-            broker_connection_timeout=2,
-            broker_connection_retry=False,
-            broker_connection_max_retries=0,
-        )
         try:
-            inspector = broker_app.control.inspect(timeout=1)
+            inspector = broker_app.control.inspect(timeout=10)
             if inspector is None:
-                logger.warning("Celery inspect returned None for broker=%s", source_name)
+                logger.warning(
+                    "Celery inspect returned None for broker=%s", source_name
+                )
                 continue
             stats = inspector.stats() or {}
             active = inspector.active() or {}
@@ -972,15 +973,9 @@ def refresh_compute_worker_health():
             active_queues = inspector.active_queues() or {}
         except Exception:
             logger.exception(
-                "Unable to inspect Celery workers for broker %s",
-                source_name,
+                "Unable to inspect Celery workers for broker %s", source_name
             )
             continue
-        finally:
-            try:
-                broker_app.close()
-            except Exception:
-                pass
 
         for worker_name in stats.keys():
             queues = active_queues.get(worker_name, []) or []
@@ -988,7 +983,9 @@ def refresh_compute_worker_health():
             if not is_compute_worker(worker_name, queue_names, known_queue_names):
                 continue
 
-            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+            running_jobs = len(active.get(worker_name, [])) + len(
+                reserved.get(worker_name, [])
+            )
             status = "busy" if running_jobs > 0 else "available"
             payload = {
                 "hostname": worker_name,
@@ -998,13 +995,8 @@ def refresh_compute_worker_health():
                 "queue_source": source_name,
                 "queue_names": sorted(queue_names),
             }
-
             heartbeat_key = f"worker:{source_name}:{worker_name}:heartbeat"
-            r.set(
-                heartbeat_key,
-                json.dumps(payload),
-                ex=WORKER_HEARTBEAT_TTL,
-            )
+            r.set(heartbeat_key, json.dumps(payload), ex=WORKER_HEARTBEAT_TTL)
             r.hset(
                 WORKERS_REGISTRY_KEY,
                 f"{source_name}:{worker_name}",

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -931,7 +931,6 @@ def refresh_compute_worker_health():
     known_queue_names = _known_compute_queue_names()
 
     broker_sources = []
-
     default_broker = getattr(celery_app.conf, "broker_url", None)
     if default_broker:
         broker_sources.append(("default", default_broker))
@@ -942,56 +941,55 @@ def refresh_compute_worker_health():
         .exclude(name="")
         .distinct()
     )
-
     for queue in private_queues:
         broker_url = _resolve_broker_url(celery_app, queue.broker_url)
         if broker_url:
             broker_sources.append((queue.name, broker_url))
 
     inspected_brokers = set()
-
     for source_name, broker_url in broker_sources:
         if broker_url in inspected_brokers:
             continue
         inspected_brokers.add(broker_url)
 
+        broker_app = celery_app.__class__(
+            "worker-monitor",
+            broker=broker_url,
+        )
+        broker_app.conf.update(
+            broker_connection_timeout=2,
+            broker_connection_retry=False,
+            broker_connection_max_retries=0,
+        )
         try:
-            broker_app = celery_app.__class__(
-                "worker-monitor",
-                broker=broker_url,
-            )
-
             inspector = broker_app.control.inspect(timeout=1)
-
             if inspector is None:
-                logger.warning(
-                    "Celery inspect returned None for broker=%s",
-                    source_name,
-                )
+                logger.warning("Celery inspect returned None for broker=%s", source_name)
                 continue
-
             stats = inspector.stats() or {}
             active = inspector.active() or {}
             reserved = inspector.reserved() or {}
             active_queues = inspector.active_queues() or {}
-
         except Exception:
             logger.exception(
                 "Unable to inspect Celery workers for broker %s",
                 source_name,
             )
             continue
+        finally:
+            try:
+                broker_app.close()
+            except Exception:
+                pass
 
         for worker_name in stats.keys():
             queues = active_queues.get(worker_name, []) or []
             queue_names = _extract_queue_names(queues)
-
             if not _is_compute_worker(worker_name, queue_names, known_queue_names):
                 continue
 
             running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
             status = "busy" if running_jobs > 0 else "available"
-
             payload = {
                 "hostname": worker_name,
                 "status": status,
@@ -1002,13 +1000,11 @@ def refresh_compute_worker_health():
             }
 
             heartbeat_key = f"worker:{source_name}:{worker_name}:heartbeat"
-
             r.set(
                 heartbeat_key,
                 json.dumps(payload),
                 ex=WORKER_HEARTBEAT_TTL,
             )
-
             r.hset(
                 WORKERS_REGISTRY_KEY,
                 f"{source_name}:{worker_name}",
@@ -1023,8 +1019,12 @@ def refresh_compute_worker_health():
                     }
                 ),
             )
-
             _broadcast_worker_state(payload)
             logger.info(
-                f"[WORKER-HEALTH] source={source_name} {worker_name} status={status} jobs={running_jobs} queues={sorted(queue_names)}"
+                "[WORKER-HEALTH] source=%s worker=%s status=%s jobs=%d queues=%s",
+                source_name,
+                worker_name,
+                status,
+                running_jobs,
+                sorted(queue_names),
             )

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -39,6 +39,7 @@ from rest_framework.exceptions import ValidationError
 from tasks.models import Task
 
 from celery_config import app
+from utils.consumers import _extract_queue_names, _is_compute_worker, _known_compute_queue_names
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
 
@@ -915,26 +916,16 @@ def refresh_compute_worker_health():
         logger.exception("Unable to inspect Celery workers")
         return
 
+    known_queue_names = _known_compute_queue_names()
+
     for worker_name in stats.keys():
         queues = active_queues.get(worker_name, []) or []
-        queue_names = []
+        queue_names = _extract_queue_names(queues)
 
-        for q in queues:
-            if isinstance(q, dict) and q.get("name"):
-                queue_names.append(q["name"])
-
-        is_compute_worker = (
-            "compute-worker" in queue_names
-            or worker_name.startswith("compute-worker")
-            or worker_name.startswith("CW")
-        )
-
-        if not is_compute_worker:
+        if not _is_compute_worker(worker_name, queue_names, known_queue_names):
             continue
 
-        running_jobs = len(active.get(worker_name, [])) + len(
-            reserved.get(worker_name, [])
-        )
+        running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
         status = "busy" if running_jobs > 0 else "available"
 
         payload = {
@@ -942,6 +933,7 @@ def refresh_compute_worker_health():
             "status": status,
             "running_jobs": running_jobs,
             "timestamp": now().timestamp(),
+            "queue_names": sorted(queue_names),
         }
 
         heartbeat_key = f"worker:{worker_name}:heartbeat"
@@ -961,11 +953,12 @@ def refresh_compute_worker_health():
                     "status": status,
                     "running_jobs": running_jobs,
                     "last_seen": payload["timestamp"],
+                    "queue_names": sorted(queue_names),
                 }
             ),
         )
 
         _broadcast_worker_state(payload)
         logger.info(
-            f"[WORKER-HEALTH] {worker_name} status={status} jobs={running_jobs}"
+            f"[WORKER-HEALTH] {worker_name} status={status} jobs={running_jobs} queues={sorted(queue_names)}"
         )

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -1,58 +1,48 @@
 import asyncio
 import json
-import logging
 import os
 import re
 import traceback
-import urllib.parse
 import zipfile
-from datetime import datetime, timedelta
+from datetime import timedelta, datetime
+
 from io import BytesIO
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+import urllib
 
 import oyaml as yaml
 import requests
-from asgiref.sync import async_to_sync
-from channels.layers import get_channel_layer
-from competitions.models import (
-    Competition,
-    CompetitionCreationTaskStatus,
-    CompetitionDump,
-    Phase,
-    Submission,
-    SubmissionDetails,
-)
+from celery._state import app_or_default
+from django.conf import settings
+from django_redis import get_redis_connection
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.files.base import ContentFile
+from django.db.models import Subquery, OuterRef, Count, Case, When, Value, F
+from django.db import transaction
+from django.utils.text import slugify
+from django.utils.timezone import now
+from rest_framework.exceptions import ValidationError
+
+from celery_config import app, app_for_vhost
+from competitions.models import Submission, CompetitionCreationTaskStatus, SubmissionDetails, Competition, \
+    CompetitionDump, Phase
+from queues.models import Queue
 from competitions.unpackers.utils import CompetitionUnpackingException
 from competitions.unpackers.v1 import V15Unpacker
 from competitions.unpackers.v2 import V2Unpacker
-from datasets.models import Data
-from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.files.base import ContentFile
-from django.db import transaction
-from django.db.models import Case, Count, F, OuterRef, Subquery, Value, When
-from django.utils.text import slugify
-from django.utils.timezone import now
-from django_redis import get_redis_connection
 from leaderboards.models import Leaderboard
-from queues.models import Queue
-from rest_framework.exceptions import ValidationError
 from tasks.models import Task
-
-from celery_config import app, app_for_vhost
+from datasets.models import Data
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
-from utils.worker_utils import (
-    WORKER_HEARTBEAT_TTL,
-    WORKERS_REGISTRY_KEY,
-    extract_queue_names,
-    is_compute_worker,
-    known_compute_queue_names,
-)
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
 
+import logging
+
+from utils.worker_utils import WORKER_HEARTBEAT_TTL, WORKERS_REGISTRY_KEY, extract_queue_names, is_compute_worker, known_compute_queue_names
 logger = logging.getLogger(__name__)
-celery_app = app
-r = get_redis_connection("default")
 
 COMPETITION_FIELDS = [
     "title",
@@ -71,35 +61,35 @@ COMPETITION_FIELDS = [
     "reward",
     "contact_email",
     "fact_sheet",
-    "forum_enabled",
+    "forum_enabled"
 ]
 
 TASK_FIELDS = [
-    "name",
-    "description",
-    "key",
-    "is_public",
+    'name',
+    'description',
+    'key',
+    'is_public',
 ]
 SOLUTION_FIELDS = [
-    "name",
-    "description",
-    "tasks",
-    "key",
+    'name',
+    'description',
+    'tasks',
+    'key',
 ]
 
 PHASE_FIELDS = [
-    "index",
-    "name",
-    "description",
-    "start",
-    "end",
-    "max_submissions_per_day",
-    "max_submissions_per_person",
-    "execution_time_limit",
-    "auto_migrate_to_this_phase",
-    "hide_output",
-    "hide_prediction_output",
-    "hide_score_output",
+    'index',
+    'name',
+    'description',
+    'start',
+    'end',
+    'max_submissions_per_day',
+    'max_submissions_per_person',
+    'execution_time_limit',
+    'auto_migrate_to_this_phase',
+    'hide_output',
+    'hide_prediction_output',
+    'hide_score_output',
 ]
 PHASE_FILES = [
     "input_data",
@@ -109,12 +99,15 @@ PHASE_FILES = [
     "public_data",
     "starting_kit",
 ]
-PAGE_FIELDS = ["title"]
+PAGE_FIELDS = [
+    "title"
+]
 LEADERBOARD_FIELDS = [
-    "title",
-    "key",
-    "hidden",
-    "submission_rule",
+    'title',
+    'key',
+    'hidden',
+    'submission_rule',
+
     # For later
     # 'force_submission_to_leaderboard',
     # 'force_best_submission_to_leaderboard',
@@ -122,18 +115,16 @@ LEADERBOARD_FIELDS = [
 ]
 
 COLUMN_FIELDS = [
-    "title",
-    "key",
-    "index",
-    "sorting",
-    "computation",
-    "computation_indexes",
-    "hidden",
-    "precision",
+    'title',
+    'key',
+    'index',
+    'sorting',
+    'computation',
+    'computation_indexes',
+    'hidden',
+    'precision',
 ]
-MAX_EXECUTION_TIME_LIMIT = int(
-    os.environ.get("MAX_EXECUTION_TIME_LIMIT", 600)
-)  # time limit of the default queue
+MAX_EXECUTION_TIME_LIMIT = int(os.environ.get('MAX_EXECUTION_TIME_LIMIT', 600))  # time limit of the default queue
 
 
 def _send_to_compute_worker(submission, is_scoring):
@@ -142,51 +133,43 @@ def _send_to_compute_worker(submission, is_scoring):
         "submissions_api_url": settings.SUBMISSIONS_API_URL,
         "secret": submission.secret,
         "docker_image": submission.phase.competition.docker_image,
-        "execution_time_limit": min(
-            MAX_EXECUTION_TIME_LIMIT, submission.phase.execution_time_limit
-        ),
+        "execution_time_limit": min(MAX_EXECUTION_TIME_LIMIT, submission.phase.execution_time_limit),
         "id": submission.pk,
         "is_scoring": is_scoring,
     }
 
-    if (
-        not submission.detailed_result.name
-        and submission.phase.competition.enable_detailed_results
-    ):
-        submission.detailed_result.save(
-            "detailed_results.html", ContentFile("".encode())
-        )  # must encode here for GCS
-        submission.save(update_fields=["detailed_result"])
+    if not submission.detailed_result.name and submission.phase.competition.enable_detailed_results:
+        submission.detailed_result.save('detailed_results.html', ContentFile(''.encode()))  # must encode here for GCS
+        submission.save(update_fields=['detailed_result'])
     if not submission.prediction_result.name:
-        submission.prediction_result.save(
-            "prediction_result.zip", ContentFile("".encode())
-        )  # must encode here for GCS
-        submission.save(update_fields=["prediction_result"])
+        submission.prediction_result.save('prediction_result.zip', ContentFile(''.encode()))  # must encode here for GCS
+        submission.save(update_fields=['prediction_result'])
     if not submission.scoring_result.name:
-        submission.scoring_result.save(
-            "scoring_result.zip", ContentFile("".encode())
-        )  # must encode here for GCS
-        submission.save(update_fields=["scoring_result"])
+        submission.scoring_result.save('scoring_result.zip', ContentFile(''.encode()))  # must encode here for GCS
+        submission.save(update_fields=['scoring_result'])
 
     submission = Submission.objects.get(id=submission.id)
     task = submission.task
 
     if not is_scoring:
-        run_args["prediction_result"] = make_url_sassy(
-            path=submission.prediction_result.name, permission="w"
+        run_args['prediction_result'] = make_url_sassy(
+            path=submission.prediction_result.name,
+            permission='w'
         )
     else:
         if submission.phase.competition.enable_detailed_results:
-            run_args["detailed_results_url"] = make_url_sassy(
+            run_args['detailed_results_url'] = make_url_sassy(
                 path=submission.detailed_result.name,
-                permission="w",
-                content_type="text/html",
+                permission='w',
+                content_type='text/html'
             )
-        run_args["prediction_result"] = make_url_sassy(
-            path=submission.prediction_result.name, permission="r"
+        run_args['prediction_result'] = make_url_sassy(
+            path=submission.prediction_result.name,
+            permission='r'
         )
-        run_args["scoring_result"] = make_url_sassy(
-            path=submission.scoring_result.name, permission="w"
+        run_args['scoring_result'] = make_url_sassy(
+            path=submission.scoring_result.name,
+            permission='w'
         )
 
     if task.ingestion_program:
@@ -194,12 +177,12 @@ def _send_to_compute_worker(submission, is_scoring):
             run_args['ingestion_program_data'] = make_url_sassy(task.ingestion_program.data_file.name)
 
     if task.input_data and (not is_scoring or task.ingestion_only_during_scoring):
-        run_args["input_data"] = make_url_sassy(task.input_data.data_file.name)
+        run_args['input_data'] = make_url_sassy(task.input_data.data_file.name)
 
     if is_scoring and task.reference_data:
-        run_args["reference_data"] = make_url_sassy(task.reference_data.data_file.name)
+        run_args['reference_data'] = make_url_sassy(task.reference_data.data_file.name)
 
-    run_args["ingestion_only_during_scoring"] = task.ingestion_only_during_scoring
+    run_args['ingestion_only_during_scoring'] = task.ingestion_only_during_scoring
 
     if is_scoring:
         run_args['scoring_program_data'] = make_url_sassy(path=task.scoring_program.data_file.name)
@@ -221,13 +204,9 @@ def _send_to_compute_worker(submission, is_scoring):
     time_padding = 60 * 20  # 20 minutes
     time_limit = submission.phase.execution_time_limit + time_padding
 
-    if (
-        submission.phase.competition.queue
-    ):  # if the competition is running on a custom queue, not the default queue
+    if submission.phase.competition.queue:  # if the competition is running on a custom queue, not the default queue
         submission.queue = submission.phase.competition.queue
-        run_args["execution_time_limit"] = (
-            submission.phase.execution_time_limit
-        )  # use the competition time limit
+        run_args['execution_time_limit'] = submission.phase.execution_time_limit  # use the competition time limit
         submission.save(update_fields=["queue"])
     if submission.status == Submission.SUBMITTING:
         # Don't want to mark an already-prepared submission as "submitted" again, so
@@ -240,24 +219,22 @@ def _send_to_compute_worker(submission, is_scoring):
         # many submissions to be scored while we're waiting for results
         priority = 10 if is_scoring else 0
         if submission.phase.competition.queue:
-            celery_app = celery_app.conf.broker_url()
+            celery_app = app_or_default()
             with celery_app.connection() as new_connection:
-                new_connection.virtual_host = str(
-                    submission.phase.competition.queue.vhost
-                )
+                new_connection.virtual_host = str(submission.phase.competition.queue.vhost)
                 task = celery_app.send_task(
-                    "compute_worker_run",
+                    'compute_worker_run',
                     args=(run_args,),
-                    queue="compute-worker",
+                    queue='compute-worker',
                     soft_time_limit=time_limit,
                     connection=new_connection,
                     priority=priority,
                 )
         else:
             task = app.send_task(
-                "compute_worker_run",
+                'compute_worker_run',
                 args=(run_args,),
-                queue="compute-worker",
+                queue='compute-worker',
                 soft_time_limit=time_limit,
                 priority=priority,
             )
@@ -269,12 +246,8 @@ def _send_to_compute_worker(submission, is_scoring):
 
 def create_detailed_output_file(detail_name, submission):
     # Detail logs like stdout/etc.
-    new_details = SubmissionDetails.objects.create(
-        submission=submission, name=detail_name
-    )
-    new_details.data_file.save(
-        f"{detail_name}.txt", ContentFile("".encode())
-    )  # must encode here for GCS
+    new_details = SubmissionDetails.objects.create(submission=submission, name=detail_name)
+    new_details.data_file.save(f'{detail_name}.txt', ContentFile(''.encode()))  # must encode here for GCS
     return make_url_sassy(new_details.data_file.name, permission="w")
 
 
@@ -285,49 +258,47 @@ def run_submission(submission_pk, tasks=None, is_scoring=False):
 
 def send_submission_message(submission, data):
     from channels.layers import get_channel_layer
-
     channel_layer = get_channel_layer()
     user = submission.owner
-    asyncio.get_event_loop().run_until_complete(
-        channel_layer.group_send(
-            f"submission_listening_{user.pk}",
-            {
-                "type": "submission.message",
-                "text": data,
-                "submission_id": submission.pk,
-            },
-        )
-    )
+    asyncio.get_event_loop().run_until_complete(channel_layer.group_send(f"submission_listening_{user.pk}", {
+        'type': 'submission.message',
+        'text': data,
+        'submission_id': submission.pk,
+    }))
 
 
 def send_parent_status(submission):
     """Helper function we can mock in tests, instead of having to do async mocks"""
-    send_submission_message(submission, {"kind": "status_update", "status": "Running"})
+    send_submission_message(submission, {
+        "kind": "status_update",
+        "status": "Running"
+    })
 
 
 def send_child_id(submission, child_id):
     """Helper function we can mock in tests, instead of having to do async mocks"""
-    send_submission_message(submission, {"kind": "child_update", "child_id": child_id})
+    send_submission_message(submission, {
+        "kind": "child_update",
+        "child_id": child_id
+    })
 
 
-@app.task(queue="site-worker", soft_time_limit=60)
+@app.task(queue='site-worker', soft_time_limit=60)
 def _run_submission(submission_pk, task_pks=None, is_scoring=False):
     """This function is wrapped so that when we run tests we can run this function not
     via celery"""
     select_models = (
-        "phase",
-        "phase__competition",
+        'phase',
+        'phase__competition',
     )
     prefetch_models = (
-        "details",
-        "phase__tasks__input_data",
-        "phase__tasks__reference_data",
-        "phase__tasks__scoring_program",
-        "phase__tasks__ingestion_program",
+        'details',
+        'phase__tasks__input_data',
+        'phase__tasks__reference_data',
+        'phase__tasks__scoring_program',
+        'phase__tasks__ingestion_program',
     )
-    qs = Submission.objects.select_related(*select_models).prefetch_related(
-        *prefetch_models
-    )
+    qs = Submission.objects.select_related(*select_models).prefetch_related(*prefetch_models)
     submission = qs.get(pk=submission_pk)
 
     if submission.is_specific_task_re_run:
@@ -338,7 +309,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
     else:
         tasks = submission.phase.tasks.filter(pk__in=task_pks)
 
-    tasks = tasks.order_by("pk")
+    tasks = tasks.order_by('pk')
 
     if len(tasks) > 1:
         # The initial submission object becomes the parent submission and we create children for each task
@@ -356,7 +327,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
                 participant=submission.participant,
                 parent=submission,
                 task=task,
-                fact_sheet_answers=submission.fact_sheet_answers,
+                fact_sheet_answers=submission.fact_sheet_answers
             )
             child_sub.save(ignore_submission_limit=True)
             _send_to_compute_worker(child_sub, is_scoring=False)
@@ -369,7 +340,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
         _send_to_compute_worker(submission, is_scoring)
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 60)  # 1 hour timeout
+@app.task(queue='site-worker', soft_time_limit=60 * 60)  # 1 hour timeout
 def unpack_competition(status_pk):
     logger.info(f"Starting unpack with status pk = {status_pk}")
     status = CompetitionCreationTaskStatus.objects.get(pk=status_pk)
@@ -390,12 +361,8 @@ def unpack_competition(status_pk):
             # Extract bundle
             try:
                 with NamedTemporaryFile(mode="w+b") as temp_file:
-                    logger.info(
-                        f"Download competition bundle: {competition_dataset.data_file.name}"
-                    )
-                    competition_bundle_url = make_url_sassy(
-                        competition_dataset.data_file.url
-                    )
+                    logger.info(f"Download competition bundle: {competition_dataset.data_file.name}")
+                    competition_bundle_url = make_url_sassy(competition_dataset.data_file.url)
                     try:
                         with requests.get(competition_bundle_url, stream=True) as r:
                             r.raise_for_status()
@@ -403,14 +370,12 @@ def unpack_competition(status_pk):
                                 temp_file.write(chunk)
                             r.close()
                     except requests.exceptions.RequestException as e:
-                        raise CompetitionUnpackingException(
-                            f"Failed to download bundle from storage: {e}"
-                        )
+                        raise CompetitionUnpackingException(f"Failed to download bundle from storage: {e}")
 
                     # seek back to the start of the tempfile after writing to it..
                     temp_file.seek(0)
 
-                    with zipfile.ZipFile(temp_file.name, "r") as zip_pointer:
+                    with zipfile.ZipFile(temp_file.name, 'r') as zip_pointer:
                         zip_pointer.extractall(temp_directory)
             except zipfile.BadZipFile:
                 raise CompetitionUnpackingException("Bad zip file uploaded.")
@@ -427,24 +392,20 @@ def unpack_competition(status_pk):
                 with open(yaml_path) as f:
                     competition_yaml = yaml.safe_load(f.read())
             except yaml.YAMLError as e:
-                raise CompetitionUnpackingException(
-                    f"Error parsing competition.yaml: {e}"
-                )
+                raise CompetitionUnpackingException(f"Error parsing competition.yaml: {e}")
             except Exception as e:
-                raise CompetitionUnpackingException(
-                    f"Failed to read competition.yaml: {e}"
-                )
+                raise CompetitionUnpackingException(f"Failed to read competition.yaml: {e}")
 
-            yaml_version = str(competition_yaml.get("version", "1"))
+            yaml_version = str(competition_yaml.get('version', '1'))
 
             logger.info(f"The YAML version is: {yaml_version}")
-            if yaml_version in ["1", "1.5"]:
+            if yaml_version in ['1', '1.5']:
                 unpacker_class = V15Unpacker
-            elif yaml_version == "2":
+            elif yaml_version == '2':
                 unpacker_class = V2Unpacker
             else:
                 raise CompetitionUnpackingException(
-                    "A suitable version could not be found for this competition. Make sure one is supplied in the yaml."
+                    'A suitable version could not be found for this competition. Make sure one is supplied in the yaml.'
                 )
 
             unpacker = unpacker_class(
@@ -457,7 +418,6 @@ def unpack_competition(status_pk):
             try:
                 competition = unpacker.save()
             except ValidationError as e:
-
                 def _get_error_string(error_dict):
                     """Helps us nicely print out a ValidationError"""
                     for key, errors in error_dict.items():
@@ -499,7 +459,7 @@ def unpack_competition(status_pk):
         mark_status_as_failed_and_delete_dataset(status, message)
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 10)
+@app.task(queue='site-worker', soft_time_limit=60 * 10)
 def create_competition_dump(competition_pk, keys_instead_of_files=False):
     yaml_data = {"version": "2"}
     try:
@@ -508,7 +468,7 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         logger.info(f"Finding competition {competition_pk}")
         comp = Competition.objects.get(pk=competition_pk)
         zip_buffer = BytesIO()
-        current_date_time = datetime.today().strftime("%Y-%m-%d %H:%M:%S")
+        current_date_time = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         zip_name = f"{comp.title}-{current_date_time}.zip"
         zip_file = zipfile.ZipFile(zip_buffer, "w")
 
@@ -516,14 +476,14 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         for field in COMPETITION_FIELDS:
             if hasattr(comp, field):
                 value = getattr(comp, field, "")
-                if field == "queue" and value is not None:
+                if field == 'queue' and value is not None:
                     value = str(value.vhost)
                 yaml_data[field] = value
         if comp.logo:
             logger.info("Checking logo")
             try:
-                yaml_data["image"] = re.sub(r".*/", "", comp.logo.name)
-                zip_file.writestr(yaml_data["image"], comp.logo.read())
+                yaml_data['image'] = re.sub(r'.*/', '', comp.logo.name)
+                zip_file.writestr(yaml_data['image'], comp.logo.read())
                 logger.info(f"Logo found for competition {comp.pk}")
             except OSError:
                 logger.warning(
@@ -532,25 +492,25 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
 
         # -------- Competition Terms -------
         if comp.terms:
-            yaml_data["terms"] = "terms.md"
-            zip_file.writestr("terms.md", comp.terms)
+            yaml_data['terms'] = 'terms.md'
+            zip_file.writestr('terms.md', comp.terms)
 
         # -------- Competition Pages -------
-        yaml_data["pages"] = []
+        yaml_data['pages'] = []
         for page in comp.pages.all():
             temp_page_data = {}
             for field in PAGE_FIELDS:
                 if hasattr(page, field):
                     temp_page_data[field] = getattr(page, field, "")
             page_file_name = f"{slugify(page.title)}-{page.pk}.md"
-            temp_page_data["file"] = page_file_name
-            yaml_data["pages"].append(temp_page_data)
-            zip_file.writestr(temp_page_data["file"], page.content)
+            temp_page_data['file'] = page_file_name
+            yaml_data['pages'].append(temp_page_data)
+            zip_file.writestr(temp_page_data['file'], page.content)
 
         # -------- Competition Tasks/Solutions -------
 
-        yaml_data["tasks"] = []
-        yaml_data["solutions"] = []
+        yaml_data['tasks'] = []
+        yaml_data['solutions'] = []
 
         task_solution_pairs = {}
         tasks = [task for phase in comp.phases.all() for task in phase.tasks.all()]
@@ -561,18 +521,23 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         for index, task in enumerate(tasks):
 
             task_solution_pairs[task.id] = {
-                "index": index,
-                "solutions": {"ids": [], "indexes": []},
+                'index': index,
+                'solutions': {
+                    'ids': [],
+                    'indexes': []
+                }
             }
 
-            temp_task_data = {"index": index}
+            temp_task_data = {
+                'index': index
+            }
 
             for field in TASK_FIELDS:
                 data = getattr(task, field, "")
                 # If keys_instead of files is not true and field is key, then skip this filed
-                if not keys_instead_of_files and field == "key":
+                if not keys_instead_of_files and field == 'key':
                     continue
-                if field == "key":
+                if field == 'key':
                     data = str(data)
                 temp_task_data[field] = data
 
@@ -585,136 +550,116 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
                                 temp_task_data[file_type] = str(temp_dataset.key)
                             else:
                                 try:
-                                    temp_task_data[file_type] = (
-                                        f"{file_type}-{task.pk}.zip"
-                                    )
-                                    zip_file.writestr(
-                                        temp_task_data[file_type],
-                                        temp_dataset.data_file.read(),
-                                    )
+                                    temp_task_data[file_type] = f"{file_type}-{task.pk}.zip"
+                                    zip_file.writestr(temp_task_data[file_type], temp_dataset.data_file.read())
                                 except OSError:
                                     logger.error(
                                         f"The file field is set, but no actual"
                                         f" file was found for dataset: {temp_dataset.pk} with name {temp_dataset.name}"
                                     )
                         else:
-                            logger.warning(
-                                f"Could not find data file for dataset object: {temp_dataset.pk}"
-                            )
+                            logger.warning(f"Could not find data file for dataset object: {temp_dataset.pk}")
             # Now for all of our solutions for the tasks, write those too
             for solution in task.solutions.all():
                 # for index_two, solution in enumerate(task.solutions.all()):
                 #     temp_index = index_two
                 # IF OUR SOLUTION WAS ALREADY ADDED
-                if solution.id in task_solution_pairs[task.id]["solutions"]["ids"]:
-                    for solution_data in yaml_data["solutions"]:
-                        if solution_data["key"] == solution.key:
-                            solution_data["tasks"].append(task.id)
+                if solution.id in task_solution_pairs[task.id]['solutions']['ids']:
+                    for solution_data in yaml_data['solutions']:
+                        if solution_data['key'] == solution.key:
+                            solution_data['tasks'].append(task.id)
                             break
                     break
                 # Else if our index is already taken
-                elif index_two in task_solution_pairs[task.id]["solutions"]["indexes"]:
+                elif index_two in task_solution_pairs[task.id]['solutions']['indexes']:
                     index_two += 1
-                task_solution_pairs[task.id]["solutions"]["indexes"].append(index_two)
-                task_solution_pairs[task.id]["solutions"]["ids"].append(solution.id)
+                task_solution_pairs[task.id]['solutions']['indexes'].append(index_two)
+                task_solution_pairs[task.id]['solutions']['ids'].append(solution.id)
 
-                temp_solution_data = {"index": index_two}
+                temp_solution_data = {
+                    'index': index_two
+                }
                 for field in SOLUTION_FIELDS:
                     if hasattr(solution, field):
                         data = getattr(solution, field, "")
-                        if field == "key":
+                        if field == 'key':
                             data = str(data)
                         temp_solution_data[field] = data
                 if solution.data:
-                    temp_dataset = getattr(solution, "data")
+                    temp_dataset = getattr(solution, 'data')
                     if temp_dataset:
                         if temp_dataset.data_file:
                             try:
-                                temp_solution_data["path"] = (
-                                    f"solution-{solution.pk}.zip"
-                                )
-                                zip_file.writestr(
-                                    temp_solution_data["path"],
-                                    temp_dataset.data_file.read(),
-                                )
+                                temp_solution_data['path'] = f"solution-{solution.pk}.zip"
+                                zip_file.writestr(temp_solution_data['path'], temp_dataset.data_file.read())
                             except OSError:
                                 logger.error(
                                     f"The file field is set, but no actual"
                                     f" file was found for dataset: {temp_dataset.pk} with name {temp_dataset.name}"
                                 )
                         else:
-                            logger.warning(
-                                f"Could not find data file for dataset object: {temp_dataset.pk}"
-                            )
+                            logger.warning(f"Could not find data file for dataset object: {temp_dataset.pk}")
                 # TODO: Make sure logic here is right. Needs to be outputted as a list, but what others can we tie to?
-                temp_solution_data["tasks"] = [index]
-                yaml_data["solutions"].append(temp_solution_data)
+                temp_solution_data['tasks'] = [index]
+                yaml_data['solutions'].append(temp_solution_data)
                 index_two += 1
             # End for loop for solutions; Append tasks data
-            yaml_data["tasks"].append(temp_task_data)
+            yaml_data['tasks'].append(temp_task_data)
 
         # -------- Competition Phases -------
 
-        yaml_data["phases"] = []
+        yaml_data['phases'] = []
         for phase in comp.phases.all():
             temp_phase_data = {}
             for field in PHASE_FIELDS:
                 if hasattr(phase, field):
-                    if field == "start" or field == "end":
+                    if field == 'start' or field == 'end':
                         temp_date = getattr(phase, field)
                         if not temp_date:
                             continue
                         temp_date = temp_date.strftime("%Y-%m-%d")
                         temp_phase_data[field] = temp_date
-                    elif field == "max_submissions_per_person":
-                        temp_phase_data["max_submissions"] = getattr(phase, field)
+                    elif field == 'max_submissions_per_person':
+                        temp_phase_data['max_submissions'] = getattr(phase, field)
                     else:
                         temp_phase_data[field] = getattr(phase, field, "")
-            task_indexes = [
-                task_solution_pairs[task.id]["index"] for task in phase.tasks.all()
-            ]
-            temp_phase_data["tasks"] = task_indexes
+            task_indexes = [task_solution_pairs[task.id]['index'] for task in phase.tasks.all()]
+            temp_phase_data['tasks'] = task_indexes
             temp_phase_solutions = []
             for task in phase.tasks.all():
-                temp_phase_solutions += task_solution_pairs[task.id]["solutions"][
-                    "indexes"
-                ]
-            temp_phase_data["solutions"] = temp_phase_solutions
-            yaml_data["phases"].append(temp_phase_data)
-        yaml_data["phases"] = sorted(
-            yaml_data["phases"], key=lambda phase: phase["index"]
-        )
+                temp_phase_solutions += task_solution_pairs[task.id]['solutions']['indexes']
+            temp_phase_data['solutions'] = temp_phase_solutions
+            yaml_data['phases'].append(temp_phase_data)
+        yaml_data['phases'] = sorted(yaml_data['phases'], key=lambda phase: phase['index'])
 
         # -------- Leaderboards -------
 
-        yaml_data["leaderboards"] = []
+        yaml_data['leaderboards'] = []
         # Have to grab leaderboards from phases
-        leaderboards = Leaderboard.objects.filter(
-            id__in=comp.phases.all().values_list("leaderboard", flat=True)
-        )
+        leaderboards = Leaderboard.objects.filter(id__in=comp.phases.all().values_list('leaderboard', flat=True))
         for index, leaderboard in enumerate(leaderboards):
-            ldb_data = {"index": index}
+            ldb_data = {
+                'index': index
+            }
             for field in LEADERBOARD_FIELDS:
                 if hasattr(leaderboard, field):
                     ldb_data[field] = getattr(leaderboard, field, "")
-            ldb_data["columns"] = []
+            ldb_data['columns'] = []
             for column in leaderboard.columns.all():
                 col_data = {}
                 for field in COLUMN_FIELDS:
                     if hasattr(column, field):
                         value = getattr(column, field, "")
-                        if field == "computation_indexes" and value is not None:
-                            value = value.split(",")
+                        if field == 'computation_indexes' and value is not None:
+                            value = value.split(',')
                         if value is not None:
                             col_data[field] = value
-                ldb_data["columns"].append(col_data)
-            yaml_data["leaderboards"].append(ldb_data)
+                ldb_data['columns'].append(col_data)
+            yaml_data['leaderboards'].append(ldb_data)
 
         # ------- Finalize --------
         logger.info(f"YAML data to be written is: {yaml_data}")
-        comp_yaml = yaml.safe_dump(
-            yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8"
-        )
+        comp_yaml = yaml.safe_dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
         logger.info(f"YAML output: {comp_yaml}")
         zip_file.writestr("competition.yaml", comp_yaml)
         zip_file.close()
@@ -725,8 +670,8 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         temp_dataset_bundle = Data.objects.create(
             created_by=comp.created_by,
             name=f"{comp.title} Dump #{bundle_count} Created {current_date_time}",
-            type="competition_bundle",
-            description="Automatically created competition dump",
+            type='competition_bundle',
+            description='Automatically created competition dump',
             # 'data_file'=,
         )
         logger.info("Saving zip to Competition Bundle")
@@ -735,74 +680,61 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         temp_comp_dump = CompetitionDump.objects.create(
             dataset=temp_dataset_bundle,
             status="Finished",
-            details="Competition Bundle {0} for Competition {1}".format(
-                temp_dataset_bundle.pk, comp.pk
-            ),
-            competition=comp,
+            details="Competition Bundle {0} for Competition {1}".format(temp_dataset_bundle.pk, comp.pk),
+            competition=comp
         )
-        logger.info(
-            f"Finished creating competition dump: {temp_comp_dump.pk} for competition: {comp.pk}"
-        )
+        logger.info(f"Finished creating competition dump: {temp_comp_dump.pk} for competition: {comp.pk}")
     except ObjectDoesNotExist:
-        logger.error(
-            "Could not find competition with pk {} to create a competition dump".format(
-                competition_pk
-            )
-        )
+        logger.error("Could not find competition with pk {} to create a competition dump".format(competition_pk))
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 5)
+@app.task(queue='site-worker', soft_time_limit=60 * 5)
 def do_phase_migrations():
     # Update phase statuses
-    previous_subquery = (
-        Phase.objects.filter(competition=OuterRef("competition"), end__lte=now())
-        .order_by("-index")
-        .values("index")[:1]
-    )
+    previous_subquery = Phase.objects.filter(
+        competition=OuterRef('competition'),
+        end__lte=now()
+    ).order_by('-index').values('index')[:1]
 
     current_subquery = Phase.objects.filter(
-        competition=OuterRef("competition"),
+        competition=OuterRef('competition'),
         start__lte=now(),
         end__gt=now(),
-    ).values("index")[:1]
+    ).values('index')[:1]
 
-    next_subquery = (
-        Phase.objects.filter(competition=OuterRef("competition"), start__gt=now())
-        .order_by("index")
-        .values("index")[:1]
-    )
+    next_subquery = Phase.objects.filter(
+        competition=OuterRef('competition'),
+        start__gt=now()
+    ).order_by('index').values('index')[:1]
 
     Phase.objects.annotate(
         previous_index=Subquery(previous_subquery),
         current_index=Subquery(current_subquery),
         next_index=Subquery(next_subquery),
-    ).update(
-        status=Case(
-            When(index=F("previous_index"), then=Value(Phase.PREVIOUS)),
-            When(index=F("current_index"), then=Value(Phase.CURRENT)),
-            When(index=F("next_index"), then=Value(Phase.NEXT)),
-            default=None,
-        )
-    )
+    ).update(status=Case(
+        When(index=F('previous_index'), then=Value(Phase.PREVIOUS)),
+        When(index=F('current_index'), then=Value(Phase.CURRENT)),
+        When(index=F('next_index'), then=Value(Phase.NEXT)),
+        default=None
+    ))
 
     # Updating Competitions whose phases have finished migrating to `is_migrating=False`
-    completed_statuses = [
-        Submission.FINISHED,
-        Submission.FAILED,
-        Submission.CANCELLED,
-        Submission.NONE,
-    ]
+    completed_statuses = [Submission.FINISHED, Submission.FAILED, Submission.CANCELLED, Submission.NONE]
 
-    running_subs_query = (
-        Submission.objects.filter(created_by_migration=OuterRef("pk"))
-        .exclude(status__in=completed_statuses)
-        .values_list("pk")[:1]
-    )
+    running_subs_query = Submission.objects.filter(
+        created_by_migration=OuterRef('pk')
+    ).exclude(
+        status__in=completed_statuses
+    ).values_list('pk')[:1]
 
     Competition.objects.filter(
-        pk__in=Phase.objects.annotate(running_subs=Count(Subquery(running_subs_query)))
-        .filter(running_subs=0, competition__is_migrating=True, status=Phase.PREVIOUS)
-        .values_list("competition__pk", flat=True)
+        pk__in=Phase.objects.annotate(
+            running_subs=Count(Subquery(running_subs_query))
+        ).filter(
+            running_subs=0,
+            competition__is_migrating=True,
+            status=Phase.PREVIOUS
+        ).values_list('competition__pk', flat=True)
     ).update(is_migrating=False)
 
     # Checking for new phases to start migrating
@@ -810,7 +742,7 @@ def do_phase_migrations():
         auto_migrate_to_this_phase=True,
         start__lte=now(),
         competition__is_migrating=False,
-        has_been_migrated=False,
+        has_been_migrated=False
     )
 
     logger.info(f"Checking {len(new_phases)} phases for phase migrations.")
@@ -819,70 +751,51 @@ def do_phase_migrations():
         p.check_future_phase_submissions()
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 5)
+@app.task(queue='site-worker', soft_time_limit=60 * 5)
 def manual_migration(phase_id):
     try:
         source_phase = Phase.objects.get(id=phase_id)
     except Phase.DoesNotExist:
-        logger.error(
-            f"Could not manually migrate phase with id: {phase_id}. Phase could not be found."
-        )
+        logger.error(f'Could not manually migrate phase with id: {phase_id}. Phase could not be found.')
         return
 
     try:
-        destination_phase = source_phase.competition.phases.get(
-            index=source_phase.index + 1
-        )
+        destination_phase = source_phase.competition.phases.get(index=source_phase.index + 1)
     except Phase.DoesNotExist:
-        logger.error(
-            f"Could not manually migrate phase with id: {phase_id}. The next phase could not be found."
-        )
+        logger.error(f'Could not manually migrate phase with id: {phase_id}. The next phase could not be found.')
         return
-    destination_phase.competition.apply_phase_migration(
-        source_phase, destination_phase, force_migration=True
-    )
+    destination_phase.competition.apply_phase_migration(source_phase, destination_phase, force_migration=True)
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 5)
+@app.task(queue='site-worker', soft_time_limit=60 * 5)
 def batch_send_email(comp_id, content):
     try:
-        competition = Competition.objects.prefetch_related("participants__user").get(
-            id=comp_id
-        )
+        competition = Competition.objects.prefetch_related('participants__user').get(id=comp_id)
     except Competition.DoesNotExist:
-        logger.error(
-            f"Not sending emails because competition with id {comp_id} could not be found"
-        )
+        logger.error(f'Not sending emails because competition with id {comp_id} could not be found')
         return
 
     codalab_send_markdown_email(
-        subject=f"A message from the admins of {competition.title}",
+        subject=f'A message from the admins of {competition.title}',
         markdown_content=content,
-        recipient_list=[
-            participant.user.email for participant in competition.participants.all()
-        ],
+        recipient_list=[participant.user.email for participant in competition.participants.all()]
     )
 
 
-@app.task(queue="site-worker", soft_time_limit=60 * 5)
+@app.task(queue='site-worker', soft_time_limit=60 * 5)
 def update_phase_statuses():
-    competitions = Competition.objects.exclude(
-        phases__in=Phase.objects.filter(is_final_phase=True, end__lt=now())
-    )
+    competitions = Competition.objects.exclude(phases__in=Phase.objects.filter(is_final_phase=True, end__lt=now()))
     for comp in competitions:
         comp.update_phase_statuses()
 
 
-@app.task(queue="site-worker")
+@app.task(queue='site-worker')
 def submission_status_cleanup():
-    submissions = Submission.objects.filter(
-        status=Submission.RUNNING, has_children=False
-    ).select_related("phase", "parent")
+    submissions = Submission.objects.filter(status=Submission.RUNNING, has_children=False).select_related('phase', 'parent')
 
     for sub in submissions:
-        if sub.started_when < now() - timedelta(
-            milliseconds=(3600000 * 24) + sub.phase.execution_time_limit
-        ):
+        # Check if the submission has been running for 24 hours longer than execution_time_limit
+        if sub.started_when < now() - timedelta(milliseconds=(3600000 * 24) + sub.phase.execution_time_limit):
             if sub.parent is not None:
                 sub.parent.cancel(status=Submission.FAILED)
             else:
@@ -906,6 +819,8 @@ def _broadcast_worker_state(payload):
 
 @app.task(queue="site-worker", soft_time_limit=120)
 def refresh_compute_worker_health():
+    celery_app = app
+    r = get_redis_connection("default")
     known_queue_names = known_compute_queue_names()
     broker_sources = []
     broker_sources.append(("default", celery_app.conf.broker_url, celery_app))

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -21,8 +21,14 @@ from django.utils.timezone import now
 from rest_framework.exceptions import ValidationError
 
 from celery_config import app
-from competitions.models import Submission, CompetitionCreationTaskStatus, SubmissionDetails, Competition, \
-    CompetitionDump, Phase
+from competitions.models import (
+    Submission,
+    CompetitionCreationTaskStatus,
+    SubmissionDetails,
+    Competition,
+    CompetitionDump,
+    Phase,
+)
 from competitions.unpackers.utils import CompetitionUnpackingException
 from competitions.unpackers.v1 import V15Unpacker
 from competitions.unpackers.v2 import V2Unpacker
@@ -36,6 +42,7 @@ from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 COMPETITION_FIELDS = [
@@ -55,35 +62,35 @@ COMPETITION_FIELDS = [
     "reward",
     "contact_email",
     "fact_sheet",
-    "forum_enabled"
+    "forum_enabled",
 ]
 
 TASK_FIELDS = [
-    'name',
-    'description',
-    'key',
-    'is_public',
+    "name",
+    "description",
+    "key",
+    "is_public",
 ]
 SOLUTION_FIELDS = [
-    'name',
-    'description',
-    'tasks',
-    'key',
+    "name",
+    "description",
+    "tasks",
+    "key",
 ]
 
 PHASE_FIELDS = [
-    'index',
-    'name',
-    'description',
-    'start',
-    'end',
-    'max_submissions_per_day',
-    'max_submissions_per_person',
-    'execution_time_limit',
-    'auto_migrate_to_this_phase',
-    'hide_output',
-    'hide_prediction_output',
-    'hide_score_output',
+    "index",
+    "name",
+    "description",
+    "start",
+    "end",
+    "max_submissions_per_day",
+    "max_submissions_per_person",
+    "execution_time_limit",
+    "auto_migrate_to_this_phase",
+    "hide_output",
+    "hide_prediction_output",
+    "hide_score_output",
 ]
 PHASE_FILES = [
     "input_data",
@@ -93,15 +100,12 @@ PHASE_FILES = [
     "public_data",
     "starting_kit",
 ]
-PAGE_FIELDS = [
-    "title"
-]
+PAGE_FIELDS = ["title"]
 LEADERBOARD_FIELDS = [
-    'title',
-    'key',
-    'hidden',
-    'submission_rule',
-
+    "title",
+    "key",
+    "hidden",
+    "submission_rule",
     # For later
     # 'force_submission_to_leaderboard',
     # 'force_best_submission_to_leaderboard',
@@ -109,16 +113,18 @@ LEADERBOARD_FIELDS = [
 ]
 
 COLUMN_FIELDS = [
-    'title',
-    'key',
-    'index',
-    'sorting',
-    'computation',
-    'computation_indexes',
-    'hidden',
-    'precision',
+    "title",
+    "key",
+    "index",
+    "sorting",
+    "computation",
+    "computation_indexes",
+    "hidden",
+    "precision",
 ]
-MAX_EXECUTION_TIME_LIMIT = int(os.environ.get('MAX_EXECUTION_TIME_LIMIT', 600))  # time limit of the default queue
+MAX_EXECUTION_TIME_LIMIT = int(
+    os.environ.get("MAX_EXECUTION_TIME_LIMIT", 600)
+)  # time limit of the default queue
 
 
 def _send_to_compute_worker(submission, is_scoring):
@@ -127,43 +133,51 @@ def _send_to_compute_worker(submission, is_scoring):
         "submissions_api_url": settings.SUBMISSIONS_API_URL,
         "secret": submission.secret,
         "docker_image": submission.phase.competition.docker_image,
-        "execution_time_limit": min(MAX_EXECUTION_TIME_LIMIT, submission.phase.execution_time_limit),
+        "execution_time_limit": min(
+            MAX_EXECUTION_TIME_LIMIT, submission.phase.execution_time_limit
+        ),
         "id": submission.pk,
         "is_scoring": is_scoring,
     }
 
-    if not submission.detailed_result.name and submission.phase.competition.enable_detailed_results:
-        submission.detailed_result.save('detailed_results.html', ContentFile(''.encode()))  # must encode here for GCS
-        submission.save(update_fields=['detailed_result'])
+    if (
+        not submission.detailed_result.name
+        and submission.phase.competition.enable_detailed_results
+    ):
+        submission.detailed_result.save(
+            "detailed_results.html", ContentFile("".encode())
+        )  # must encode here for GCS
+        submission.save(update_fields=["detailed_result"])
     if not submission.prediction_result.name:
-        submission.prediction_result.save('prediction_result.zip', ContentFile(''.encode()))  # must encode here for GCS
-        submission.save(update_fields=['prediction_result'])
+        submission.prediction_result.save(
+            "prediction_result.zip", ContentFile("".encode())
+        )  # must encode here for GCS
+        submission.save(update_fields=["prediction_result"])
     if not submission.scoring_result.name:
-        submission.scoring_result.save('scoring_result.zip', ContentFile(''.encode()))  # must encode here for GCS
-        submission.save(update_fields=['scoring_result'])
+        submission.scoring_result.save(
+            "scoring_result.zip", ContentFile("".encode())
+        )  # must encode here for GCS
+        submission.save(update_fields=["scoring_result"])
 
     submission = Submission.objects.get(id=submission.id)
     task = submission.task
 
     if not is_scoring:
-        run_args['prediction_result'] = make_url_sassy(
-            path=submission.prediction_result.name,
-            permission='w'
+        run_args["prediction_result"] = make_url_sassy(
+            path=submission.prediction_result.name, permission="w"
         )
     else:
         if submission.phase.competition.enable_detailed_results:
-            run_args['detailed_results_url'] = make_url_sassy(
+            run_args["detailed_results_url"] = make_url_sassy(
                 path=submission.detailed_result.name,
-                permission='w',
-                content_type='text/html'
+                permission="w",
+                content_type="text/html",
             )
-        run_args['prediction_result'] = make_url_sassy(
-            path=submission.prediction_result.name,
-            permission='r'
+        run_args["prediction_result"] = make_url_sassy(
+            path=submission.prediction_result.name, permission="r"
         )
-        run_args['scoring_result'] = make_url_sassy(
-            path=submission.scoring_result.name,
-            permission='w'
+        run_args["scoring_result"] = make_url_sassy(
+            path=submission.scoring_result.name, permission="w"
         )
 
     if task.ingestion_program:
@@ -171,12 +185,12 @@ def _send_to_compute_worker(submission, is_scoring):
             run_args['ingestion_program_data'] = make_url_sassy(task.ingestion_program.data_file.name)
 
     if task.input_data and (not is_scoring or task.ingestion_only_during_scoring):
-        run_args['input_data'] = make_url_sassy(task.input_data.data_file.name)
+        run_args["input_data"] = make_url_sassy(task.input_data.data_file.name)
 
     if is_scoring and task.reference_data:
-        run_args['reference_data'] = make_url_sassy(task.reference_data.data_file.name)
+        run_args["reference_data"] = make_url_sassy(task.reference_data.data_file.name)
 
-    run_args['ingestion_only_during_scoring'] = task.ingestion_only_during_scoring
+    run_args["ingestion_only_during_scoring"] = task.ingestion_only_during_scoring
 
     if is_scoring:
         run_args['scoring_program_data'] = make_url_sassy(path=task.scoring_program.data_file.name)
@@ -198,9 +212,13 @@ def _send_to_compute_worker(submission, is_scoring):
     time_padding = 60 * 20  # 20 minutes
     time_limit = submission.phase.execution_time_limit + time_padding
 
-    if submission.phase.competition.queue:  # if the competition is running on a custom queue, not the default queue
+    if (
+        submission.phase.competition.queue
+    ):  # if the competition is running on a custom queue, not the default queue
         submission.queue = submission.phase.competition.queue
-        run_args['execution_time_limit'] = submission.phase.execution_time_limit  # use the competition time limit
+        run_args["execution_time_limit"] = (
+            submission.phase.execution_time_limit
+        )  # use the competition time limit
         submission.save(update_fields=["queue"])
     if submission.status == Submission.SUBMITTING:
         # Don't want to mark an already-prepared submission as "submitted" again, so
@@ -215,20 +233,22 @@ def _send_to_compute_worker(submission, is_scoring):
         if submission.phase.competition.queue:
             celery_app = app_or_default()
             with celery_app.connection() as new_connection:
-                new_connection.virtual_host = str(submission.phase.competition.queue.vhost)
+                new_connection.virtual_host = str(
+                    submission.phase.competition.queue.vhost
+                )
                 task = celery_app.send_task(
-                    'compute_worker_run',
+                    "compute_worker_run",
                     args=(run_args,),
-                    queue='compute-worker',
+                    queue="compute-worker",
                     soft_time_limit=time_limit,
                     connection=new_connection,
                     priority=priority,
                 )
         else:
             task = app.send_task(
-                'compute_worker_run',
+                "compute_worker_run",
                 args=(run_args,),
-                queue='compute-worker',
+                queue="compute-worker",
                 soft_time_limit=time_limit,
                 priority=priority,
             )
@@ -240,8 +260,12 @@ def _send_to_compute_worker(submission, is_scoring):
 
 def create_detailed_output_file(detail_name, submission):
     # Detail logs like stdout/etc.
-    new_details = SubmissionDetails.objects.create(submission=submission, name=detail_name)
-    new_details.data_file.save(f'{detail_name}.txt', ContentFile(''.encode()))  # must encode here for GCS
+    new_details = SubmissionDetails.objects.create(
+        submission=submission, name=detail_name
+    )
+    new_details.data_file.save(
+        f"{detail_name}.txt", ContentFile("".encode())
+    )  # must encode here for GCS
     return make_url_sassy(new_details.data_file.name, permission="w")
 
 
@@ -252,47 +276,49 @@ def run_submission(submission_pk, tasks=None, is_scoring=False):
 
 def send_submission_message(submission, data):
     from channels.layers import get_channel_layer
+
     channel_layer = get_channel_layer()
     user = submission.owner
-    asyncio.get_event_loop().run_until_complete(channel_layer.group_send(f"submission_listening_{user.pk}", {
-        'type': 'submission.message',
-        'text': data,
-        'submission_id': submission.pk,
-    }))
+    asyncio.get_event_loop().run_until_complete(
+        channel_layer.group_send(
+            f"submission_listening_{user.pk}",
+            {
+                "type": "submission.message",
+                "text": data,
+                "submission_id": submission.pk,
+            },
+        )
+    )
 
 
 def send_parent_status(submission):
     """Helper function we can mock in tests, instead of having to do async mocks"""
-    send_submission_message(submission, {
-        "kind": "status_update",
-        "status": "Running"
-    })
+    send_submission_message(submission, {"kind": "status_update", "status": "Running"})
 
 
 def send_child_id(submission, child_id):
     """Helper function we can mock in tests, instead of having to do async mocks"""
-    send_submission_message(submission, {
-        "kind": "child_update",
-        "child_id": child_id
-    })
+    send_submission_message(submission, {"kind": "child_update", "child_id": child_id})
 
 
-@app.task(queue='site-worker', soft_time_limit=60)
+@app.task(queue="site-worker", soft_time_limit=60)
 def _run_submission(submission_pk, task_pks=None, is_scoring=False):
     """This function is wrapped so that when we run tests we can run this function not
     via celery"""
     select_models = (
-        'phase',
-        'phase__competition',
+        "phase",
+        "phase__competition",
     )
     prefetch_models = (
-        'details',
-        'phase__tasks__input_data',
-        'phase__tasks__reference_data',
-        'phase__tasks__scoring_program',
-        'phase__tasks__ingestion_program',
+        "details",
+        "phase__tasks__input_data",
+        "phase__tasks__reference_data",
+        "phase__tasks__scoring_program",
+        "phase__tasks__ingestion_program",
     )
-    qs = Submission.objects.select_related(*select_models).prefetch_related(*prefetch_models)
+    qs = Submission.objects.select_related(*select_models).prefetch_related(
+        *prefetch_models
+    )
     submission = qs.get(pk=submission_pk)
 
     if submission.is_specific_task_re_run:
@@ -303,7 +329,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
     else:
         tasks = submission.phase.tasks.filter(pk__in=task_pks)
 
-    tasks = tasks.order_by('pk')
+    tasks = tasks.order_by("pk")
 
     if len(tasks) > 1:
         # The initial submission object becomes the parent submission and we create children for each task
@@ -321,7 +347,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
                 participant=submission.participant,
                 parent=submission,
                 task=task,
-                fact_sheet_answers=submission.fact_sheet_answers
+                fact_sheet_answers=submission.fact_sheet_answers,
             )
             child_sub.save(ignore_submission_limit=True)
             _send_to_compute_worker(child_sub, is_scoring=False)
@@ -334,7 +360,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
         _send_to_compute_worker(submission, is_scoring)
 
 
-@app.task(queue='site-worker', soft_time_limit=60 * 60)  # 1 hour timeout
+@app.task(queue="site-worker", soft_time_limit=60 * 60)  # 1 hour timeout
 def unpack_competition(status_pk):
     logger.info(f"Starting unpack with status pk = {status_pk}")
     status = CompetitionCreationTaskStatus.objects.get(pk=status_pk)
@@ -355,8 +381,12 @@ def unpack_competition(status_pk):
             # Extract bundle
             try:
                 with NamedTemporaryFile(mode="w+b") as temp_file:
-                    logger.info(f"Download competition bundle: {competition_dataset.data_file.name}")
-                    competition_bundle_url = make_url_sassy(competition_dataset.data_file.url)
+                    logger.info(
+                        f"Download competition bundle: {competition_dataset.data_file.name}"
+                    )
+                    competition_bundle_url = make_url_sassy(
+                        competition_dataset.data_file.url
+                    )
                     try:
                         with requests.get(competition_bundle_url, stream=True) as r:
                             r.raise_for_status()
@@ -364,12 +394,14 @@ def unpack_competition(status_pk):
                                 temp_file.write(chunk)
                             r.close()
                     except requests.exceptions.RequestException as e:
-                        raise CompetitionUnpackingException(f"Failed to download bundle from storage: {e}")
+                        raise CompetitionUnpackingException(
+                            f"Failed to download bundle from storage: {e}"
+                        )
 
                     # seek back to the start of the tempfile after writing to it..
                     temp_file.seek(0)
 
-                    with zipfile.ZipFile(temp_file.name, 'r') as zip_pointer:
+                    with zipfile.ZipFile(temp_file.name, "r") as zip_pointer:
                         zip_pointer.extractall(temp_directory)
             except zipfile.BadZipFile:
                 raise CompetitionUnpackingException("Bad zip file uploaded.")
@@ -386,20 +418,24 @@ def unpack_competition(status_pk):
                 with open(yaml_path) as f:
                     competition_yaml = yaml.safe_load(f.read())
             except yaml.YAMLError as e:
-                raise CompetitionUnpackingException(f"Error parsing competition.yaml: {e}")
+                raise CompetitionUnpackingException(
+                    f"Error parsing competition.yaml: {e}"
+                )
             except Exception as e:
-                raise CompetitionUnpackingException(f"Failed to read competition.yaml: {e}")
+                raise CompetitionUnpackingException(
+                    f"Failed to read competition.yaml: {e}"
+                )
 
-            yaml_version = str(competition_yaml.get('version', '1'))
+            yaml_version = str(competition_yaml.get("version", "1"))
 
             logger.info(f"The YAML version is: {yaml_version}")
-            if yaml_version in ['1', '1.5']:
+            if yaml_version in ["1", "1.5"]:
                 unpacker_class = V15Unpacker
-            elif yaml_version == '2':
+            elif yaml_version == "2":
                 unpacker_class = V2Unpacker
             else:
                 raise CompetitionUnpackingException(
-                    'A suitable version could not be found for this competition. Make sure one is supplied in the yaml.'
+                    "A suitable version could not be found for this competition. Make sure one is supplied in the yaml."
                 )
 
             unpacker = unpacker_class(
@@ -412,6 +448,7 @@ def unpack_competition(status_pk):
             try:
                 competition = unpacker.save()
             except ValidationError as e:
+
                 def _get_error_string(error_dict):
                     """Helps us nicely print out a ValidationError"""
                     for key, errors in error_dict.items():
@@ -453,7 +490,7 @@ def unpack_competition(status_pk):
         mark_status_as_failed_and_delete_dataset(status, message)
 
 
-@app.task(queue='site-worker', soft_time_limit=60 * 10)
+@app.task(queue="site-worker", soft_time_limit=60 * 10)
 def create_competition_dump(competition_pk, keys_instead_of_files=False):
     yaml_data = {"version": "2"}
     try:
@@ -462,7 +499,7 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         logger.info(f"Finding competition {competition_pk}")
         comp = Competition.objects.get(pk=competition_pk)
         zip_buffer = BytesIO()
-        current_date_time = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        current_date_time = datetime.today().strftime("%Y-%m-%d %H:%M:%S")
         zip_name = f"{comp.title}-{current_date_time}.zip"
         zip_file = zipfile.ZipFile(zip_buffer, "w")
 
@@ -470,14 +507,14 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         for field in COMPETITION_FIELDS:
             if hasattr(comp, field):
                 value = getattr(comp, field, "")
-                if field == 'queue' and value is not None:
+                if field == "queue" and value is not None:
                     value = str(value.vhost)
                 yaml_data[field] = value
         if comp.logo:
             logger.info("Checking logo")
             try:
-                yaml_data['image'] = re.sub(r'.*/', '', comp.logo.name)
-                zip_file.writestr(yaml_data['image'], comp.logo.read())
+                yaml_data["image"] = re.sub(r".*/", "", comp.logo.name)
+                zip_file.writestr(yaml_data["image"], comp.logo.read())
                 logger.info(f"Logo found for competition {comp.pk}")
             except OSError:
                 logger.warning(
@@ -486,25 +523,25 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
 
         # -------- Competition Terms -------
         if comp.terms:
-            yaml_data['terms'] = 'terms.md'
-            zip_file.writestr('terms.md', comp.terms)
+            yaml_data["terms"] = "terms.md"
+            zip_file.writestr("terms.md", comp.terms)
 
         # -------- Competition Pages -------
-        yaml_data['pages'] = []
+        yaml_data["pages"] = []
         for page in comp.pages.all():
             temp_page_data = {}
             for field in PAGE_FIELDS:
                 if hasattr(page, field):
                     temp_page_data[field] = getattr(page, field, "")
             page_file_name = f"{slugify(page.title)}-{page.pk}.md"
-            temp_page_data['file'] = page_file_name
-            yaml_data['pages'].append(temp_page_data)
-            zip_file.writestr(temp_page_data['file'], page.content)
+            temp_page_data["file"] = page_file_name
+            yaml_data["pages"].append(temp_page_data)
+            zip_file.writestr(temp_page_data["file"], page.content)
 
         # -------- Competition Tasks/Solutions -------
 
-        yaml_data['tasks'] = []
-        yaml_data['solutions'] = []
+        yaml_data["tasks"] = []
+        yaml_data["solutions"] = []
 
         task_solution_pairs = {}
         tasks = [task for phase in comp.phases.all() for task in phase.tasks.all()]
@@ -515,23 +552,18 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         for index, task in enumerate(tasks):
 
             task_solution_pairs[task.id] = {
-                'index': index,
-                'solutions': {
-                    'ids': [],
-                    'indexes': []
-                }
+                "index": index,
+                "solutions": {"ids": [], "indexes": []},
             }
 
-            temp_task_data = {
-                'index': index
-            }
+            temp_task_data = {"index": index}
 
             for field in TASK_FIELDS:
                 data = getattr(task, field, "")
                 # If keys_instead of files is not true and field is key, then skip this filed
-                if not keys_instead_of_files and field == 'key':
+                if not keys_instead_of_files and field == "key":
                     continue
-                if field == 'key':
+                if field == "key":
                     data = str(data)
                 temp_task_data[field] = data
 
@@ -544,116 +576,136 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
                                 temp_task_data[file_type] = str(temp_dataset.key)
                             else:
                                 try:
-                                    temp_task_data[file_type] = f"{file_type}-{task.pk}.zip"
-                                    zip_file.writestr(temp_task_data[file_type], temp_dataset.data_file.read())
+                                    temp_task_data[file_type] = (
+                                        f"{file_type}-{task.pk}.zip"
+                                    )
+                                    zip_file.writestr(
+                                        temp_task_data[file_type],
+                                        temp_dataset.data_file.read(),
+                                    )
                                 except OSError:
                                     logger.error(
                                         f"The file field is set, but no actual"
                                         f" file was found for dataset: {temp_dataset.pk} with name {temp_dataset.name}"
                                     )
                         else:
-                            logger.warning(f"Could not find data file for dataset object: {temp_dataset.pk}")
+                            logger.warning(
+                                f"Could not find data file for dataset object: {temp_dataset.pk}"
+                            )
             # Now for all of our solutions for the tasks, write those too
             for solution in task.solutions.all():
                 # for index_two, solution in enumerate(task.solutions.all()):
                 #     temp_index = index_two
                 # IF OUR SOLUTION WAS ALREADY ADDED
-                if solution.id in task_solution_pairs[task.id]['solutions']['ids']:
-                    for solution_data in yaml_data['solutions']:
-                        if solution_data['key'] == solution.key:
-                            solution_data['tasks'].append(task.id)
+                if solution.id in task_solution_pairs[task.id]["solutions"]["ids"]:
+                    for solution_data in yaml_data["solutions"]:
+                        if solution_data["key"] == solution.key:
+                            solution_data["tasks"].append(task.id)
                             break
                     break
                 # Else if our index is already taken
-                elif index_two in task_solution_pairs[task.id]['solutions']['indexes']:
+                elif index_two in task_solution_pairs[task.id]["solutions"]["indexes"]:
                     index_two += 1
-                task_solution_pairs[task.id]['solutions']['indexes'].append(index_two)
-                task_solution_pairs[task.id]['solutions']['ids'].append(solution.id)
+                task_solution_pairs[task.id]["solutions"]["indexes"].append(index_two)
+                task_solution_pairs[task.id]["solutions"]["ids"].append(solution.id)
 
-                temp_solution_data = {
-                    'index': index_two
-                }
+                temp_solution_data = {"index": index_two}
                 for field in SOLUTION_FIELDS:
                     if hasattr(solution, field):
                         data = getattr(solution, field, "")
-                        if field == 'key':
+                        if field == "key":
                             data = str(data)
                         temp_solution_data[field] = data
                 if solution.data:
-                    temp_dataset = getattr(solution, 'data')
+                    temp_dataset = getattr(solution, "data")
                     if temp_dataset:
                         if temp_dataset.data_file:
                             try:
-                                temp_solution_data['path'] = f"solution-{solution.pk}.zip"
-                                zip_file.writestr(temp_solution_data['path'], temp_dataset.data_file.read())
+                                temp_solution_data["path"] = (
+                                    f"solution-{solution.pk}.zip"
+                                )
+                                zip_file.writestr(
+                                    temp_solution_data["path"],
+                                    temp_dataset.data_file.read(),
+                                )
                             except OSError:
                                 logger.error(
                                     f"The file field is set, but no actual"
                                     f" file was found for dataset: {temp_dataset.pk} with name {temp_dataset.name}"
                                 )
                         else:
-                            logger.warning(f"Could not find data file for dataset object: {temp_dataset.pk}")
+                            logger.warning(
+                                f"Could not find data file for dataset object: {temp_dataset.pk}"
+                            )
                 # TODO: Make sure logic here is right. Needs to be outputted as a list, but what others can we tie to?
-                temp_solution_data['tasks'] = [index]
-                yaml_data['solutions'].append(temp_solution_data)
+                temp_solution_data["tasks"] = [index]
+                yaml_data["solutions"].append(temp_solution_data)
                 index_two += 1
             # End for loop for solutions; Append tasks data
-            yaml_data['tasks'].append(temp_task_data)
+            yaml_data["tasks"].append(temp_task_data)
 
         # -------- Competition Phases -------
 
-        yaml_data['phases'] = []
+        yaml_data["phases"] = []
         for phase in comp.phases.all():
             temp_phase_data = {}
             for field in PHASE_FIELDS:
                 if hasattr(phase, field):
-                    if field == 'start' or field == 'end':
+                    if field == "start" or field == "end":
                         temp_date = getattr(phase, field)
                         if not temp_date:
                             continue
                         temp_date = temp_date.strftime("%Y-%m-%d")
                         temp_phase_data[field] = temp_date
-                    elif field == 'max_submissions_per_person':
-                        temp_phase_data['max_submissions'] = getattr(phase, field)
+                    elif field == "max_submissions_per_person":
+                        temp_phase_data["max_submissions"] = getattr(phase, field)
                     else:
                         temp_phase_data[field] = getattr(phase, field, "")
-            task_indexes = [task_solution_pairs[task.id]['index'] for task in phase.tasks.all()]
-            temp_phase_data['tasks'] = task_indexes
+            task_indexes = [
+                task_solution_pairs[task.id]["index"] for task in phase.tasks.all()
+            ]
+            temp_phase_data["tasks"] = task_indexes
             temp_phase_solutions = []
             for task in phase.tasks.all():
-                temp_phase_solutions += task_solution_pairs[task.id]['solutions']['indexes']
-            temp_phase_data['solutions'] = temp_phase_solutions
-            yaml_data['phases'].append(temp_phase_data)
-        yaml_data['phases'] = sorted(yaml_data['phases'], key=lambda phase: phase['index'])
+                temp_phase_solutions += task_solution_pairs[task.id]["solutions"][
+                    "indexes"
+                ]
+            temp_phase_data["solutions"] = temp_phase_solutions
+            yaml_data["phases"].append(temp_phase_data)
+        yaml_data["phases"] = sorted(
+            yaml_data["phases"], key=lambda phase: phase["index"]
+        )
 
         # -------- Leaderboards -------
 
-        yaml_data['leaderboards'] = []
+        yaml_data["leaderboards"] = []
         # Have to grab leaderboards from phases
-        leaderboards = Leaderboard.objects.filter(id__in=comp.phases.all().values_list('leaderboard', flat=True))
+        leaderboards = Leaderboard.objects.filter(
+            id__in=comp.phases.all().values_list("leaderboard", flat=True)
+        )
         for index, leaderboard in enumerate(leaderboards):
-            ldb_data = {
-                'index': index
-            }
+            ldb_data = {"index": index}
             for field in LEADERBOARD_FIELDS:
                 if hasattr(leaderboard, field):
                     ldb_data[field] = getattr(leaderboard, field, "")
-            ldb_data['columns'] = []
+            ldb_data["columns"] = []
             for column in leaderboard.columns.all():
                 col_data = {}
                 for field in COLUMN_FIELDS:
                     if hasattr(column, field):
                         value = getattr(column, field, "")
-                        if field == 'computation_indexes' and value is not None:
-                            value = value.split(',')
+                        if field == "computation_indexes" and value is not None:
+                            value = value.split(",")
                         if value is not None:
                             col_data[field] = value
-                ldb_data['columns'].append(col_data)
-            yaml_data['leaderboards'].append(ldb_data)
+                ldb_data["columns"].append(col_data)
+            yaml_data["leaderboards"].append(ldb_data)
 
         # ------- Finalize --------
         logger.info(f"YAML data to be written is: {yaml_data}")
-        comp_yaml = yaml.safe_dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
+        comp_yaml = yaml.safe_dump(
+            yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8"
+        )
         logger.info(f"YAML output: {comp_yaml}")
         zip_file.writestr("competition.yaml", comp_yaml)
         zip_file.close()
@@ -664,8 +716,8 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         temp_dataset_bundle = Data.objects.create(
             created_by=comp.created_by,
             name=f"{comp.title} Dump #{bundle_count} Created {current_date_time}",
-            type='competition_bundle',
-            description='Automatically created competition dump',
+            type="competition_bundle",
+            description="Automatically created competition dump",
             # 'data_file'=,
         )
         logger.info("Saving zip to Competition Bundle")
@@ -674,61 +726,74 @@ def create_competition_dump(competition_pk, keys_instead_of_files=False):
         temp_comp_dump = CompetitionDump.objects.create(
             dataset=temp_dataset_bundle,
             status="Finished",
-            details="Competition Bundle {0} for Competition {1}".format(temp_dataset_bundle.pk, comp.pk),
-            competition=comp
+            details="Competition Bundle {0} for Competition {1}".format(
+                temp_dataset_bundle.pk, comp.pk
+            ),
+            competition=comp,
         )
-        logger.info(f"Finished creating competition dump: {temp_comp_dump.pk} for competition: {comp.pk}")
+        logger.info(
+            f"Finished creating competition dump: {temp_comp_dump.pk} for competition: {comp.pk}"
+        )
     except ObjectDoesNotExist:
-        logger.error("Could not find competition with pk {} to create a competition dump".format(competition_pk))
+        logger.error(
+            "Could not find competition with pk {} to create a competition dump".format(
+                competition_pk
+            )
+        )
 
 
-@app.task(queue='site-worker', soft_time_limit=60 * 5)
+@app.task(queue="site-worker", soft_time_limit=60 * 5)
 def do_phase_migrations():
     # Update phase statuses
-    previous_subquery = Phase.objects.filter(
-        competition=OuterRef('competition'),
-        end__lte=now()
-    ).order_by('-index').values('index')[:1]
+    previous_subquery = (
+        Phase.objects.filter(competition=OuterRef("competition"), end__lte=now())
+        .order_by("-index")
+        .values("index")[:1]
+    )
 
     current_subquery = Phase.objects.filter(
-        competition=OuterRef('competition'),
+        competition=OuterRef("competition"),
         start__lte=now(),
         end__gt=now(),
-    ).values('index')[:1]
+    ).values("index")[:1]
 
-    next_subquery = Phase.objects.filter(
-        competition=OuterRef('competition'),
-        start__gt=now()
-    ).order_by('index').values('index')[:1]
+    next_subquery = (
+        Phase.objects.filter(competition=OuterRef("competition"), start__gt=now())
+        .order_by("index")
+        .values("index")[:1]
+    )
 
     Phase.objects.annotate(
         previous_index=Subquery(previous_subquery),
         current_index=Subquery(current_subquery),
         next_index=Subquery(next_subquery),
-    ).update(status=Case(
-        When(index=F('previous_index'), then=Value(Phase.PREVIOUS)),
-        When(index=F('current_index'), then=Value(Phase.CURRENT)),
-        When(index=F('next_index'), then=Value(Phase.NEXT)),
-        default=None
-    ))
+    ).update(
+        status=Case(
+            When(index=F("previous_index"), then=Value(Phase.PREVIOUS)),
+            When(index=F("current_index"), then=Value(Phase.CURRENT)),
+            When(index=F("next_index"), then=Value(Phase.NEXT)),
+            default=None,
+        )
+    )
 
     # Updating Competitions whose phases have finished migrating to `is_migrating=False`
-    completed_statuses = [Submission.FINISHED, Submission.FAILED, Submission.CANCELLED, Submission.NONE]
+    completed_statuses = [
+        Submission.FINISHED,
+        Submission.FAILED,
+        Submission.CANCELLED,
+        Submission.NONE,
+    ]
 
-    running_subs_query = Submission.objects.filter(
-        created_by_migration=OuterRef('pk')
-    ).exclude(
-        status__in=completed_statuses
-    ).values_list('pk')[:1]
+    running_subs_query = (
+        Submission.objects.filter(created_by_migration=OuterRef("pk"))
+        .exclude(status__in=completed_statuses)
+        .values_list("pk")[:1]
+    )
 
     Competition.objects.filter(
-        pk__in=Phase.objects.annotate(
-            running_subs=Count(Subquery(running_subs_query))
-        ).filter(
-            running_subs=0,
-            competition__is_migrating=True,
-            status=Phase.PREVIOUS
-        ).values_list('competition__pk', flat=True)
+        pk__in=Phase.objects.annotate(running_subs=Count(Subquery(running_subs_query)))
+        .filter(running_subs=0, competition__is_migrating=True, status=Phase.PREVIOUS)
+        .values_list("competition__pk", flat=True)
     ).update(is_migrating=False)
 
     # Checking for new phases to start migrating
@@ -736,7 +801,7 @@ def do_phase_migrations():
         auto_migrate_to_this_phase=True,
         start__lte=now(),
         competition__is_migrating=False,
-        has_been_migrated=False
+        has_been_migrated=False,
     )
 
     logger.info(f"Checking {len(new_phases)} phases for phase migrations.")
@@ -745,50 +810,70 @@ def do_phase_migrations():
         p.check_future_phase_submissions()
 
 
-@app.task(queue='site-worker', soft_time_limit=60 * 5)
+@app.task(queue="site-worker", soft_time_limit=60 * 5)
 def manual_migration(phase_id):
     try:
         source_phase = Phase.objects.get(id=phase_id)
     except Phase.DoesNotExist:
-        logger.error(f'Could not manually migrate phase with id: {phase_id}. Phase could not be found.')
+        logger.error(
+            f"Could not manually migrate phase with id: {phase_id}. Phase could not be found."
+        )
         return
 
     try:
-        destination_phase = source_phase.competition.phases.get(index=source_phase.index + 1)
+        destination_phase = source_phase.competition.phases.get(
+            index=source_phase.index + 1
+        )
     except Phase.DoesNotExist:
-        logger.error(f'Could not manually migrate phase with id: {phase_id}. The next phase could not be found.')
+        logger.error(
+            f"Could not manually migrate phase with id: {phase_id}. The next phase could not be found."
+        )
         return
-    destination_phase.competition.apply_phase_migration(source_phase, destination_phase, force_migration=True)
-
-
-@app.task(queue='site-worker', soft_time_limit=60 * 5)
-def batch_send_email(comp_id, content):
-    try:
-        competition = Competition.objects.prefetch_related('participants__user').get(id=comp_id)
-    except Competition.DoesNotExist:
-        logger.error(f'Not sending emails because competition with id {comp_id} could not be found')
-        return
-
-    codalab_send_markdown_email(
-        subject=f'A message from the admins of {competition.title}',
-        markdown_content=content,
-        recipient_list=[participant.user.email for participant in competition.participants.all()]
+    destination_phase.competition.apply_phase_migration(
+        source_phase, destination_phase, force_migration=True
     )
 
 
-@app.task(queue='site-worker', soft_time_limit=60 * 5)
+@app.task(queue="site-worker", soft_time_limit=60 * 5)
+def batch_send_email(comp_id, content):
+    try:
+        competition = Competition.objects.prefetch_related("participants__user").get(
+            id=comp_id
+        )
+    except Competition.DoesNotExist:
+        logger.error(
+            f"Not sending emails because competition with id {comp_id} could not be found"
+        )
+        return
+
+    codalab_send_markdown_email(
+        subject=f"A message from the admins of {competition.title}",
+        markdown_content=content,
+        recipient_list=[
+            participant.user.email for participant in competition.participants.all()
+        ],
+    )
+
+
+@app.task(queue="site-worker", soft_time_limit=60 * 5)
 def update_phase_statuses():
-    competitions = Competition.objects.exclude(phases__in=Phase.objects.filter(is_final_phase=True, end__lt=now()))
+    competitions = Competition.objects.exclude(
+        phases__in=Phase.objects.filter(is_final_phase=True, end__lt=now())
+    )
     for comp in competitions:
         comp.update_phase_statuses()
 
 
-@app.task(queue='site-worker')
+@app.task(queue="site-worker")
 def submission_status_cleanup():
-    submissions = Submission.objects.filter(status=Submission.RUNNING, has_children=False).select_related('phase', 'parent')
+    submissions = Submission.objects.filter(
+        status=Submission.RUNNING, has_children=False
+    ).select_related("phase", "parent")
 
     for sub in submissions:
-        if sub.started_when < now() - timedelta(milliseconds=(3600000 * 24) + sub.phase.execution_time_limit):
+        if sub.started_when < now() - timedelta(
+            milliseconds=(3600000 * 24) + sub.phase.execution_time_limit
+        ):
             if sub.parent is not None:
                 sub.parent.cancel(status=Submission.FAILED)
             else:
@@ -830,7 +915,9 @@ def refresh_compute_worker_health():
         if not worker_name.startswith("compute-worker"):
             continue
 
-        raw_running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+        raw_running_jobs = len(active.get(worker_name, [])) + len(
+            reserved.get(worker_name, [])
+        )
         status = "busy" if raw_running_jobs > 0 else "available"
 
         payload = {
@@ -844,10 +931,12 @@ def refresh_compute_worker_health():
         r.hset(
             WORKERS_REGISTRY_KEY,
             worker_name,
-            json.dumps({
-                "hostname": worker_name,
-                "last_seen": payload["timestamp"],
-            }),
+            json.dumps(
+                {
+                    "hostname": worker_name,
+                    "last_seen": payload["timestamp"],
+                }
+            ),
         )
 
         _broadcast_worker_state(payload)

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -45,6 +45,8 @@ from celery_config import app_for_vhost
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
 from utils.worker_utils import (
+    WORKER_HEARTBEAT_TTL,
+    WORKERS_REGISTRY_KEY,
     extract_queue_names,
     is_compute_worker,
     known_compute_queue_names,
@@ -53,8 +55,6 @@ from utils.worker_utils import (
 logger = logging.getLogger(__name__)
 
 r = get_redis_connection("default")
-WORKERS_REGISTRY_KEY = "workers:registry"
-WORKER_HEARTBEAT_TTL = 35
 
 COMPETITION_FIELDS = [
     "title",

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from queue import Queue
 import re
 import traceback
 import zipfile
@@ -46,7 +47,7 @@ from utils.email import codalab_send_markdown_email
 logger = logging.getLogger(__name__)
 
 r = get_redis_connection("default")
-WORKERS_REGISTRY_KEY = "compute_workers_registry"
+WORKERS_REGISTRY_KEY = "workers:registry"
 WORKER_HEARTBEAT_TTL = 35
 
 COMPETITION_FIELDS = [
@@ -884,6 +885,7 @@ def submission_status_cleanup():
                 sub.cancel(status=Submission.FAILED)
 
 
+# -------------------------------------------------
 def _broadcast_worker_state(payload):
     channel_layer = get_channel_layer()
     if not channel_layer:
@@ -898,67 +900,131 @@ def _broadcast_worker_state(payload):
     )
 
 
+def _get_broker_host(broker_url):
+    if not broker_url or "@" not in broker_url:
+        return None
+    try:
+        return broker_url.split("@", 1)[1].split("/", 1)[0].split(":", 1)[0]
+    except Exception:
+        return None
+
+
+def _resolve_broker_url(celery_app, broker_url):
+    if not broker_url:
+        return broker_url
+
+    if "@localhost:" not in broker_url:
+        return broker_url
+
+    default_broker = getattr(celery_app.conf, "broker_url", None)
+    default_host = _get_broker_host(default_broker)
+
+    if not default_host or default_host == "localhost":
+        return broker_url
+
+    return broker_url.replace("@localhost:", f"@{default_host}:")
+
+
 @app.task(queue="site-worker", soft_time_limit=60)
 def refresh_compute_worker_health():
     celery_app = app_or_default()
-    inspector = celery_app.control.inspect(timeout=1)
-
-    if inspector is None:
-        logger.warning("Celery inspect returned None")
-        return
-
-    try:
-        stats = inspector.stats() or {}
-        active = inspector.active() or {}
-        reserved = inspector.reserved() or {}
-        active_queues = inspector.active_queues() or {}
-    except Exception:
-        logger.exception("Unable to inspect Celery workers")
-        return
-
     known_queue_names = _known_compute_queue_names()
 
-    for worker_name in stats.keys():
-        queues = active_queues.get(worker_name, []) or []
-        queue_names = _extract_queue_names(queues)
+    broker_sources = []
 
-        if not _is_compute_worker(worker_name, queue_names, known_queue_names):
+    default_broker = getattr(celery_app.conf, "broker_url", None)
+    if default_broker:
+        broker_sources.append(("default", default_broker))
+
+    private_queues = (
+        Queue.objects.filter(competitions__isnull=False)
+        .exclude(name__isnull=True)
+        .exclude(name="")
+        .distinct()
+    )
+
+    for queue in private_queues:
+        broker_url = _resolve_broker_url(celery_app, queue.broker_url)
+        if broker_url:
+            broker_sources.append((queue.name, broker_url))
+
+    inspected_brokers = set()
+
+    for source_name, broker_url in broker_sources:
+        if broker_url in inspected_brokers:
+            continue
+        inspected_brokers.add(broker_url)
+
+        try:
+            broker_app = celery_app.__class__(
+                "worker-monitor",
+                broker=broker_url,
+            )
+
+            inspector = broker_app.control.inspect(timeout=1)
+
+            if inspector is None:
+                logger.warning(
+                    "Celery inspect returned None for broker=%s",
+                    source_name,
+                )
+                continue
+
+            stats = inspector.stats() or {}
+            active = inspector.active() or {}
+            reserved = inspector.reserved() or {}
+            active_queues = inspector.active_queues() or {}
+
+        except Exception:
+            logger.exception(
+                "Unable to inspect Celery workers for broker %s",
+                source_name,
+            )
             continue
 
-        running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
-        status = "busy" if running_jobs > 0 else "available"
+        for worker_name in stats.keys():
+            queues = active_queues.get(worker_name, []) or []
+            queue_names = _extract_queue_names(queues)
 
-        payload = {
-            "hostname": worker_name,
-            "status": status,
-            "running_jobs": running_jobs,
-            "timestamp": now().timestamp(),
-            "queue_names": sorted(queue_names),
-        }
+            if not _is_compute_worker(worker_name, queue_names, known_queue_names):
+                continue
 
-        heartbeat_key = f"worker:{worker_name}:heartbeat"
+            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+            status = "busy" if running_jobs > 0 else "available"
 
-        r.set(
-            heartbeat_key,
-            json.dumps(payload),
-            ex=WORKER_HEARTBEAT_TTL,
-        )
+            payload = {
+                "hostname": worker_name,
+                "status": status,
+                "running_jobs": running_jobs,
+                "timestamp": now().timestamp(),
+                "queue_source": source_name,
+                "queue_names": sorted(queue_names),
+            }
 
-        r.hset(
-            WORKERS_REGISTRY_KEY,
-            worker_name,
-            json.dumps(
-                {
-                    "hostname": worker_name,
-                    "status": status,
-                    "running_jobs": running_jobs,
-                    "last_seen": payload["timestamp"],
-                    "queue_names": sorted(queue_names),
-                }
-            ),
-        )
+            heartbeat_key = f"worker:{source_name}:{worker_name}:heartbeat"
 
-        _broadcast_worker_state(payload)
-        logger.info(
-            f"[WORKER-HEALTH] {worker_name} status={status} jobs={running_jobs} queues={sorted(queue_names)}"
-        )
+            r.set(
+                heartbeat_key,
+                json.dumps(payload),
+                ex=WORKER_HEARTBEAT_TTL,
+            )
+
+            r.hset(
+                WORKERS_REGISTRY_KEY,
+                f"{source_name}:{worker_name}",
+                json.dumps(
+                    {
+                        "hostname": worker_name,
+                        "status": status,
+                        "running_jobs": running_jobs,
+                        "last_seen": payload["timestamp"],
+                        "queue_source": source_name,
+                        "queue_names": sorted(queue_names),
+                    }
+                ),
+            )
+
+            _broadcast_worker_state(payload)
+            logger.info(
+                f"[WORKER-HEALTH] source={source_name} {worker_name} status={status} jobs={running_jobs} queues={sorted(queue_names)}"
+            )

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -32,6 +32,9 @@ from datasets.models import Data
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
 
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -785,9 +788,66 @@ def submission_status_cleanup():
     submissions = Submission.objects.filter(status=Submission.RUNNING, has_children=False).select_related('phase', 'parent')
 
     for sub in submissions:
-        # Check if the submission has been running for 24 hours longer than execution_time_limit
         if sub.started_when < now() - timedelta(milliseconds=(3600000 * 24) + sub.phase.execution_time_limit):
             if sub.parent is not None:
                 sub.parent.cancel(status=Submission.FAILED)
             else:
                 sub.cancel(status=Submission.FAILED)
+
+
+def _broadcast_worker_state(payload):
+    channel_layer = get_channel_layer()
+    if not channel_layer:
+        return
+
+    async_to_sync(channel_layer.group_send)(
+        "compute_workers",
+        {
+            "type": "worker.health",
+            "worker": payload,
+        },
+    )
+
+
+@app.task(queue="site-worker", soft_time_limit=60)
+def refresh_compute_worker_health():
+    celery_app = app_or_default()
+    inspector = celery_app.control.inspect(timeout=1)
+
+    if inspector is None:
+        logger.warning("Celery inspect returned None")
+        return
+
+    try:
+        stats = inspector.stats() or {}
+        active = inspector.active() or {}
+        reserved = inspector.reserved() or {}
+    except Exception:
+        logger.exception("Unable to inspect Celery workers")
+        return
+
+    for worker_name in stats.keys():
+        if not worker_name.startswith("compute-worker"):
+            continue
+
+        raw_running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+        status = "busy" if raw_running_jobs > 0 else "available"
+
+        payload = {
+            "hostname": worker_name,
+            "status": status,
+            "running_jobs": raw_running_jobs,
+            "timestamp": now().timestamp(),
+        }
+
+        r.set(f"worker:{worker_name}:heartbeat", json.dumps(payload), ex=35)
+        r.hset(
+            WORKERS_REGISTRY_KEY,
+            worker_name,
+            json.dumps({
+                "hostname": worker_name,
+                "last_seen": payload["timestamp"],
+            }),
+        )
+
+        _broadcast_worker_state(payload)

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -40,7 +40,7 @@ from rest_framework.exceptions import ValidationError
 from tasks.models import Task
 
 from celery_config import app
-from utils.consumers import _extract_queue_names, _is_compute_worker, _known_compute_queue_names
+from utils.worker_utils import extract_queue_names, known_compute_queue_names, is_compute_worker
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
 
@@ -928,7 +928,7 @@ def _resolve_broker_url(celery_app, broker_url):
 @app.task(queue="site-worker", soft_time_limit=60)
 def refresh_compute_worker_health():
     celery_app = app_or_default()
-    known_queue_names = _known_compute_queue_names()
+    known_queue_names = known_compute_queue_names()
 
     broker_sources = []
     default_broker = getattr(celery_app.conf, "broker_url", None)
@@ -984,8 +984,8 @@ def refresh_compute_worker_health():
 
         for worker_name in stats.keys():
             queues = active_queues.get(worker_name, []) or []
-            queue_names = _extract_queue_names(queues)
-            if not _is_compute_worker(worker_name, queue_names, known_queue_names):
+            queue_names = extract_queue_names(queues)
+            if not is_compute_worker(worker_name, queue_names, known_queue_names):
                 continue
 
             running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -1,48 +1,46 @@
 import asyncio
+import json
+import logging
 import os
 import re
 import traceback
 import zipfile
-import json
-from datetime import timedelta, datetime
-from django.conf import settings
+from datetime import datetime, timedelta
 from io import BytesIO
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import oyaml as yaml
 import requests
+from asgiref.sync import async_to_sync
 from celery._state import app_or_default
-from django_redis import get_redis_connection
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.files.base import ContentFile
-from django.db.models import Subquery, OuterRef, Count, Case, When, Value, F
-from django.db import transaction
-from django.utils.text import slugify
-from django.utils.timezone import now
-from rest_framework.exceptions import ValidationError
-
-from celery_config import app
+from channels.layers import get_channel_layer
 from competitions.models import (
-    Submission,
-    CompetitionCreationTaskStatus,
-    SubmissionDetails,
     Competition,
+    CompetitionCreationTaskStatus,
     CompetitionDump,
     Phase,
+    Submission,
+    SubmissionDetails,
 )
 from competitions.unpackers.utils import CompetitionUnpackingException
 from competitions.unpackers.v1 import V15Unpacker
 from competitions.unpackers.v2 import V2Unpacker
-from leaderboards.models import Leaderboard
-from tasks.models import Task
 from datasets.models import Data
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.files.base import ContentFile
+from django.db import transaction
+from django.db.models import Case, Count, F, OuterRef, Subquery, Value, When
+from django.utils.text import slugify
+from django.utils.timezone import now
+from django_redis import get_redis_connection
+from leaderboards.models import Leaderboard
+from rest_framework.exceptions import ValidationError
+from tasks.models import Task
+
+from celery_config import app
 from utils.data import make_url_sassy
 from utils.email import codalab_send_markdown_email
-
-from channels.layers import get_channel_layer
-from asgiref.sync import async_to_sync
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -3,15 +3,16 @@ import os
 import re
 import traceback
 import zipfile
+import json
 from datetime import timedelta, datetime
-
+from django.conf import settings
 from io import BytesIO
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 import oyaml as yaml
 import requests
 from celery._state import app_or_default
-from django.conf import settings
+from django_redis import get_redis_connection
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.db.models import Subquery, OuterRef, Count, Case, When, Value, F
@@ -42,8 +43,11 @@ from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 
 import logging
-
 logger = logging.getLogger(__name__)
+
+r = get_redis_connection("default")
+WORKERS_REGISTRY_KEY = "compute_workers_registry"
+WORKER_HEARTBEAT_TTL = 35
 
 COMPETITION_FIELDS = [
     "title",
@@ -907,36 +911,61 @@ def refresh_compute_worker_health():
         stats = inspector.stats() or {}
         active = inspector.active() or {}
         reserved = inspector.reserved() or {}
+        active_queues = inspector.active_queues() or {}
     except Exception:
         logger.exception("Unable to inspect Celery workers")
         return
 
     for worker_name in stats.keys():
-        if not worker_name.startswith("compute-worker"):
+        queues = active_queues.get(worker_name, []) or []
+        queue_names = []
+
+        for q in queues:
+            if isinstance(q, dict) and q.get("name"):
+                queue_names.append(q["name"])
+
+        is_compute_worker = (
+            "compute-worker" in queue_names
+            or worker_name.startswith("compute-worker")
+            or worker_name.startswith("CW")
+        )
+
+        if not is_compute_worker:
             continue
 
-        raw_running_jobs = len(active.get(worker_name, [])) + len(
-            reserved.get(worker_name, [])
+        running_jobs = (
+            len(active.get(worker_name, []))
+            + len(reserved.get(worker_name, []))
         )
-        status = "busy" if raw_running_jobs > 0 else "available"
+        status = "busy" if running_jobs > 0 else "available"
 
         payload = {
             "hostname": worker_name,
             "status": status,
-            "running_jobs": raw_running_jobs,
+            "running_jobs": running_jobs,
             "timestamp": now().timestamp(),
         }
 
-        r.set(f"worker:{worker_name}:heartbeat", json.dumps(payload), ex=35)
+        heartbeat_key = f"worker:{worker_name}:heartbeat"
+
+        r.set(
+            heartbeat_key,
+            json.dumps(payload),
+            ex=WORKER_HEARTBEAT_TTL,
+        )
+
         r.hset(
             WORKERS_REGISTRY_KEY,
             worker_name,
-            json.dumps(
-                {
-                    "hostname": worker_name,
-                    "last_seen": payload["timestamp"],
-                }
-            ),
+            json.dumps({
+                "hostname": worker_name,
+                "status": status,
+                "running_jobs": running_jobs,
+                "last_seen": payload["timestamp"],
+            }),
         )
 
         _broadcast_worker_state(payload)
+        logger.info(
+            f"[WORKER-HEALTH] {worker_name} status={status} jobs={running_jobs}"
+        )

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -8,11 +8,16 @@ app = Celery()
 
 from django.conf import settings  # noqa
 
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 app.conf.task_queues = [
     # Mostly defining queue here so we can set x-max-priority
-    Queue('compute-worker', Exchange('compute-worker'), routing_key='compute-worker', queue_arguments={'x-max-priority': 10}),
+    Queue(
+        "compute-worker",
+        Exchange("compute-worker"),
+        routing_key="compute-worker",
+        queue_arguments={"x-max-priority": 10},
+    ),
 ]
 
 _vhost_apps = {}
@@ -32,11 +37,10 @@ def app_for_vhost(vhost):
         # Copy the settings so we can modify the broker url to include the vhost
         django_settings = copy.copy(settings)
         django_settings.CELERY_BROKER_URL = broker_url
-        vhost_app.config_from_object(django_settings, namespace='CELERY')
+        vhost_app.config_from_object(django_settings, namespace="CELERY")
         vhost_app.conf.task_queues = app.conf.task_queues
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]
-
 
 
 app.conf.beat_schedule = {

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -1,8 +1,9 @@
-from celery import Celery
-from kombu import Queue, Exchange
-from django.conf import settings
-import urllib.parse
 import copy
+import urllib.parse
+
+from celery import Celery
+from django.conf import settings
+from kombu import Exchange, Queue
 
 app = Celery()
 

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -36,3 +36,12 @@ def app_for_vhost(vhost):
         vhost_app.conf.task_queues = app.conf.task_queues
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]
+
+
+
+app.conf.beat_schedule = {
+    "refresh-compute-worker-health": {
+        "task": "chemin.vers.refresh_compute_worker_health",
+        "schedule": 5.0,
+    },
+}

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -42,10 +42,9 @@ def app_for_vhost(vhost):
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]
 
-
 app.conf.beat_schedule = {
     "refresh-compute-worker-health": {
-        "task": "chemin.vers.refresh_compute_worker_health",
-        "schedule": 5.0,
+        "task": "apps.competitions.tasks.refresh_compute_worker_health",
+        "schedule": 3.0,
     },
 }

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -42,6 +42,7 @@ def app_for_vhost(vhost):
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]
 
+
 app.conf.beat_schedule = {
     "refresh-compute-worker-health": {
         "task": "apps.competitions.tasks.refresh_compute_worker_health",

--- a/src/celery_config.py
+++ b/src/celery_config.py
@@ -42,11 +42,3 @@ def app_for_vhost(vhost):
         vhost_app.conf.task_queues = app.conf.task_queues
         _vhost_apps[vhost] = vhost_app
     return _vhost_apps[vhost]
-
-
-app.conf.beat_schedule = {
-    "refresh-compute-worker-health": {
-        "task": "apps.competitions.tasks.refresh_compute_worker_health",
-        "schedule": 3.0,
-    },
-}

--- a/src/routing.py
+++ b/src/routing.py
@@ -1,7 +1,10 @@
 from django.urls import re_path
 from apps.competitions.consumers import SubmissionIOConsumer, SubmissionOutputConsumer
+from utils.consumers import ComputeWorkersConsumer
+
 
 websocket_urlpatterns = [
     re_path(r'submission_input/(?P<user_pk>\d+)/(?P<submission_id>\d+)/(?P<secret>[^/]+)/$', SubmissionIOConsumer.as_asgi()),
     re_path(r'submission_output/$', SubmissionOutputConsumer.as_asgi()),
+    re_path(r"ws/workers/$", ComputeWorkersConsumer.as_asgi()),
 ]

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -276,6 +276,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'profiles.tasks.clean_non_activated_users',
         'schedule': timedelta(days=1),  # Run every 24 hours
     },
+    "refresh_compute_worker_health": {
+        "task": "competitions.tasks.refresh_compute_worker_health",
+        "schedule": 30,
+    },
 }
 CELERY_TIMEZONE = 'UTC'
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -278,7 +278,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "refresh_compute_worker_health": {
         "task": "competitions.tasks.refresh_compute_worker_health",
-        "schedule": 30,
+        "schedule": 60,
     },
 }
 CELERY_TIMEZONE = 'UTC'

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -38,9 +38,9 @@
 
                         <worker-monitor-toggle
                             if="{competition.admin}"
-                            can_view_workers_panel="true">
+                            can_view_workers_panel="true"
+                            competition_id="{ competition.id }">
                         </worker-monitor-toggle>
-
 
                     </div>
                     <div class="row">

--- a/src/static/riot/competitions/detail/_header.tag
+++ b/src/static/riot/competitions/detail/_header.tag
@@ -35,6 +35,13 @@
                         <button class="ui small button" onclick="{show_modal.bind(this, '.migration.modal')}">
                             Migrate
                         </button>
+
+                        <worker-monitor-toggle
+                            if="{competition.admin}"
+                            can_view_workers_panel="true">
+                        </worker-monitor-toggle>
+
+
                     </div>
                     <div class="row">
                         <div class="column">

--- a/src/static/riot/competitions/detail/detail.tag
+++ b/src/static/riot/competitions/detail/detail.tag
@@ -475,10 +475,10 @@
         }
 
         .workers-toggle-btn
+            z-index 0
             position fixed
             top 74px
             right 24px
-            z-index 30
             background #576671 !important
             color white !important
             

--- a/src/static/riot/competitions/detail/detail.tag
+++ b/src/static/riot/competitions/detail/detail.tag
@@ -71,7 +71,7 @@
                                     <span class="ui tiny label worker-status { getStatusClass(worker) }">
                                         <i class="{ getStatusIcon(worker) } icon"></i>
                                         { getStatusText(worker) }
-                            return        </span>
+                                    </span>
                                 </td>
                                 <td><span class="ui circular label">{ worker.running_jobs || 0 }</span></td>
                                 <td>{ formatLastSeen(worker.timestamp) }</td>
@@ -479,8 +479,8 @@
         .workers-toggle-btn
             z-index 10
             position relative
-            top 150%
-            right 1%
+            top 10%
+            right 100vh
             background #576671 !important
             color white !important
             

--- a/src/static/riot/competitions/detail/detail.tag
+++ b/src/static/riot/competitions/detail/detail.tag
@@ -6,25 +6,13 @@
             <comp-tabs class="comp-detail-paragraph-text" competition="{ competition }"></comp-tabs>
         </div>
 
-        <button
-            if="{ canViewWorkersPanel }"
-            class="ui button primary workers-toggle-btn"
-            onclick="{ toggleWorkersPanel }">
-            <i class="server icon"></i>
-            { showWorkersPanel ? 'Hide workers' : 'Show workers' }
-        </button>
-
-        <aside if="{ canViewWorkersPanel && showWorkersPanel }"
-               class="workers-panel"
-               style="left: { panelLeft }px; top: { panelTop }px;">
+        <aside class="workers-panel" style="left: { panelLeft }px; top: { panelTop }px;">
             <div class="workers-card">
                 <div class="workers-header workers-drag-handle" onmousedown="{ startPanelDrag }">
                     <div class="workers-title">
                         <i class="server icon"></i>
                         <div class="workers-title-text">
                             Compute Workers
-                            </br>
-                            <small><small><small>displayed only for competition organizers</small></small></small>
                             <div class="workers-subtitle">
                                 <span class="workers-connection { wsState }">{ connectionLabel() }</span>
                                 <span class="workers-separator">•</span>
@@ -32,7 +20,10 @@
                             </div>
                         </div>
                     </div>
-                    <div class="workers-drag-hint">Drag to move</div>
+
+                    <div class="workers-drag-hint">
+                        Drag to move
+                    </div>
                 </div>
 
                 <div class="workers-stats">
@@ -64,18 +55,29 @@
                                 <th class="col-lastseen">Last seen</th>
                             </tr>
                         </thead>
+
                         <tbody>
-                            <tr each="{ worker in sortedWorkers() }">
-                                <td><strong>{ worker.hostname }</strong></td>
-                                <td>
+                            <tr each="{worker in sortedWorkers()}">
+                                <td class="worker-hostname">
+                                    <strong>{ worker.hostname }</strong>
+                                </td>
+
+                                <td class="worker-status-cell">
                                     <span class="ui tiny label worker-status { getStatusClass(worker) }">
                                         <i class="{ getStatusIcon(worker) } icon"></i>
                                         { getStatusText(worker) }
-                                    </span>
+                            return        </span>
                                 </td>
-                                <td><span class="ui circular label">{ worker.running_jobs || 0 }</span></td>
-                                <td>{ formatLastSeen(worker.timestamp) }</td>
+
+                                <td class="worker-jobs">
+                                    <span class="ui circular label">{ worker.running_jobs || 0 }</span>
+                                </td>
+
+                                <td class="worker-lastseen">
+                                    { formatLastSeen(worker.timestamp) }
+                                </td>
                             </tr>
+
                             <tr if="{ sortedWorkers().length === 0 }">
                                 <td colspan="4" class="center aligned">
                                     <div class="workers-empty">
@@ -98,95 +100,76 @@
     <script>
         var self = this;
 
-        self.competition = {};
-        self.workers = [];
-        self.ws = null;
-        self.wsReconnectTimer = null;
-        self.wsState = 'disconnected';
-        self.lastSyncAt = null;
+        self.competition = {}
+        self.workers = []
+        self.ws = null
+        self.wsReconnectTimer = null
+        self.wsState = 'disconnected'
+        self.lastSyncAt = null
 
-        self.canViewWorkersPanel = (self.opts.can_view_workers_panel === 'true');
-        self.showWorkersPanel = false
-
-        self.canViewWorkersPanel = String(self.opts.can_view_workers_panel || 'false') === 'true'
-        self.panelLeft = 24;
-        self.panelTop = 24;
-        self.panelWidth = 375;
-        self.draggingPanel = false;
-        self.dragOffsetX = 0;
-        self.dragOffsetY = 0;
-        self.panelStorageKey = 'codabench_workers_panel_position';
-        self.resizeListenerAttached = false;
-
-        self.toggleWorkersPanel = function () {
-            self.showWorkersPanel = !self.showWorkersPanel
-
-            if (self.showWorkersPanel) {
-                self.loadPanelPosition()
-                self.connect_workers_socket()
-            } else {
-                self.close_workers_socket()
-            }
-
-            self.update()
-        }
+        self.panelLeft = 24
+        self.panelTop = 24
+        self.panelWidth = 500
+        self.panelHeight = 120
+        self.draggingPanel = false
+        self.dragOffsetX = 0
+        self.dragOffsetY = 0
+        self.panelStorageKey = 'codabench_workers_panel_position'
 
         self.one('mount', function () {
-            $('.menu .item', self.root).tab();
-            self.update_competition_data();
-            if (self.canViewWorkersPanel) {
-                self.loadPanelPosition();
-                self.attachResizeListener();
-            }
-        });
+            $('.menu .item', self.root).tab()
+            self.loadPanelPosition()
+            self.update_competition_data()
+            self.connect_workers_socket()
+            window.addEventListener('resize', self.onWindowResize)
+        })
 
-        self.close_workers_socket = function () {
+        self.one('unmount', function () {
+            window.removeEventListener('resize', self.onWindowResize)
+            window.removeEventListener('mousemove', self.onPanelDragMove)
+            window.removeEventListener('mouseup', self.stopPanelDrag)
+
             if (self.wsReconnectTimer) {
                 clearTimeout(self.wsReconnectTimer)
                 self.wsReconnectTimer = null
             }
 
             if (self.ws) {
-                self.ws.onclose = null
-
                 try { self.ws.close() } catch (e) {}
                 self.ws = null
             }
 
-            self.wsState = 'disconnected'
-        }
-
-        self.one('unmount', function () {
-            self.detachResizeListener();
-            if (self.wsReconnectTimer) {
-                clearTimeout(self.wsReconnectTimer);
-                self.wsReconnectTimer = null;
-            }
-            if (self.ws) {
-                try { self.ws.close(); } catch(e) {}
-                self.ws = null;
-            }
-            document.body.classList.remove('workers-panel-dragging');
-        });
+            document.body.classList.remove('workers-panel-dragging')
+        })
 
         self.update_competition_data = function () {
             CODALAB.api.get_competition(self.opts.competition_pk, self.opts.secret_key)
                 .done(function (data) {
-                    self.competition = data;
-                    CODALAB.events.trigger('competition_loaded', self.competition);
+                    self.competition = data
 
-                    let currentPhase = _.find(self.competition.phases, { status: 'Current' });
-                    let selectedPhaseId = currentPhase ? currentPhase.id : null;
-                    if (selectedPhaseId === null) {
-                        let finalPhase = _.find(self.competition.phases, { is_final_phase: true });
-                        selectedPhaseId = finalPhase ? finalPhase.id : null;
+                    CODALAB.events.trigger('competition_loaded', self.competition)
+
+                    let selected_phase_index = _.get(
+                        _.find(self.competition.phases, { 'status': 'Current' }),
+                        'id'
+                    )
+
+                    if (selected_phase_index == null) {
+                        selected_phase_index = _.get(
+                            _.find(self.competition.phases, { is_final_phase: true }),
+                            'id'
+                        )
                     }
+
                     CODALAB.events.trigger(
                         'phase.selected',
-                        (_.find(self.competition.phases, { id: selectedPhaseId }))
-                    );
+                        (_.find(self.competition.phases, { id: selected_phase_index }))
+                    )
 
-                    self.update();
+                    self.update()
+                })
+                .fail(function () {
+                    toastr.error('Could not find benchmark')
                 })
                 .fail(function () {
                     toastr.error("Could not find competition");
@@ -456,193 +439,545 @@
             max-height: calc(100vh - 48px);
         }
 
-        .workers-card {
-            background: #fff;
-            border: 1px solid rgba(0,0,0,0.1);
-            border-radius: 16px;
-            box-shadow: 0 8px 24px rgba(0,0,0,0.08);
-            padding: 12px;
-        }
-        .workers-header { margin-bottom: 12px; }
-        .workers-title { display: flex; align-items: flex-start; gap: 10px; }
-        .workers-title .icon { margin-top: 2px; }
-        .workers-title-text { font-size: 18px; font-weight: 700; color: #1f2937; line-height: 1.2; }
-        .workers-subtitle {
-            margin-top: 4px;
-            font-size: 12px;
-            color: #6b7280;
-            display: flex;
-            align-items: center;
-            gap: 6px;
+        self.loadPanelPosition = function () {
+            try {
+                var raw = localStorage.getItem(self.panelStorageKey)
+                if (!raw) return
+
+                var pos = JSON.parse(raw)
+                if (typeof pos.left === 'number') self.panelLeft = pos.left
+                if (typeof pos.top === 'number') self.panelTop = pos.top
+
+                self.clampPanelPosition()
+            } catch (e) {
+                console.warn('Could not load panel position', e)
+            }
         }
 
-        .workers-toggle-btn
-            z-index 10
+        self.savePanelPosition = function () {
+            try {
+                localStorage.setItem(self.panelStorageKey, JSON.stringify({
+                    left: self.panelLeft,
+                    top: self.panelTop
+                }))
+            } catch (e) {
+                console.warn('Could not save panel position', e)
+            }
+        }
+
+        self.clampPanelPosition = function () {
+            var minLeft = 8
+            var minTop = 8
+            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
+            var maxTop = Math.max(minTop, window.innerHeight - 80)
+
+            self.panelLeft = Math.min(Math.max(minLeft, self.panelLeft), maxLeft)
+            self.panelTop = Math.min(Math.max(minTop, self.panelTop), maxTop)
+        }
+
+        self.onWindowResize = function () {
+            self.clampPanelPosition()
+            self.update()
+        }
+
+        self.startPanelDrag = function (e) {
+            if (e.button !== 0) return
+
+            var panel = self.root.querySelector('.workers-panel')
+            if (!panel) return
+
+            var rect = panel.getBoundingClientRect()
+
+            self.draggingPanel = true
+            self.dragOffsetX = e.clientX - rect.left
+            self.dragOffsetY = e.clientY - rect.top
+
+            document.body.classList.add('workers-panel-dragging')
+            window.addEventListener('mousemove', self.onPanelDragMove)
+            window.addEventListener('mouseup', self.stopPanelDrag)
+
+            e.preventDefault()
+            e.stopPropagation()
+        }
+
+        self.onPanelDragMove = function (e) {
+            if (!self.draggingPanel) return
+
+            var minLeft = 8
+            var minTop = 8
+            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
+            var maxTop = Math.max(minTop, window.innerHeight - 80)
+
+            var newLeft = e.clientX - self.dragOffsetX
+            var newTop = e.clientY - self.dragOffsetY
+
+            self.panelLeft = Math.min(Math.max(minLeft, newLeft), maxLeft)
+            self.panelTop = Math.min(Math.max(minTop, newTop), maxTop)
+
+            self.update()
+        }
+
+        self.stopPanelDrag = function () {
+            if (!self.draggingPanel) return
+
+            self.draggingPanel = false
+            document.body.classList.remove('workers-panel-dragging')
+
+            window.removeEventListener('mousemove', self.onPanelDragMove)
+            window.removeEventListener('mouseup', self.stopPanelDrag)
+
+            self.savePanelPosition()
+            self.update()
+        }
+
+        self.connect_workers_socket = function () {
+            if (self.ws) {
+                try { self.ws.close() } catch (e) {}
+                self.ws = null
+            }
+
+            var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
+            var url = scheme + '://' + window.location.host + '/ws/workers/'
+
+            self.wsState = 'connecting'
+            self.update()
+
+            self.ws = new WebSocket(url)
+
+            self.ws.onopen = function () {
+                self.wsState = 'connected'
+                self.update()
+            }
+
+            self.ws.onmessage = function (event) {
+                var message = null
+
+                try {
+                    message = JSON.parse(event.data)
+                } catch (e) {
+                    console.error('Invalid websocket payload:', event.data)
+                    return
+                }
+
+                if (message.type === 'workers.snapshot') {
+                    self.workers = self.normalizeWorkers(message.workers || [])
+                    self.lastSyncAt = Date.now()
+                    self.update()
+                    return
+                }
+
+                if (message.type === 'worker.health' && message.worker) {
+                    self.upsertWorker(message.worker)
+                    self.lastSyncAt = Date.now()
+                    self.update()
+                }
+            }
+
+            self.ws.onerror = function () {
+                self.wsState = 'error'
+                self.update()
+            }
+
+            self.ws.onclose = function () {
+                self.wsState = 'disconnected'
+                self.update()
+
+                if (self.wsReconnectTimer) {
+                    clearTimeout(self.wsReconnectTimer)
+                }
+
+                self.wsReconnectTimer = setTimeout(function () {
+                    self.connect_workers_socket()
+                }, 2000)
+            }
+        }
+
+        self.normalizeWorker = function (worker) {
+            worker = worker || {}
+
+            return {
+                hostname: worker.hostname || 'unknown',
+                status: worker.status || 'unavailable',
+                running_jobs: typeof worker.running_jobs === 'number' ? worker.running_jobs : 0,
+                timestamp: worker.timestamp || null
+            }
+        }
+
+        self.normalizeWorkers = function (workers) {
+            return (workers || [])
+                .filter(function (worker) {
+                    return worker && worker.hostname
+                })
+                .map(function (worker) {
+                    return self.normalizeWorker(worker)
+                })
+        }
+
+        self.upsertWorker = function (worker) {
+            worker = self.normalizeWorker(worker)
+
+            if (!worker.hostname || worker.hostname === 'unknown') return
+
+            var idx = _.findIndex(self.workers, { hostname: worker.hostname })
+
+            if (idx === -1) {
+                self.workers.push(worker)
+            } else {
+                self.workers[idx] = worker
+            }
+
+            self.workers = self.workers.slice()
+        }
+
+        self.sortedWorkers = function () {
+            var order = {
+                available: 0,
+                busy: 1,
+                unavailable: 2
+            }
+
+            return (self.workers || []).slice().sort(function (a, b) {
+                var sa = self.displayStatus(a)
+                var sb = self.displayStatus(b)
+
+                var oa = order.hasOwnProperty(sa) ? order[sa] : 99
+                var ob = order.hasOwnProperty(sb) ? order[sb] : 99
+
+                if (oa !== ob) return oa - ob
+                if ((b.running_jobs || 0) !== (a.running_jobs || 0)) {
+                    return (b.running_jobs || 0) - (a.running_jobs || 0)
+                }
+
+                return (a.hostname || '').localeCompare(b.hostname || '')
+            })
+        }
+
+        self.displayStatus = function (worker) {
+            return worker && worker.status ? worker.status : 'unavailable'
+        }
+
+        self.getStatusClass = function (worker) {
+            var status = self.displayStatus(worker)
+            if (status === 'available') return 'green'
+            if (status === 'busy') return 'yellow'
+            return 'red'
+        }
+
+        self.getStatusIcon = function (worker) {
+            var status = self.displayStatus(worker)
+            if (status === 'available') return 'check circle'
+            if (status === 'busy') return 'clock'
+            return 'times circle'
+        }
+
+        self.getStatusText = function (worker) {
+            var status = self.displayStatus(worker)
+            if (status === 'available') return 'Available'
+            if (status === 'busy') return 'Busy'
+            return 'Unavailable'
+        }
+
+        self.formatLastSeen = function (timestamp) {
+            if (!timestamp) return '—'
+
+            var age = Math.max(0, Math.round((Date.now() / 1000) - timestamp))
+            if (age < 5) return 'just now'
+            if (age < 60) return age + 's ago'
+
+            var minutes = Math.floor(age / 60)
+            if (minutes < 60) return minutes + 'm ago'
+
+            var hours = Math.floor(minutes / 60)
+            return hours + 'h ago'
+        }
+
+        self.lastSyncLabel = function () {
+            if (!self.lastSyncAt) return 'never'
+
+            var age = Math.max(0, Math.round((Date.now() - self.lastSyncAt) / 1000))
+            if (age < 5) return 'just now'
+            if (age < 60) return age + 's ago'
+
+            var minutes = Math.floor(age / 60)
+            return minutes + 'm ago'
+        }
+
+        self.totalCount = function () {
+            return (self.workers || []).length
+        }
+
+        self.availableCount = function () {
+            return (self.workers || []).filter(function (worker) {
+                return self.displayStatus(worker) === 'available'
+            }).length
+        }
+
+        self.busyCount = function () {
+            return (self.workers || []).filter(function (worker) {
+                return self.displayStatus(worker) === 'busy'
+            }).length
+        }
+
+        self.unavailableCount = function () {
+            return (self.workers || []).filter(function (worker) {
+                return self.displayStatus(worker) === 'unavailable'
+            }).length
+        }
+
+        self.connectionLabel = function () {
+            if (self.wsState === 'connected') return 'Connected'
+            if (self.wsState === 'connecting') return 'Connecting'
+            if (self.wsState === 'error') return 'Error'
+            return 'Disconnected'
+        }
+
+        CODALAB.events.on('new_submission_created', function () {
+            self.update_competition_data()
+        })
+    </script>
+
+    <style type="text/stylus">
+        .comp-detail-paragraph-text
+            font-size 16px !important
+            line-height 20px !important
+
+        :scope
+            display block
+            width 100%
+            height 100%
+
+        .layout
+            display block
             position relative
-            top 10%
-            right 100vh
-            background #576671 !important
+
+        .comp-content
+            min-width 0
+            padding-right 0
+
+        .workers-panel
+            position fixed
+            top 24px
+            right 24px
+            width 375px
+            z-index 25
+            max-height calc(100vh - 48px)
+            overflow auto
+
+        .workers-card
+            background #fff
+            border 1px solid rgba(34, 36, 38, .12)
+            border-radius 16px
+            box-shadow 0 8px 24px rgba(16, 24, 40, .08)
+            padding 12px
+
+        .workers-drag-handle
+            cursor move
+            user-select none
+            touch-action none
+
+        .workers-header
+            margin-bottom 12px
+
+        .workers-title
+            display flex
+            align-items flex-start
+            gap 10px
+
+        .workers-title .icon
+            margin-top 2px
+
+        .workers-title-text
+            font-size 18px
+            font-weight 700
+            color #1f2937
+            line-height 1.2
+
+        .workers-subtitle
+            margin-top 4px
+            font-size 12px
+            color #6b7280
+            display flex
+            align-items center
+            flex-wrap wrap
+            gap 6px
+
+        .workers-connection
+            display inline-flex
+            align-items center
+            padding 3px 8px
+            border-radius 999px
+            font-weight 700
+            font-size 11px
+            text-transform uppercase
+            letter-spacing .04em
+            background #f3f4f6
+            color #6b7280
+
+        .workers-connection.connected
+            background rgba(33, 186, 69, .12)
+            color #21ba45
+
+        .workers-connection.connecting
+            background rgba(251, 189, 8, .14)
+            color #b58105
+
+        .workers-connection.error
+            background rgba(219, 40, 40, .12)
+            color #db2828
+
+        .workers-connection.disconnected
+            background rgba(219, 40, 40, .12)
+            color #db2828
+
+        .workers-separator
+            opacity .6
+
+        .workers-drag-hint
+            margin-top 4px
+            font-size 11px
+            color #9ca3af
+            white-space nowrap
+
+        .workers-stats
+            display grid
+            grid-template-columns repeat(4, minmax(0, 1fr))
+            gap 8px
+            margin 10px 0 15px 0 !important
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
+        .stat-card
+            background #f9fafb
+            border 1px solid rgba(17, 24, 39, .06)
+            border-radius 12px
+            padding 10px 8px
+            text-align center
+            min-width 0
+            display flex
+            flex-direction column
+            align-items center
+            justify-content center
+
+        .stat-value
+            font-size 18px
+            font-weight 800
+            line-height 1
+            color #111827
+            margin-bottom 4px
+            min-width 1ch
+            text-align center
+
+        .stat-green
+            color #21ba45
+
+        .stat-yellow
+            color #b58105
+
+        .stat-red
+            color #db2828
+
+        .stat-label
+            font-size 11px
+            font-weight 700
+            text-transform uppercase
+            letter-spacing .04em
+            color #6b7280
+            line-height 1.1
+            text-align center
+            white-space nowrap
+
+        .workers-table-wrap
+            max-height calc(100vh - 240px)
+            overflow auto
+            border-radius 12px
+
+        .workers-table
+            margin 0 !important
+            width :autofill
+            table-layout auto
+            font-size 13px
+
+        .workers-table thead th
+            position sticky
+            top 0
+            z-index 2
+            background #f8fafc !important
+            color #374151 !important
+            font-weight 700 !important
+            font-size 12px
+            text-transform uppercase
+            letter-spacing .03em
+
+        .workers-table td,
+        .workers-table th
+            vertical-align middle !important
+
+        .worker-hostname
+            font-size 13px
+            font-weight 700
+            white-space nowrap
+            overflow hidden
+            text-overflow ellipsis
+
+        .worker-jobs
+            text-align center
+
+        .worker-lastseen
+            color #6b7280
+            font-size 12px
+            white-space nowrap
+            overflow hidden
+            text-overflow ellipsis
+
+        .worker-status
+            border-radius 999px !important
+            font-weight 700 !important
+            display inline-flex !important
+            align-items center
+            gap 6px
+            white-space nowrap
+
+        .workers-empty
+            padding 24px 12px
+            text-align center
+            color #6b7280
+
+        .workers-empty .header
+            font-weight 700
+            color #374151
+            margin-bottom 4px
+
+        .workers-footer
+            margin-top 12px
+            font-size 12px
+            color #6b7280
+
+        .ui.label.green
+            background-color #21ba45 !important
             color white !important
-            
-        .workers-connection {
-            display: inline-flex;
-            align-items: center;
-            padding: 3px 8px;
-            border-radius: 999px;
-            font-weight: 700;
-            font-size: 11px;
-            text-transform: uppercase;
-            background: #f3f4f6;
-            color: #6b7280;
-        }
-        .workers-connection.connected {
-            background: rgba(33,186,69,.12);
-            color: #21ba45;
-        }
-        .workers-connection.connecting {
-            background: rgba(251,189,8,.14);
-            color: #b58105;
-        }
-        .workers-connection.error {
-            background: rgba(219,40,40,.12);
-            color: #db2828;
-        }
-        .workers-connection.disconnected {
-            background: rgba(219,40,40,.12);
-            color: #db2828;
-        }
-        .workers-separator { opacity: .6; }
-        .workers-drag-hint { margin-top: 4px; font-size: 11px; color: #9ca3af; white-space: nowrap; }
 
-        .workers-stats {
-            display: grid;
-            grid-template-columns: repeat(4, 1fr);
-            gap: 8px;
-            margin: 10px 0 15px 0 !important;
-        }
-        .stat-card {
-            background: #f9fafb;
-            border: 1px solid rgba(0,0,0,0.06);
-            border-radius: 12px;
-            padding: 10px 8px;
-            text-align: center;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-        }
-        .stat-value {
-            font-size: 18px;
-            font-weight: 800;
-            color: #111827;
-            margin-bottom: 4px;
-            min-width: 1ch;
-        }
-        .stat-green { color: #21ba45; }
-        .stat-yellow { color: #b58105; }
-        .stat-red { color: #db2828; }
-        .stat-label {
-            font-size: 11px;
-            font-weight: 700;
-            text-transform: uppercase;
-            color: #6b7280;
-            letter-spacing: .04em;
-        }
+        .ui.label.yellow
+            background-color #f2c037 !important
+            color black !important
 
-        .workers-table-wrap {
-            max-height: calc(100vh - 240px);
-            overflow: auto;
-            border-radius: 12px;
-        }
-        .workers-table {
-            margin: 0 !important;
-            width: 100%;
-            table-layout: auto;
-            font-size: 13px;
-        }
-        .workers-table thead th {
-            position: sticky;
-            top: 0;
-            background: #f8fafc !important;
-            color: #374151 !important;
-            font-weight: 700 !important;
-            font-size: 12px;
-            text-transform: uppercase;
-        }
-        .workers-table td, .workers-table th {
-            vertical-align: middle !important;
-        }
-        .worker-hostname {
-            font-size: 13px;
-            font-weight: 700;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-        .worker-jobs {
-            text-align: center;
-        }
-        .worker-lastseen {
-            color: #6b7280;
-            font-size: 12px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-        .worker-status {
-            border-radius: 999px !important;
-            font-weight: 700 !important;
-            display: inline-flex !important;
-            align-items: center;
-            gap: 6px;
-            white-space: nowrap;
-        }
-        .workers-empty {
-            padding: 24px 12px;
-            text-align: center;
-            color: #6b7280;
-        }
-        .workers-empty .header {
-            font-weight: 700;
-            color: #374151;
-            margin-bottom: 4px;
-        }
-        .workers-footer {
-            margin-top: 12px;
-            font-size: 12px;
-            color: #6b7280;
-        }
-        .ui.label.green {
-            background-color: #21ba45 !important;
-            color: white !important;
-        }
-        .ui.label.yellow {
-            background-color: #f2c037 !important;
-            color: black !important;
-        }
-        .ui.label.red {
-            background-color: #db2828 !important;
-            color: white !important;
-        }
-        body.workers-panel-dragging {
-            user-select: none;
-        }
+        .ui.label.red
+            background-color #db2828 !important
+            color white !important
 
-        @media (max-width: 1400px) {
-            .workers-panel {
-                position: static;
-                width: 100%;
-                max-height: none;
-                margin-top: 16px;
-            }
-            .workers-table-wrap {
-                max-height: none;
-            }
-        }
-        @media (max-width: 768px) {
-            .workers-stats {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
+        body.workers-panel-dragging
+            user-select none
+
+        @media (max-width: 1400px)
+            .workers-panel
+                position static
+                width 100%
+                max-height none
+                margin-top 16px
+
+            .workers-table-wrap
+                max-height none
+
+        @media (max-width: 768px)
+            .workers-stats
+                grid-template-columns repeat(2, minmax(0, 1fr))
     </style>
 </competition-detail>

--- a/src/static/riot/competitions/detail/detail.tag
+++ b/src/static/riot/competitions/detail/detail.tag
@@ -23,6 +23,8 @@
                         <i class="server icon"></i>
                         <div class="workers-title-text">
                             Compute Workers
+                            </br>
+                            <small><small><small>displayed only for competition organizers</small></small></small>
                             <div class="workers-subtitle">
                                 <span class="workers-connection { wsState }">{ connectionLabel() }</span>
                                 <span class="workers-separator">•</span>
@@ -475,10 +477,10 @@
         }
 
         .workers-toggle-btn
-            z-index 0
-            position fixed
-            top 74px
-            right 24px
+            z-index 10
+            position relative
+            top 150%
+            right 1%
             background #576671 !important
             color white !important
             

--- a/src/static/riot/competitions/detail/detail.tag
+++ b/src/static/riot/competitions/detail/detail.tag
@@ -6,7 +6,17 @@
             <comp-tabs class="comp-detail-paragraph-text" competition="{ competition }"></comp-tabs>
         </div>
 
-        <aside class="workers-panel" style="left: { panelLeft }px; top: { panelTop }px;">
+        <button
+            if="{ canViewWorkersPanel }"
+            class="ui button primary workers-toggle-btn"
+            onclick="{ toggleWorkersPanel }">
+            <i class="server icon"></i>
+            { showWorkersPanel ? 'Hide workers' : 'Show workers' }
+        </button>
+
+        <aside if="{ canViewWorkersPanel && showWorkersPanel }"
+               class="workers-panel"
+               style="left: { panelLeft }px; top: { panelTop }px;">
             <div class="workers-card">
                 <div class="workers-header workers-drag-handle" onmousedown="{ startPanelDrag }">
                     <div class="workers-title">
@@ -20,10 +30,7 @@
                             </div>
                         </div>
                     </div>
-
-                    <div class="workers-drag-hint">
-                        Drag to move
-                    </div>
+                    <div class="workers-drag-hint">Drag to move</div>
                 </div>
 
                 <div class="workers-stats">
@@ -55,29 +62,18 @@
                                 <th class="col-lastseen">Last seen</th>
                             </tr>
                         </thead>
-
                         <tbody>
-                            <tr each="{worker in sortedWorkers()}">
-                                <td class="worker-hostname">
-                                    <strong>{ worker.hostname }</strong>
-                                </td>
-
-                                <td class="worker-status-cell">
+                            <tr each="{ worker in sortedWorkers() }">
+                                <td><strong>{ worker.hostname }</strong></td>
+                                <td>
                                     <span class="ui tiny label worker-status { getStatusClass(worker) }">
                                         <i class="{ getStatusIcon(worker) } icon"></i>
                                         { getStatusText(worker) }
                             return        </span>
                                 </td>
-
-                                <td class="worker-jobs">
-                                    <span class="ui circular label">{ worker.running_jobs || 0 }</span>
-                                </td>
-
-                                <td class="worker-lastseen">
-                                    { formatLastSeen(worker.timestamp) }
-                                </td>
+                                <td><span class="ui circular label">{ worker.running_jobs || 0 }</span></td>
+                                <td>{ formatLastSeen(worker.timestamp) }</td>
                             </tr>
-
                             <tr if="{ sortedWorkers().length === 0 }">
                                 <td colspan="4" class="center aligned">
                                     <div class="workers-empty">
@@ -100,76 +96,95 @@
     <script>
         var self = this;
 
-        self.competition = {}
-        self.workers = []
-        self.ws = null
-        self.wsReconnectTimer = null
-        self.wsState = 'disconnected'
-        self.lastSyncAt = null
+        self.competition = {};
+        self.workers = [];
+        self.ws = null;
+        self.wsReconnectTimer = null;
+        self.wsState = 'disconnected';
+        self.lastSyncAt = null;
 
-        self.panelLeft = 24
-        self.panelTop = 24
-        self.panelWidth = 500
-        self.panelHeight = 120
-        self.draggingPanel = false
-        self.dragOffsetX = 0
-        self.dragOffsetY = 0
-        self.panelStorageKey = 'codabench_workers_panel_position'
+        self.canViewWorkersPanel = (self.opts.can_view_workers_panel === 'true');
+        self.showWorkersPanel = false
+
+        self.canViewWorkersPanel = String(self.opts.can_view_workers_panel || 'false') === 'true'
+        self.panelLeft = 24;
+        self.panelTop = 24;
+        self.panelWidth = 375;
+        self.draggingPanel = false;
+        self.dragOffsetX = 0;
+        self.dragOffsetY = 0;
+        self.panelStorageKey = 'codabench_workers_panel_position';
+        self.resizeListenerAttached = false;
+
+        self.toggleWorkersPanel = function () {
+            self.showWorkersPanel = !self.showWorkersPanel
+
+            if (self.showWorkersPanel) {
+                self.loadPanelPosition()
+                self.connect_workers_socket()
+            } else {
+                self.close_workers_socket()
+            }
+
+            self.update()
+        }
 
         self.one('mount', function () {
-            $('.menu .item', self.root).tab()
-            self.loadPanelPosition()
-            self.update_competition_data()
-            self.connect_workers_socket()
-            window.addEventListener('resize', self.onWindowResize)
-        })
+            $('.menu .item', self.root).tab();
+            self.update_competition_data();
+            if (self.canViewWorkersPanel) {
+                self.loadPanelPosition();
+                self.attachResizeListener();
+            }
+        });
 
-        self.one('unmount', function () {
-            window.removeEventListener('resize', self.onWindowResize)
-            window.removeEventListener('mousemove', self.onPanelDragMove)
-            window.removeEventListener('mouseup', self.stopPanelDrag)
-
+        self.close_workers_socket = function () {
             if (self.wsReconnectTimer) {
                 clearTimeout(self.wsReconnectTimer)
                 self.wsReconnectTimer = null
             }
 
             if (self.ws) {
+                self.ws.onclose = null
+
                 try { self.ws.close() } catch (e) {}
                 self.ws = null
             }
 
-            document.body.classList.remove('workers-panel-dragging')
-        })
+            self.wsState = 'disconnected'
+        }
+
+        self.one('unmount', function () {
+            self.detachResizeListener();
+            if (self.wsReconnectTimer) {
+                clearTimeout(self.wsReconnectTimer);
+                self.wsReconnectTimer = null;
+            }
+            if (self.ws) {
+                try { self.ws.close(); } catch(e) {}
+                self.ws = null;
+            }
+            document.body.classList.remove('workers-panel-dragging');
+        });
 
         self.update_competition_data = function () {
             CODALAB.api.get_competition(self.opts.competition_pk, self.opts.secret_key)
                 .done(function (data) {
-                    self.competition = data
+                    self.competition = data;
+                    CODALAB.events.trigger('competition_loaded', self.competition);
 
-                    CODALAB.events.trigger('competition_loaded', self.competition)
-
-                    let selected_phase_index = _.get(
-                        _.find(self.competition.phases, { 'status': 'Current' }),
-                        'id'
-                    )
-
-                    if (selected_phase_index == null) {
-                        selected_phase_index = _.get(
-                            _.find(self.competition.phases, { is_final_phase: true }),
-                            'id'
-                        )
+                    let currentPhase = _.find(self.competition.phases, { status: 'Current' });
+                    let selectedPhaseId = currentPhase ? currentPhase.id : null;
+                    if (selectedPhaseId === null) {
+                        let finalPhase = _.find(self.competition.phases, { is_final_phase: true });
+                        selectedPhaseId = finalPhase ? finalPhase.id : null;
                     }
-
                     CODALAB.events.trigger(
                         'phase.selected',
-                        (_.find(self.competition.phases, { id: selected_phase_index }))
-                    )
+                        (_.find(self.competition.phases, { id: selectedPhaseId }))
+                    );
 
-                    self.update()
-                })
-                .fail(function () {
-                    toastr.error('Could not find benchmark')
+                    self.update();
                 })
                 .fail(function () {
                     toastr.error("Could not find competition");
@@ -439,545 +454,193 @@
             max-height: calc(100vh - 48px);
         }
 
-        self.loadPanelPosition = function () {
-            try {
-                var raw = localStorage.getItem(self.panelStorageKey)
-                if (!raw) return
-
-                var pos = JSON.parse(raw)
-                if (typeof pos.left === 'number') self.panelLeft = pos.left
-                if (typeof pos.top === 'number') self.panelTop = pos.top
-
-                self.clampPanelPosition()
-            } catch (e) {
-                console.warn('Could not load panel position', e)
-            }
+        .workers-card {
+            background: #fff;
+            border: 1px solid rgba(0,0,0,0.1);
+            border-radius: 16px;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+            padding: 12px;
+        }
+        .workers-header { margin-bottom: 12px; }
+        .workers-title { display: flex; align-items: flex-start; gap: 10px; }
+        .workers-title .icon { margin-top: 2px; }
+        .workers-title-text { font-size: 18px; font-weight: 700; color: #1f2937; line-height: 1.2; }
+        .workers-subtitle {
+            margin-top: 4px;
+            font-size: 12px;
+            color: #6b7280;
+            display: flex;
+            align-items: center;
+            gap: 6px;
         }
 
-        self.savePanelPosition = function () {
-            try {
-                localStorage.setItem(self.panelStorageKey, JSON.stringify({
-                    left: self.panelLeft,
-                    top: self.panelTop
-                }))
-            } catch (e) {
-                console.warn('Could not save panel position', e)
-            }
-        }
-
-        self.clampPanelPosition = function () {
-            var minLeft = 8
-            var minTop = 8
-            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
-            var maxTop = Math.max(minTop, window.innerHeight - 80)
-
-            self.panelLeft = Math.min(Math.max(minLeft, self.panelLeft), maxLeft)
-            self.panelTop = Math.min(Math.max(minTop, self.panelTop), maxTop)
-        }
-
-        self.onWindowResize = function () {
-            self.clampPanelPosition()
-            self.update()
-        }
-
-        self.startPanelDrag = function (e) {
-            if (e.button !== 0) return
-
-            var panel = self.root.querySelector('.workers-panel')
-            if (!panel) return
-
-            var rect = panel.getBoundingClientRect()
-
-            self.draggingPanel = true
-            self.dragOffsetX = e.clientX - rect.left
-            self.dragOffsetY = e.clientY - rect.top
-
-            document.body.classList.add('workers-panel-dragging')
-            window.addEventListener('mousemove', self.onPanelDragMove)
-            window.addEventListener('mouseup', self.stopPanelDrag)
-
-            e.preventDefault()
-            e.stopPropagation()
-        }
-
-        self.onPanelDragMove = function (e) {
-            if (!self.draggingPanel) return
-
-            var minLeft = 8
-            var minTop = 8
-            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
-            var maxTop = Math.max(minTop, window.innerHeight - 80)
-
-            var newLeft = e.clientX - self.dragOffsetX
-            var newTop = e.clientY - self.dragOffsetY
-
-            self.panelLeft = Math.min(Math.max(minLeft, newLeft), maxLeft)
-            self.panelTop = Math.min(Math.max(minTop, newTop), maxTop)
-
-            self.update()
-        }
-
-        self.stopPanelDrag = function () {
-            if (!self.draggingPanel) return
-
-            self.draggingPanel = false
-            document.body.classList.remove('workers-panel-dragging')
-
-            window.removeEventListener('mousemove', self.onPanelDragMove)
-            window.removeEventListener('mouseup', self.stopPanelDrag)
-
-            self.savePanelPosition()
-            self.update()
-        }
-
-        self.connect_workers_socket = function () {
-            if (self.ws) {
-                try { self.ws.close() } catch (e) {}
-                self.ws = null
-            }
-
-            var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-            var url = scheme + '://' + window.location.host + '/ws/workers/'
-
-            self.wsState = 'connecting'
-            self.update()
-
-            self.ws = new WebSocket(url)
-
-            self.ws.onopen = function () {
-                self.wsState = 'connected'
-                self.update()
-            }
-
-            self.ws.onmessage = function (event) {
-                var message = null
-
-                try {
-                    message = JSON.parse(event.data)
-                } catch (e) {
-                    console.error('Invalid websocket payload:', event.data)
-                    return
-                }
-
-                if (message.type === 'workers.snapshot') {
-                    self.workers = self.normalizeWorkers(message.workers || [])
-                    self.lastSyncAt = Date.now()
-                    self.update()
-                    return
-                }
-
-                if (message.type === 'worker.health' && message.worker) {
-                    self.upsertWorker(message.worker)
-                    self.lastSyncAt = Date.now()
-                    self.update()
-                }
-            }
-
-            self.ws.onerror = function () {
-                self.wsState = 'error'
-                self.update()
-            }
-
-            self.ws.onclose = function () {
-                self.wsState = 'disconnected'
-                self.update()
-
-                if (self.wsReconnectTimer) {
-                    clearTimeout(self.wsReconnectTimer)
-                }
-
-                self.wsReconnectTimer = setTimeout(function () {
-                    self.connect_workers_socket()
-                }, 2000)
-            }
-        }
-
-        self.normalizeWorker = function (worker) {
-            worker = worker || {}
-
-            return {
-                hostname: worker.hostname || 'unknown',
-                status: worker.status || 'unavailable',
-                running_jobs: typeof worker.running_jobs === 'number' ? worker.running_jobs : 0,
-                timestamp: worker.timestamp || null
-            }
-        }
-
-        self.normalizeWorkers = function (workers) {
-            return (workers || [])
-                .filter(function (worker) {
-                    return worker && worker.hostname
-                })
-                .map(function (worker) {
-                    return self.normalizeWorker(worker)
-                })
-        }
-
-        self.upsertWorker = function (worker) {
-            worker = self.normalizeWorker(worker)
-
-            if (!worker.hostname || worker.hostname === 'unknown') return
-
-            var idx = _.findIndex(self.workers, { hostname: worker.hostname })
-
-            if (idx === -1) {
-                self.workers.push(worker)
-            } else {
-                self.workers[idx] = worker
-            }
-
-            self.workers = self.workers.slice()
-        }
-
-        self.sortedWorkers = function () {
-            var order = {
-                available: 0,
-                busy: 1,
-                unavailable: 2
-            }
-
-            return (self.workers || []).slice().sort(function (a, b) {
-                var sa = self.displayStatus(a)
-                var sb = self.displayStatus(b)
-
-                var oa = order.hasOwnProperty(sa) ? order[sa] : 99
-                var ob = order.hasOwnProperty(sb) ? order[sb] : 99
-
-                if (oa !== ob) return oa - ob
-                if ((b.running_jobs || 0) !== (a.running_jobs || 0)) {
-                    return (b.running_jobs || 0) - (a.running_jobs || 0)
-                }
-
-                return (a.hostname || '').localeCompare(b.hostname || '')
-            })
-        }
-
-        self.displayStatus = function (worker) {
-            return worker && worker.status ? worker.status : 'unavailable'
-        }
-
-        self.getStatusClass = function (worker) {
-            var status = self.displayStatus(worker)
-            if (status === 'available') return 'green'
-            if (status === 'busy') return 'yellow'
-            return 'red'
-        }
-
-        self.getStatusIcon = function (worker) {
-            var status = self.displayStatus(worker)
-            if (status === 'available') return 'check circle'
-            if (status === 'busy') return 'clock'
-            return 'times circle'
-        }
-
-        self.getStatusText = function (worker) {
-            var status = self.displayStatus(worker)
-            if (status === 'available') return 'Available'
-            if (status === 'busy') return 'Busy'
-            return 'Unavailable'
-        }
-
-        self.formatLastSeen = function (timestamp) {
-            if (!timestamp) return '—'
-
-            var age = Math.max(0, Math.round((Date.now() / 1000) - timestamp))
-            if (age < 5) return 'just now'
-            if (age < 60) return age + 's ago'
-
-            var minutes = Math.floor(age / 60)
-            if (minutes < 60) return minutes + 'm ago'
-
-            var hours = Math.floor(minutes / 60)
-            return hours + 'h ago'
-        }
-
-        self.lastSyncLabel = function () {
-            if (!self.lastSyncAt) return 'never'
-
-            var age = Math.max(0, Math.round((Date.now() - self.lastSyncAt) / 1000))
-            if (age < 5) return 'just now'
-            if (age < 60) return age + 's ago'
-
-            var minutes = Math.floor(age / 60)
-            return minutes + 'm ago'
-        }
-
-        self.totalCount = function () {
-            return (self.workers || []).length
-        }
-
-        self.availableCount = function () {
-            return (self.workers || []).filter(function (worker) {
-                return self.displayStatus(worker) === 'available'
-            }).length
-        }
-
-        self.busyCount = function () {
-            return (self.workers || []).filter(function (worker) {
-                return self.displayStatus(worker) === 'busy'
-            }).length
-        }
-
-        self.unavailableCount = function () {
-            return (self.workers || []).filter(function (worker) {
-                return self.displayStatus(worker) === 'unavailable'
-            }).length
-        }
-
-        self.connectionLabel = function () {
-            if (self.wsState === 'connected') return 'Connected'
-            if (self.wsState === 'connecting') return 'Connecting'
-            if (self.wsState === 'error') return 'Error'
-            return 'Disconnected'
-        }
-
-        CODALAB.events.on('new_submission_created', function () {
-            self.update_competition_data()
-        })
-    </script>
-
-    <style type="text/stylus">
-        .comp-detail-paragraph-text
-            font-size 16px !important
-            line-height 20px !important
-
-        :scope
-            display block
-            width 100%
-            height 100%
-
-        .layout
-            display block
-            position relative
-
-        .comp-content
-            min-width 0
-            padding-right 0
-
-        .workers-panel
+        .workers-toggle-btn
             position fixed
-            top 24px
+            top 74px
             right 24px
-            width 375px
-            z-index 25
-            max-height calc(100vh - 48px)
-            overflow auto
-
-        .workers-card
-            background #fff
-            border 1px solid rgba(34, 36, 38, .12)
-            border-radius 16px
-            box-shadow 0 8px 24px rgba(16, 24, 40, .08)
-            padding 12px
-
-        .workers-drag-handle
-            cursor move
-            user-select none
-            touch-action none
-
-        .workers-header
-            margin-bottom 12px
-
-        .workers-title
-            display flex
-            align-items flex-start
-            gap 10px
-
-        .workers-title .icon
-            margin-top 2px
-
-        .workers-title-text
-            font-size 18px
-            font-weight 700
-            color #1f2937
-            line-height 1.2
-
-        .workers-subtitle
-            margin-top 4px
-            font-size 12px
-            color #6b7280
-            display flex
-            align-items center
-            flex-wrap wrap
-            gap 6px
-
-        .workers-connection
-            display inline-flex
-            align-items center
-            padding 3px 8px
-            border-radius 999px
-            font-weight 700
-            font-size 11px
-            text-transform uppercase
-            letter-spacing .04em
-            background #f3f4f6
-            color #6b7280
-
-        .workers-connection.connected
-            background rgba(33, 186, 69, .12)
-            color #21ba45
-
-        .workers-connection.connecting
-            background rgba(251, 189, 8, .14)
-            color #b58105
-
-        .workers-connection.error
-            background rgba(219, 40, 40, .12)
-            color #db2828
-
-        .workers-connection.disconnected
-            background rgba(219, 40, 40, .12)
-            color #db2828
-
-        .workers-separator
-            opacity .6
-
-        .workers-drag-hint
-            margin-top 4px
-            font-size 11px
-            color #9ca3af
-            white-space nowrap
-
-        .workers-stats
-            display grid
-            grid-template-columns repeat(4, minmax(0, 1fr))
-            gap 8px
-            margin 10px 0 15px 0 !important
-from channels.layers import get_channel_layer
-from asgiref.sync import async_to_sync
-        .stat-card
-            background #f9fafb
-            border 1px solid rgba(17, 24, 39, .06)
-            border-radius 12px
-            padding 10px 8px
-            text-align center
-            min-width 0
-            display flex
-            flex-direction column
-            align-items center
-            justify-content center
-
-        .stat-value
-            font-size 18px
-            font-weight 800
-            line-height 1
-            color #111827
-            margin-bottom 4px
-            min-width 1ch
-            text-align center
-
-        .stat-green
-            color #21ba45
-
-        .stat-yellow
-            color #b58105
-
-        .stat-red
-            color #db2828
-
-        .stat-label
-            font-size 11px
-            font-weight 700
-            text-transform uppercase
-            letter-spacing .04em
-            color #6b7280
-            line-height 1.1
-            text-align center
-            white-space nowrap
-
-        .workers-table-wrap
-            max-height calc(100vh - 240px)
-            overflow auto
-            border-radius 12px
-
-        .workers-table
-            margin 0 !important
-            width :autofill
-            table-layout auto
-            font-size 13px
-
-        .workers-table thead th
-            position sticky
-            top 0
-            z-index 2
-            background #f8fafc !important
-            color #374151 !important
-            font-weight 700 !important
-            font-size 12px
-            text-transform uppercase
-            letter-spacing .03em
-
-        .workers-table td,
-        .workers-table th
-            vertical-align middle !important
-
-        .worker-hostname
-            font-size 13px
-            font-weight 700
-            white-space nowrap
-            overflow hidden
-            text-overflow ellipsis
-
-        .worker-jobs
-            text-align center
-
-        .worker-lastseen
-            color #6b7280
-            font-size 12px
-            white-space nowrap
-            overflow hidden
-            text-overflow ellipsis
-
-        .worker-status
-            border-radius 999px !important
-            font-weight 700 !important
-            display inline-flex !important
-            align-items center
-            gap 6px
-            white-space nowrap
-
-        .workers-empty
-            padding 24px 12px
-            text-align center
-            color #6b7280
-
-        .workers-empty .header
-            font-weight 700
-            color #374151
-            margin-bottom 4px
-
-        .workers-footer
-            margin-top 12px
-            font-size 12px
-            color #6b7280
-
-        .ui.label.green
-            background-color #21ba45 !important
+            z-index 30
+            background #576671 !important
             color white !important
+            
+        .workers-connection {
+            display: inline-flex;
+            align-items: center;
+            padding: 3px 8px;
+            border-radius: 999px;
+            font-weight: 700;
+            font-size: 11px;
+            text-transform: uppercase;
+            background: #f3f4f6;
+            color: #6b7280;
+        }
+        .workers-connection.connected {
+            background: rgba(33,186,69,.12);
+            color: #21ba45;
+        }
+        .workers-connection.connecting {
+            background: rgba(251,189,8,.14);
+            color: #b58105;
+        }
+        .workers-connection.error {
+            background: rgba(219,40,40,.12);
+            color: #db2828;
+        }
+        .workers-connection.disconnected {
+            background: rgba(219,40,40,.12);
+            color: #db2828;
+        }
+        .workers-separator { opacity: .6; }
+        .workers-drag-hint { margin-top: 4px; font-size: 11px; color: #9ca3af; white-space: nowrap; }
 
-        .ui.label.yellow
-            background-color #f2c037 !important
-            color black !important
+        .workers-stats {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 8px;
+            margin: 10px 0 15px 0 !important;
+        }
+        .stat-card {
+            background: #f9fafb;
+            border: 1px solid rgba(0,0,0,0.06);
+            border-radius: 12px;
+            padding: 10px 8px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        .stat-value {
+            font-size: 18px;
+            font-weight: 800;
+            color: #111827;
+            margin-bottom: 4px;
+            min-width: 1ch;
+        }
+        .stat-green { color: #21ba45; }
+        .stat-yellow { color: #b58105; }
+        .stat-red { color: #db2828; }
+        .stat-label {
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            color: #6b7280;
+            letter-spacing: .04em;
+        }
 
-        .ui.label.red
-            background-color #db2828 !important
-            color white !important
+        .workers-table-wrap {
+            max-height: calc(100vh - 240px);
+            overflow: auto;
+            border-radius: 12px;
+        }
+        .workers-table {
+            margin: 0 !important;
+            width: 100%;
+            table-layout: auto;
+            font-size: 13px;
+        }
+        .workers-table thead th {
+            position: sticky;
+            top: 0;
+            background: #f8fafc !important;
+            color: #374151 !important;
+            font-weight: 700 !important;
+            font-size: 12px;
+            text-transform: uppercase;
+        }
+        .workers-table td, .workers-table th {
+            vertical-align: middle !important;
+        }
+        .worker-hostname {
+            font-size: 13px;
+            font-weight: 700;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .worker-jobs {
+            text-align: center;
+        }
+        .worker-lastseen {
+            color: #6b7280;
+            font-size: 12px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .worker-status {
+            border-radius: 999px !important;
+            font-weight: 700 !important;
+            display: inline-flex !important;
+            align-items: center;
+            gap: 6px;
+            white-space: nowrap;
+        }
+        .workers-empty {
+            padding: 24px 12px;
+            text-align: center;
+            color: #6b7280;
+        }
+        .workers-empty .header {
+            font-weight: 700;
+            color: #374151;
+            margin-bottom: 4px;
+        }
+        .workers-footer {
+            margin-top: 12px;
+            font-size: 12px;
+            color: #6b7280;
+        }
+        .ui.label.green {
+            background-color: #21ba45 !important;
+            color: white !important;
+        }
+        .ui.label.yellow {
+            background-color: #f2c037 !important;
+            color: black !important;
+        }
+        .ui.label.red {
+            background-color: #db2828 !important;
+            color: white !important;
+        }
+        body.workers-panel-dragging {
+            user-select: none;
+        }
 
-        body.workers-panel-dragging
-            user-select none
-
-        @media (max-width: 1400px)
-            .workers-panel
-                position static
-                width 100%
-                max-height none
-                margin-top 16px
-
-            .workers-table-wrap
-                max-height none
-
-        @media (max-width: 768px)
-            .workers-stats
-                grid-template-columns repeat(2, minmax(0, 1fr))
+        @media (max-width: 1400px) {
+            .workers-panel {
+                position: static;
+                width: 100%;
+                max-height: none;
+                margin-top: 16px;
+            }
+            .workers-table-wrap {
+                max-height: none;
+            }
+        }
+        @media (max-width: 768px) {
+            .workers-stats {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
     </style>
 </competition-detail>

--- a/src/static/riot/competitions/detail/worker-monitor-toggle.tag
+++ b/src/static/riot/competitions/detail/worker-monitor-toggle.tag
@@ -151,7 +151,7 @@
 
         self.toggleWorkersPanel = function () {
             self.showWorkersPanel = !self.showWorkersPanel
-            #   here, we make sure the network is not used when the pannel is closed
+            //   here, we make sure the network is not used when the pannel is closed
             if (self.showWorkersPanel) {
                 self.loadPanelPosition()
                 self.connect_workers_socket()

--- a/src/static/riot/competitions/detail/worker-monitor-toggle.tag
+++ b/src/static/riot/competitions/detail/worker-monitor-toggle.tag
@@ -96,7 +96,6 @@
                         <thead>
                             <tr>
                                 <th>Worker</th>
-                                <th>Queue</th>
                                 <th>Status</th>
                                 <th>Jobs</th>
                                 <th>Last seen</th>

--- a/src/static/riot/competitions/detail/worker-monitor-toggle.tag
+++ b/src/static/riot/competitions/detail/worker-monitor-toggle.tag
@@ -46,9 +46,12 @@
             </div>
 
             <div class="workers-section">
-                <div class="workers-section-title">Default compute workers</div>
+                <div class="workers-section-title workers-section-header" onclick="{ toggleDefaultWorkers }">
+                    <span>Default compute workers</span>
 
-                <div class="workers-table-wrap">
+                    <i class="dropdown icon workers-collapse-icon { showDefaultWorkers ? 'open' : '' }"></i>
+                </div>
+                <div class="workers-table-wrap" if="{ showDefaultWorkers }">
                     <table class="ui very compact selectable striped table workers-table">
                         <thead>
                             <tr>
@@ -92,7 +95,7 @@
                     <table class="ui very compact selectable striped table workers-table">
                         <thead>
                             <tr>
-                                <th>Competition</th>
+                                <th>Worker</th>
                                 <th>Queue</th>
                                 <th>Status</th>
                                 <th>Jobs</th>
@@ -134,6 +137,7 @@
         self.wsReconnectTimer = null
         self.wsState = 'disconnected'
         self.lastSyncAt = null
+        self.showDefaultWorkers = true
 
         self.canViewWorkersPanel =
             String(self.opts.can_view_workers_panel || 'false') === 'true'
@@ -370,6 +374,11 @@
             if (self.displayStatus(worker) === 'available') return 'green'
             if (self.displayStatus(worker) === 'busy') return 'yellow'
             return 'red'
+        }
+
+        self.toggleDefaultWorkers = function () {
+            self.showDefaultWorkers = !self.showDefaultWorkers
+            self.update()
         }
 
         self.getStatusIcon = function (worker) {

--- a/src/static/riot/competitions/detail/worker-monitor-toggle.tag
+++ b/src/static/riot/competitions/detail/worker-monitor-toggle.tag
@@ -1,0 +1,637 @@
+<worker-monitor-toggle>
+    <button
+        if="{ canViewWorkersPanel }"
+        class="ui small button"
+        onclick="{ toggleWorkersPanel }">
+        { showWorkersPanel ? 'Hide workers' : 'Show workers' }
+    </button>
+
+    <aside
+        if="{ canViewWorkersPanel && showWorkersPanel }"
+        class="workers-panel"
+        style="left: { panelLeft }px; top: { panelTop }px; width: { panelWidth }px;">
+        <div class="workers-card">
+            <div class="workers-header workers-drag-handle" onmousedown="{ startPanelDrag }">
+                <div class="workers-title">
+                    <i class="server icon"></i>
+                    <div class="workers-title-text">
+                        Compute Workers
+                        <div class="workers-subtitle">
+                            <span class="workers-connection { wsState }">{ connectionLabel() }</span>
+                            <span class="workers-separator">•</span>
+                            Last update: { lastSyncLabel() }
+                        </div>
+                    </div>
+                </div>
+                <div class="workers-drag-hint">Drag to move</div>
+            </div>
+
+            <div class="workers-stats">
+                <div class="stat-card">
+                    <div class="stat-value">{ totalCount() }</div>
+                    <div class="stat-label">Total</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value stat-green">{ availableCount() }</div>
+                    <div class="stat-label">Available</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value stat-yellow">{ busyCount() }</div>
+                    <div class="stat-label">Busy</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value stat-red">{ unavailableCount() }</div>
+                    <div class="stat-label">Down</div>
+                </div>
+            </div>
+
+            <div class="workers-section">
+                <div class="workers-section-title">Default compute workers</div>
+
+                <div class="workers-table-wrap">
+                    <table class="ui very compact selectable striped table workers-table">
+                        <thead>
+                            <tr>
+                                <th>Worker</th>
+                                <th>Status</th>
+                                <th>Jobs</th>
+                                <th>Last seen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr each="{ worker in sortedWorkers() }">
+                                <td>
+                                    <strong>{ worker.hostname }</strong>
+                                </td>
+                                <td>
+                                    <span class="ui tiny label worker-status { getStatusClass(worker) }">
+                                        <i class="{ getStatusIcon(worker) } icon"></i>
+                                        { getStatusText(worker) }
+                                    </span>
+                                </td>
+                                <td>{ worker.running_jobs || 0 }</td>
+                                <td>{ formatLastSeen(worker.timestamp) }</td>
+                            </tr>
+                            <tr if="{ sortedWorkers().length === 0 }">
+                                <td colspan="4" class="center aligned">
+                                    <div class="workers-empty">
+                                        <div class="header">No compute workers detected</div>
+                                        <div class="description">Waiting for the first websocket snapshot.</div>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="workers-section" if="{ sortedPrivateWorkers().length }">
+                <div class="workers-section-title">Private queues</div>
+
+                <div class="workers-table-wrap">
+                    <table class="ui very compact selectable striped table workers-table">
+                        <thead>
+                            <tr>
+                                <th>Competition</th>
+                                <th>Queue</th>
+                                <th>Status</th>
+                                <th>Jobs</th>
+                                <th>Last seen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr each="{ worker in sortedPrivateWorkers() }">
+                                <td>
+                                    <strong>{ worker.hostname || worker.competition_title || 'Private competition' }</strong>
+                                </td>
+                                <td>{ worker.queue_name || '—' }</td>
+                                <td>
+                                    <span class="ui tiny label worker-status { getStatusClass(worker) }">
+                                        <i class="{ getStatusIcon(worker) } icon"></i>
+                                        { getStatusText(worker) }
+                                    </span>
+                                </td>
+                                <td>{ worker.running_jobs || 0 }</td>
+                                <td>{ formatLastSeen(worker.timestamp) }</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="workers-footer">
+                Green = available, yellow = busy, red = unavailable
+            </div>
+        </div>
+    </aside>
+
+    <script>
+        var self = this
+
+        self.workers = []
+        self.privateWorkers = []
+        self.ws = null
+        self.wsReconnectTimer = null
+        self.wsState = 'disconnected'
+        self.lastSyncAt = null
+
+        self.canViewWorkersPanel =
+            String(self.opts.can_view_workers_panel || 'false') === 'true'
+
+        self.showWorkersPanel = false
+        self.panelLeft = 24
+        self.panelTop = 24
+        self.panelWidth = 460
+
+        self.draggingPanel = false
+        self.dragOffsetX = 0
+        self.dragOffsetY = 0
+
+        self.toggleWorkersPanel = function () {
+            self.showWorkersPanel = !self.showWorkersPanel
+
+            if (self.showWorkersPanel) {
+                self.loadPanelPosition()
+                self.connect_workers_socket()
+            } else {
+                self.close_workers_socket()
+            }
+
+            self.update()
+        }
+
+        self.close_workers_socket = function () {
+            if (self.wsReconnectTimer) {
+                clearTimeout(self.wsReconnectTimer)
+                self.wsReconnectTimer = null
+            }
+
+            if (self.ws) {
+                try {
+                    self.ws.close()
+                } catch (e) {}
+                self.ws = null
+            }
+
+            self.wsState = 'disconnected'
+        }
+
+        self.connect_workers_socket = function () {
+            if (self.ws) {
+                try {
+                    self.ws.close()
+                } catch (e) {}
+                self.ws = null
+            }
+
+            var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
+            var url = scheme + '://' + window.location.host + '/ws/workers/'
+
+            self.wsState = 'connecting'
+            self.update()
+
+            self.ws = new WebSocket(url)
+
+            self.ws.onopen = function () {
+                self.wsState = 'connected'
+                self.update()
+            }
+
+            self.ws.onmessage = function (event) {
+                var message = null
+
+                try {
+                    message = JSON.parse(event.data)
+                } catch (e) {
+                    console.error('Invalid websocket payload:', event.data)
+                    return
+                }
+
+                if (message.type === 'workers.snapshot') {
+                    self.workers = message.workers || []
+                    self.privateWorkers = message.private_workers || []
+                    self.lastSyncAt = Date.now()
+                    self.update()
+                }
+            }
+
+            self.ws.onclose = function () {
+                self.wsState = 'disconnected'
+                self.update()
+            }
+        }
+
+        self.startPanelDrag = function (e) {
+            if (e.button !== 0) return
+
+            var panel = self.root.querySelector('.workers-panel')
+            if (!panel) return
+
+            var rect = panel.getBoundingClientRect()
+
+            self.draggingPanel = true
+            self.dragOffsetX = e.clientX - rect.left
+            self.dragOffsetY = e.clientY - rect.top
+
+            document.body.classList.add('workers-panel-dragging')
+
+            window.addEventListener('mousemove', self.onPanelDragMove)
+            window.addEventListener('mouseup', self.stopPanelDrag)
+
+            e.preventDefault()
+        }
+
+        self.onPanelDragMove = function (e) {
+            if (!self.draggingPanel) return
+
+            var minLeft = 8
+            var minTop = 8
+            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
+            var maxTop = Math.max(minTop, window.innerHeight - 80)
+
+            var newLeft = e.clientX - self.dragOffsetX
+            var newTop = e.clientY - self.dragOffsetY
+
+            self.panelLeft = Math.min(Math.max(minLeft, newLeft), maxLeft)
+            self.panelTop = Math.min(Math.max(minTop, newTop), maxTop)
+
+            self.update()
+        }
+
+        self.stopPanelDrag = function () {
+            if (!self.draggingPanel) return
+
+            self.draggingPanel = false
+            document.body.classList.remove('workers-panel-dragging')
+
+            window.removeEventListener('mousemove', self.onPanelDragMove)
+            window.removeEventListener('mouseup', self.stopPanelDrag)
+        }
+
+        self.one('mount', function () {
+            self.loadPanelPosition()
+        })
+
+        self.one('unmount', function () {
+            window.removeEventListener('mousemove', self.onPanelDragMove)
+            window.removeEventListener('mouseup', self.stopPanelDrag)
+            self.close_workers_socket()
+            document.body.classList.remove('workers-panel-dragging')
+        })
+
+        self.loadPanelPosition = function () {
+            try {
+                var raw = localStorage.getItem(self.panelStorageKey)
+                if (!raw) return
+
+                var pos = JSON.parse(raw)
+                if (typeof pos.left === 'number') self.panelLeft = pos.left
+                if (typeof pos.top === 'number') self.panelTop = pos.top
+
+                self.clampPanelPosition()
+            } catch (e) {
+                console.warn('Could not load panel position', e)
+            }
+        }
+
+        self.savePanelPosition = function () {
+            try {
+                localStorage.setItem(self.panelStorageKey, JSON.stringify({
+                    left: self.panelLeft,
+                    top: self.panelTop
+                }))
+            } catch (e) {
+                console.warn('Could not save panel position', e)
+            }
+        }
+
+        self.clampPanelPosition = function () {
+            var minLeft = 8
+            var minTop = 8
+            var maxLeft = Math.max(minLeft, window.innerWidth - self.panelWidth - 8)
+            var maxTop = Math.max(minTop, window.innerHeight - 80)
+
+            self.panelLeft = Math.min(Math.max(minLeft, self.panelLeft), maxLeft)
+            self.panelTop = Math.min(Math.max(minTop, self.panelTop), maxTop)
+        }
+
+        self.sortedWorkers = function () {
+            var order = { available: 0, busy: 1, unavailable: 2 }
+
+            return (self.workers || []).slice().sort(function (a, b) {
+                var sa = self.displayStatus(a)
+                var sb = self.displayStatus(b)
+
+                var oa = order[sa] != null ? order[sa] : 99
+                var ob = order[sb] != null ? order[sb] : 99
+
+                if (oa !== ob) return oa - ob
+
+                if ((b.running_jobs || 0) !== (a.running_jobs || 0)) {
+                    return (b.running_jobs || 0) - (a.running_jobs || 0)
+                }
+
+                return (a.hostname || '').localeCompare(b.hostname || '')
+            })
+        }
+
+        self.sortedPrivateWorkers = function () {
+            var order = { available: 0, busy: 1, unavailable: 2 }
+
+            return (self.privateWorkers || []).slice().sort(function (a, b) {
+                var sa = self.displayStatus(a)
+                var sb = self.displayStatus(b)
+
+                var oa = order[sa] != null ? order[sa] : 99
+                var ob = order[sb] != null ? order[sb] : 99
+
+                if (oa !== ob) return oa - ob
+
+                if ((b.running_jobs || 0) !== (a.running_jobs || 0)) {
+                    return (b.running_jobs || 0) - (a.running_jobs || 0)
+                }
+
+                var an = a.competition_title || a.queue_name || a.hostname || ''
+                var bn = b.competition_title || b.queue_name || b.hostname || ''
+                return an.localeCompare(bn)
+            })
+        }
+
+        self.displayStatus = function (worker) {
+            return worker && worker.status ? worker.status : 'unavailable'
+        }
+
+        self.getStatusClass = function (worker) {
+            if (self.displayStatus(worker) === 'available') return 'green'
+            if (self.displayStatus(worker) === 'busy') return 'yellow'
+            return 'red'
+        }
+
+        self.getStatusIcon = function (worker) {
+            if (self.displayStatus(worker) === 'available') return 'check circle'
+            if (self.displayStatus(worker) === 'busy') return 'clock'
+            return 'times circle'
+        }
+
+        self.getStatusText = function (worker) {
+            if (self.displayStatus(worker) === 'available') return 'Available'
+            if (self.displayStatus(worker) === 'busy') return 'Busy'
+            return 'Unavailable'
+        }
+
+        self.formatLastSeen = function (timestamp) {
+            if (!timestamp) return '—'
+
+            var age = Math.round((Date.now() / 1000) - timestamp)
+            if (age < 5) return 'just now'
+            if (age < 60) return age + 's ago'
+
+            var minutes = Math.floor(age / 60)
+            if (minutes < 60) return minutes + 'm ago'
+
+            return Math.floor(minutes / 60) + 'h ago'
+        }
+
+        self.lastSyncLabel = function () {
+            if (!self.lastSyncAt) return 'never'
+
+            var age = Math.round((Date.now() - self.lastSyncAt) / 1000)
+            if (age < 5) return 'just now'
+            if (age < 60) return age + 's ago'
+
+            var minutes = Math.floor(age / 60)
+            return minutes + 'm ago'
+        }
+
+        self.totalCount = function () {
+            return (self.workers || []).length
+        }
+
+        self.availableCount = function () {
+            return (self.workers || []).filter(function (w) {
+                return self.displayStatus(w) === 'available'
+            }).length
+        }
+
+        self.busyCount = function () {
+            return (self.workers || []).filter(function (w) {
+                return self.displayStatus(w) === 'busy'
+            }).length
+        }
+
+        self.unavailableCount = function () {
+            return (self.workers || []).filter(function (w) {
+                return self.displayStatus(w) === 'unavailable'
+            }).length
+        }
+
+        self.connectionLabel = function () {
+            if (self.wsState === 'connected') return 'Connected'
+            if (self.wsState === 'connecting') return 'Connecting'
+            if (self.wsState === 'error') return 'Error'
+            return 'Disconnected'
+        }
+
+        self.panelStorageKey = 'codabench_workers_panel_position'
+
+        window.addEventListener('resize', function () {
+            if (!self.showWorkersPanel) return
+            self.clampPanelPosition()
+            self.update()
+        })
+    </script>
+
+    <style type="text/stylus">
+        .workers-panel
+            position fixed
+            z-index 25
+            max-height calc(100vh - 48px)
+            overflow auto
+
+        .workers-card
+            width 100%
+            background #fff
+            border 1px solid rgba(0,0,0,.1)
+            border-radius 16px
+            box-shadow 0 8px 24px rgba(0,0,0,.08)
+            padding 14px
+
+        .workers-header
+            margin-bottom 12px
+
+        .workers-drag-handle
+            cursor move
+            user-select none
+            touch-action none
+
+        .workers-title
+            display flex
+            align-items flex-start
+            gap 10px
+
+        .workers-title .icon
+            margin-top 2px
+
+        .workers-title-text
+            font-size 18px
+            font-weight 700
+            color #1f2937
+            line-height 1.2
+
+        .workers-subtitle
+            margin-top 4px
+            font-size 12px
+            color #6b7280
+            display flex
+            align-items center
+            flex-wrap wrap
+            gap 6px
+
+        .workers-connection
+            display inline-flex
+            align-items center
+            padding 3px 8px
+            border-radius 999px
+            font-weight 700
+            font-size 11px
+            text-transform uppercase
+            letter-spacing .04em
+            background #f3f4f6
+            color #6b7280
+
+        .workers-connection.connected
+            background rgba(33, 186, 69, .12)
+            color #21ba45
+
+        .workers-connection.connecting
+            background rgba(251, 189, 8, .14)
+            color #b58105
+
+        .workers-connection.error
+            background rgba(219, 40, 40, .12)
+            color #db2828
+
+        .workers-connection.disconnected
+            background rgba(219, 40, 40, .12)
+            color #db2828
+
+        .workers-separator
+            opacity .6
+
+        .workers-drag-hint
+            margin-top 4px
+            font-size 11px
+            color #9ca3af
+            white-space nowrap
+
+        .workers-stats
+            display grid
+            grid-template-columns repeat(4, minmax(0, 1fr))
+            gap 8px
+            margin 10px 0 15px 0 !important
+
+        .stat-card
+            background #f9fafb
+            border 1px solid rgba(0,0,0,.06)
+            border-radius 12px
+            padding 10px 8px
+            text-align center
+            display flex
+            flex-direction column
+            align-items center
+            justify-content center
+
+        .stat-value
+            font-size 18px
+            font-weight 800
+            color #111827
+            margin-bottom 4px
+            min-width 1ch
+
+        .stat-green
+            color #21ba45
+
+        .stat-yellow
+            color #b58105
+
+        .stat-red
+            color #db2828
+
+        .stat-label
+            font-size 11px
+            font-weight 700
+            text-transform uppercase
+            color #6b7280
+            letter-spacing .04em
+
+        .workers-section
+            margin-top 16px
+
+        .workers-section-title
+            margin 12px 0 8px 0
+            font-size 12px
+            font-weight 700
+            text-transform uppercase
+            letter-spacing .04em
+            color #6b7280
+
+        .workers-table-wrap
+            max-height calc(100vh - 240px)
+            overflow auto
+            border-radius 12px
+
+        .workers-table
+            margin 0 !important
+            width 100%
+            table-layout auto
+            font-size 13px
+
+        .workers-table thead th
+            position sticky
+            top 0
+            background #f8fafc !important
+            color #374151 !important
+            font-weight 700 !important
+            font-size 12px
+            text-transform uppercase
+
+        .workers-table td
+        .workers-table th
+            vertical-align middle !important
+
+        .worker-status
+            border-radius 999px !important
+            font-weight 700 !important
+            display inline-flex !important
+            align-items center
+            gap 6px
+            white-space nowrap
+
+        .workers-empty
+            padding 24px 12px
+            text-align center
+            color #6b7280
+
+        .workers-empty .header
+            font-weight 700
+            color #374151
+            margin-bottom 4px
+
+        .workers-footer
+            margin-top 12px
+            font-size 12px
+            color #6b7280
+
+        body.workers-panel-dragging
+            user-select none
+
+        @media (max-width: 1400px)
+            .workers-panel
+                width calc(100vw - 32px)
+                max-width 520px
+
+        @media (max-width: 768px)
+            .workers-stats
+                grid-template-columns repeat(2, minmax(0, 1fr))
+    </style>
+</worker-monitor-toggle>

--- a/src/static/riot/competitions/detail/worker-monitor-toggle.tag
+++ b/src/static/riot/competitions/detail/worker-monitor-toggle.tag
@@ -138,6 +138,8 @@
         self.canViewWorkersPanel =
             String(self.opts.can_view_workers_panel || 'false') === 'true'
 
+        self.competitionId = parseInt(self.opts.competition_id) || null
+
         self.showWorkersPanel = false
         self.panelLeft = 24
         self.panelTop = 24
@@ -149,7 +151,7 @@
 
         self.toggleWorkersPanel = function () {
             self.showWorkersPanel = !self.showWorkersPanel
-
+            #   here, we make sure the network is not used when the pannel is closed
             if (self.showWorkersPanel) {
                 self.loadPanelPosition()
                 self.connect_workers_socket()
@@ -183,7 +185,7 @@
                 } catch (e) {}
                 self.ws = null
             }
-
+            var competitionId = parseInt(self.opts.competition_id) || null
             var scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
             var url = scheme + '://' + window.location.host + '/ws/workers/'
 
@@ -194,9 +196,12 @@
 
             self.ws.onopen = function () {
                 self.wsState = 'connected'
+                if (self.competitionId) {
+                    var msg = JSON.stringify({ type: 'subscribe', competition_id: self.competitionId })
+                    self.ws.send(msg)
+                }
                 self.update()
             }
-
             self.ws.onmessage = function (event) {
                 var message = null
 

--- a/src/templates/competitions/detail.html
+++ b/src/templates/competitions/detail.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}{{ competition.title }} - Codabench{% endblock %}
+{% block title %}{{ competition.title }} – Codabench{% endblock %}
 
 {% block content %}
-    <competition-detail competition_pk="{{ object.pk }}" secret_key="{{ secret_key }}"></competition-detail>
+<competition-detail
+    competition_pk="{{ object.pk }}"
+    secret_key="{{ secret_key }}"
+    can_view_workers_panel="{% if request.user.is_authenticated and request.user == competition.created_by or request.user in competition.collaborators.all or request.user.is_superuser %}true{% else %}false{% endif %}">
+</competition-detail>
 {% endblock %}

--- a/src/urls.py
+++ b/src/urls.py
@@ -33,7 +33,6 @@ urlpatterns = [
 
 ]
 
-
 if settings.DEBUG:
     # Static files for local dev, so we don't have to collectstatic and such
     urlpatterns += staticfiles_urlpatterns()

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -8,6 +8,11 @@ from celery._state import app_or_default
 
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
+        user = self.scope["user"]
+
+        if user is None or user.is_anonymous:
+            await self.close()
+            return
         await self.accept()
         self._running = True
         self._task = asyncio.create_task(self._push_workers_loop())

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -5,8 +5,34 @@ import time
 from asgiref.sync import sync_to_async
 from celery._state import app_or_default
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from queues.models import Queue
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_queue_names(active_queues):
+    names = set()
+    for q in active_queues or []:
+        if isinstance(q, dict) and q.get("name"):
+            names.add(q["name"])
+    return names
+
+
+def _known_compute_queue_names():
+    return set(
+        Queue.objects.exclude(name__isnull=True)
+        .exclude(name="")
+        .values_list("name", flat=True)
+    )
+
+
+def _is_compute_worker(worker_name, queue_names, known_queue_names):
+    return (
+        bool(queue_names & known_queue_names)
+        or "compute-worker" in queue_names
+        or worker_name.startswith("compute-worker")
+        or worker_name.startswith("CW")
+    )
 
 
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
@@ -59,28 +85,17 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             logger.exception("Unable to inspect Celery workers")
             return []
 
+        known_queue_names = _known_compute_queue_names()
         workers = []
 
         for worker_name in stats.keys():
             queues = active_queues.get(worker_name, []) or []
-            queue_names = []
+            queue_names = _extract_queue_names(queues)
 
-            for q in queues:
-                if isinstance(q, dict) and q.get("name"):
-                    queue_names.append(q["name"])
-
-            is_compute_worker = (
-                "compute-worker" in queue_names
-                or worker_name.startswith("compute-worker")
-                or worker_name.startswith("CW")
-            )
-
-            if not is_compute_worker:
+            if not _is_compute_worker(worker_name, queue_names, known_queue_names):
                 continue
 
-            running_jobs = len(active.get(worker_name, [])) + len(
-                reserved.get(worker_name, [])
-            )
+            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
             status = "busy" if running_jobs > 0 else "available"
 
             workers.append(
@@ -89,6 +104,7 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                     "status": status,
                     "running_jobs": running_jobs,
                     "timestamp": time.time(),
+                    "queue_names": sorted(queue_names),
                 }
             )
 

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -20,7 +20,7 @@ def _extract_queue_names(active_queues):
 
 def _known_compute_queue_names():
     return set(
-        Queue.objects.exclude(name__isnull=True)
+        Queue.objects.exclude(name__isnull=False)
         .exclude(name="")
         .values_list("name", flat=True)
     )

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -11,7 +11,7 @@ from channels.generic.websocket import AsyncJsonWebsocketConsumer
 logger = logging.getLogger(__name__)
 
 WORKERS_REGISTRY_KEY = "workers:registry"
-WORKER_HEARTBEAT_TTL = 35
+WORKER_HEARTBEAT_TTL = 180
 
 r = get_redis_connection("default")
 

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -3,10 +3,11 @@ import json
 import logging
 import time
 
-from django_redis import get_redis_connection
+from competitions.models import Competition
 
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django_redis import get_redis_connection
 
 from utils.worker_utils import WORKER_HEARTBEAT_TTL, WORKERS_REGISTRY_KEY
 
@@ -15,29 +16,54 @@ logger = logging.getLogger(__name__)
 r = get_redis_connection("default")
 
 
-# consumers.py
-def _load_snapshot():
+def _load_snapshot(competition_queue_name=None):
+    """
+    Charge les workers depuis Redis.
+    - workers par défaut : toujours inclus (queue_source == 'default')
+    - workers privés : inclus uniquement si leur queue_source correspond
+      à la queue de la compétition courante
+    """
     raw = r.hgetall(WORKERS_REGISTRY_KEY)
     workers = []
     private_workers = []
     now = time.time()
+
     for _, value in raw.items():
         try:
             worker = json.loads(value)
         except Exception:
             continue
+
         if now - worker.get("last_seen", 0) > WORKER_HEARTBEAT_TTL:
             continue
+
         if worker.get("queue_source") == "default":
             workers.append(worker)
         else:
-            private_workers.append(worker)
+            # Worker privé : n'afficher que si la queue correspond à la compétition
+            if competition_queue_name and worker.get("queue_source") == competition_queue_name:
+                private_workers.append(worker)
+
     workers.sort(key=lambda x: x.get("hostname", ""))
     private_workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
     return workers, private_workers
 
 
+def _get_competition_queue_name(competition_id):
+    """Retourne le nom de la queue de la compétition, ou None."""
+    if not competition_id:
+        return None
+    try:
+        competition = Competition.objects.select_related("queue").get(pk=competition_id)
+        if competition.queue and competition.queue.name:
+            return competition.queue.name
+    except Exception:
+        logger.warning("Competition %s not found or has no queue", competition_id)
+    return None
+
+
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
+
     async def connect(self):
         user = self.scope.get("user")
         if user is None or user.is_anonymous:
@@ -45,7 +71,9 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             return
         await self.accept()
         await self.channel_layer.group_add("compute_workers", self.channel_name)
+        self._competition_queue_name = None
         self._running = True
+        self._subscribed = asyncio.Event()
         self._task = asyncio.create_task(self._push_workers_loop())
 
     async def disconnect(self, close_code):
@@ -59,10 +87,25 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             except (asyncio.CancelledError, RuntimeError):
                 pass
 
+    async def receive_json(self, content):
+        logger.debug("WebSocket received: %s", content)
+        if content.get("type") == "subscribe":
+            competition_id = content.get("competition_id")
+            self._competition_queue_name = await sync_to_async(_get_competition_queue_name)(
+                competition_id)
+            self._subscribed.set()
+
     async def _push_workers_loop(self):
         try:
+            try:
+                await asyncio.wait_for(self._subscribed.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("WebSocket subscribe timeout, proceeding without competition filter")
+
             while self._running:
-                workers, private_workers = await sync_to_async(_load_snapshot)()
+                workers, private_workers = await sync_to_async(_load_snapshot)(
+                    self._competition_queue_name
+                )
                 if not self._running:
                     break
                 try:
@@ -78,10 +121,22 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             pass
 
     async def worker_health(self, event):
+        worker = event["worker"]
+        is_default = worker.get("queue_source") == "default"
+        is_mine = (
+            self._competition_queue_name is not None
+            and worker.get("queue_source") == self._competition_queue_name
+        )
+        if not is_default and not is_mine:
+            return
         try:
+            workers, private_workers = await sync_to_async(_load_snapshot)(
+                self._competition_queue_name
+            )
             await self.send_json({
                 "type": "workers.snapshot",
-                "workers": [event["worker"]],
+                "workers": workers,
+                "private_workers": private_workers,
             })
         except RuntimeError:
             pass

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -8,29 +8,33 @@ from django_redis import get_redis_connection
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
-logger = logging.getLogger(__name__)
+from utils.worker_utils import WORKER_HEARTBEAT_TTL, WORKERS_REGISTRY_KEY
 
-WORKERS_REGISTRY_KEY = "workers:registry"
-WORKER_HEARTBEAT_TTL = 180
+logger = logging.getLogger(__name__)
 
 r = get_redis_connection("default")
 
 
+# consumers.py
 def _load_snapshot():
     raw = r.hgetall(WORKERS_REGISTRY_KEY)
     workers = []
+    private_workers = []
     now = time.time()
     for _, value in raw.items():
         try:
             worker = json.loads(value)
         except Exception:
             continue
-        last_seen = worker.get("last_seen", 0)
-        if now - last_seen > WORKER_HEARTBEAT_TTL:
+        if now - worker.get("last_seen", 0) > WORKER_HEARTBEAT_TTL:
             continue
-        workers.append(worker)
-    workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
-    return workers
+        if worker.get("queue_source") == "default":
+            workers.append(worker)
+        else:
+            private_workers.append(worker)
+    workers.sort(key=lambda x: x.get("hostname", ""))
+    private_workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
+    return workers, private_workers
 
 
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
@@ -40,11 +44,13 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             await self.close()
             return
         await self.accept()
+        await self.channel_layer.group_add("compute_workers", self.channel_name)
         self._running = True
         self._task = asyncio.create_task(self._push_workers_loop())
 
     async def disconnect(self, close_code):
         self._running = False
+        await self.channel_layer.group_discard("compute_workers", self.channel_name)
         task = getattr(self, "_task", None)
         if task:
             task.cancel()
@@ -56,13 +62,14 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def _push_workers_loop(self):
         try:
             while self._running:
-                workers = await sync_to_async(_load_snapshot)()
+                workers, private_workers = await sync_to_async(_load_snapshot)()
                 if not self._running:
                     break
                 try:
                     await self.send_json({
                         "type": "workers.snapshot",
                         "workers": workers,
+                        "private_workers": private_workers,
                     })
                 except RuntimeError:
                     break

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -1,185 +1,81 @@
 import asyncio
+import json
 import logging
 import time
 
-import urllib
+from django_redis import get_redis_connection
 
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from queues.models import Queue
-from celery_config import app as celery_app, app_for_vhost
 
 logger = logging.getLogger(__name__)
 
+WORKERS_REGISTRY_KEY = "workers:registry"
+WORKER_HEARTBEAT_TTL = 35
 
-def _extract_queue_names(active_queues):
-    names = set()
-    for q in active_queues or []:
-        if isinstance(q, dict) and q.get("name"):
-            names.add(q["name"])
-    return names
+r = get_redis_connection("default")
 
 
-def _known_compute_queue_names():
-    return set(
-        Queue.objects.exclude(name__isnull=True)
-        .exclude(name="")
-        .values_list("name", flat=True)
-    )
-
-
-def _is_compute_worker(worker_name, queue_names, known_queue_names):
-    return (
-        bool(queue_names & known_queue_names)
-        or "compute-worker" in queue_names
-        or worker_name.startswith("compute-worker")
-        or worker_name.startswith("CW")
-    )
-
-
-def _get_broker_host(broker_url):
-    if not broker_url or "@" not in broker_url:
-        return None
-    try:
-        return broker_url.split("@", 1)[1].split("/", 1)[0].split(":", 1)[0]
-    except Exception:
-        return None
-
-
-def _resolve_broker_url(celery_app, broker_url):
-    if not broker_url:
-        return broker_url
-
-    if "@localhost:" not in broker_url:
-        return broker_url
-
-    default_broker = getattr(celery_app.conf, "broker_url", None)
-    default_host = _get_broker_host(default_broker)
-
-    if not default_host or default_host == "localhost":
-        return broker_url
-
-    return broker_url.replace("@localhost:", f"@{default_host}:")
+def _load_snapshot():
+    raw = r.hgetall(WORKERS_REGISTRY_KEY)
+    workers = []
+    now = time.time()
+    for _, value in raw.items():
+        try:
+            worker = json.loads(value)
+        except Exception:
+            continue
+        # Filtrer les workers dont le heartbeat est trop vieux
+        last_seen = worker.get("last_seen", 0)
+        if now - last_seen > WORKER_HEARTBEAT_TTL:
+            continue
+        workers.append(worker)
+    workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
+    return workers
 
 
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         user = self.scope.get("user")
-
         if user is None or user.is_anonymous:
             await self.close()
             return
-
         await self.accept()
         self._running = True
         self._task = asyncio.create_task(self._push_workers_loop())
 
     async def disconnect(self, close_code):
         self._running = False
-
         task = getattr(self, "_task", None)
         if task:
             task.cancel()
             try:
                 await task
-            except asyncio.CancelledError:
-                pass
-            except RuntimeError:
+            except (asyncio.CancelledError, RuntimeError):
                 pass
 
     async def _push_workers_loop(self):
         try:
             while self._running:
-                workers = await sync_to_async(
-                    self._load_snapshot, thread_sensitive=True
-                )()
-
+                workers = await sync_to_async(_load_snapshot)()
                 if not self._running:
                     break
-
                 try:
-                    await self.send_json(
-                        {
-                            "type": "workers.snapshot",
-                            "workers": workers,
-                        }
-                    )
+                    await self.send_json({
+                        "type": "workers.snapshot",
+                        "workers": workers,
+                    })
                 except RuntimeError:
                     break
-
                 await asyncio.sleep(3)
-
         except asyncio.CancelledError:
             pass
 
-    def _load_snapshot(self):
-        known_queue_names = _known_compute_queue_names()
-        workers = []
-        seen = set()
-        inspected_brokers = set()
-        broker_sources = []
-
-        # Broker par défaut : l'app principale déjà configurée
-        broker_sources.append(("default", celery_app.conf.broker_url, celery_app))
-
-        # Brokers privés : utiliser app_for_vhost comme le reste du code
-        private_queues = (
-            Queue.objects.filter(competitions__isnull=False)
-            .exclude(name__isnull=True)
-            .exclude(name="")
-            .distinct()
-        )
-        for queue in private_queues:
-            if not queue.broker_url:
-                continue
-            # Extraire le vhost de l'URL de la queue
-            parsed = urllib.parse.urlparse(queue.broker_url)
-            vhost = parsed.path  # ex: "/0475fa69-6c4f-4de6-992b-dafa6899211b"
-            broker_url = urllib.parse.urljoin(celery_app.conf.broker_url, vhost)
-            if broker_url in inspected_brokers:
-                continue
-            broker_sources.append((queue.name, broker_url, app_for_vhost(vhost)))
-
-        for source_name, broker_url, broker_app in broker_sources:
-            if broker_url in inspected_brokers:
-                continue
-            inspected_brokers.add(broker_url)
-
-            try:
-                inspector = broker_app.control.inspect(timeout=10)
-                stats = inspector.stats() or {}
-                active = inspector.active() or {}
-                reserved = inspector.reserved() or {}
-                active_queues = inspector.active_queues() or {}
-            except Exception:
-                logger.exception(
-                    "Unable to inspect Celery workers for broker %s", source_name
-                )
-                continue
-
-            for worker_name in stats.keys():
-                queues = active_queues.get(worker_name, []) or []
-                queue_names = _extract_queue_names(queues)
-                if not _is_compute_worker(worker_name, queue_names, known_queue_names):
-                    continue
-                unique_key = (source_name, worker_name)
-                if unique_key in seen:
-                    continue
-                seen.add(unique_key)
-
-                running_jobs = len(active.get(worker_name, [])) + len(
-                    reserved.get(worker_name, [])
-                )
-                workers.append(
-                    {
-                        "hostname": worker_name,
-                        "status": "busy" if running_jobs > 0 else "available",
-                        "running_jobs": running_jobs,
-                        "timestamp": time.time(),
-                        "queue_source": source_name,
-                        "queue_names": sorted(queue_names),
-                    }
-                )
-
-        workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
-        return workers
+    async def worker_health(self, event):
+        try:
+            await self.send_json({
+                "type": "workers.snapshot",
+                "workers": [event["worker"]],
+            })
+        except RuntimeError:
+            pass

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -20,7 +20,7 @@ def _extract_queue_names(active_queues):
 
 def _known_compute_queue_names():
     return set(
-        Queue.objects.exclude(name__isnull=False)
+        Queue.objects.exclude(name__isnull=True)
         .exclude(name="")
         .values_list("name", flat=True)
     )
@@ -111,13 +111,11 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     def _load_snapshot(self):
         celery_app = app_or_default()
         known_queue_names = _known_compute_queue_names()
-
         workers = []
         seen = set()
         inspected_brokers = set()
 
         broker_sources = []
-
         default_broker = getattr(celery_app.conf, "broker_url", None)
         if default_broker:
             broker_sources.append(("default", default_broker))
@@ -128,7 +126,6 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             .exclude(name="")
             .distinct()
         )
-
         for queue in private_queues:
             broker_url = _resolve_broker_url(celery_app, queue.broker_url)
             if broker_url:
@@ -139,44 +136,48 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 continue
             inspected_brokers.add(broker_url)
 
+            broker_app = celery_app.__class__(
+                "compute-worker-monitor",
+                broker=broker_url,
+            )
+            # Timeout de connexion court + pas de retry pour ne pas bloquer le WS
+            broker_app.conf.update(
+                broker_connection_timeout=2,
+                broker_connection_retry=False,
+                broker_connection_max_retries=0,
+            )
             try:
-                broker_app = celery_app.__class__(
-                    "compute-worker-monitor",
-                    broker=broker_url,
-                )
-
                 inspector = broker_app.control.inspect(timeout=2)
-
                 if inspector is None:
                     continue
-
                 stats = inspector.stats() or {}
                 active = inspector.active() or {}
                 reserved = inspector.reserved() or {}
                 active_queues = inspector.active_queues() or {}
-
             except Exception:
                 logger.exception(
                     "Unable to inspect Celery workers for broker %s",
                     source_name,
                 )
                 continue
+            finally:
+                # Toujours libérer les ressources, même en cas d'erreur
+                try:
+                    broker_app.close()
+                except Exception:
+                    pass
 
             for worker_name in stats.keys():
                 queues = active_queues.get(worker_name, []) or []
                 queue_names = _extract_queue_names(queues)
-
                 if not _is_compute_worker(worker_name, queue_names, known_queue_names):
                     continue
-
                 unique_key = (source_name, worker_name)
                 if unique_key in seen:
                     continue
                 seen.add(unique_key)
-
                 running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
                 status = "busy" if running_jobs > 0 else "available"
-
                 workers.append(
                     {
                         "hostname": worker_name,

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -79,9 +79,8 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             if not is_compute_worker:
                 continue
 
-            running_jobs = (
-                len(active.get(worker_name, []))
-                + len(reserved.get(worker_name, []))
+            running_jobs = len(active.get(worker_name, [])) + len(
+                reserved.get(worker_name, [])
             )
             status = "busy" if running_jobs > 0 else "available"
 

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -1,11 +1,10 @@
 import asyncio
+import logging
 import time
 
 from asgiref.sync import sync_to_async
-from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from celery._state import app_or_default
-
-import logging
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -2,11 +2,12 @@ import asyncio
 import logging
 import time
 
+import urllib
+
 from asgiref.sync import sync_to_async
-from celery._state import app_or_default
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from kombu import Connection
 from queues.models import Queue
+from celery_config import app as celery_app, app_for_vhost
 
 logger = logging.getLogger(__name__)
 
@@ -112,17 +113,16 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             pass
 
     def _load_snapshot(self):
-        celery_app = app_or_default()
         known_queue_names = _known_compute_queue_names()
         workers = []
         seen = set()
         inspected_brokers = set()
         broker_sources = []
 
-        default_broker = getattr(celery_app.conf, "broker_url", None)
-        if default_broker:
-            broker_sources.append(("default", default_broker))
+        # Broker par défaut : l'app principale déjà configurée
+        broker_sources.append(("default", celery_app.conf.broker_url, celery_app))
 
+        # Brokers privés : utiliser app_for_vhost comme le reste du code
         private_queues = (
             Queue.objects.filter(competitions__isnull=False)
             .exclude(name__isnull=True)
@@ -130,72 +130,32 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             .distinct()
         )
         for queue in private_queues:
-            broker_url = _resolve_broker_url(celery_app, queue.broker_url)
-            if broker_url:
-                broker_sources.append((queue.name, broker_url))
+            if not queue.broker_url:
+                continue
+            # Extraire le vhost de l'URL de la queue
+            parsed = urllib.parse.urlparse(queue.broker_url)
+            vhost = parsed.path  # ex: "/0475fa69-6c4f-4de6-992b-dafa6899211b"
+            broker_url = urllib.parse.urljoin(celery_app.conf.broker_url, vhost)
+            if broker_url in inspected_brokers:
+                continue
+            broker_sources.append((queue.name, broker_url, app_for_vhost(vhost)))
 
-        for source_name, broker_url in broker_sources:
+        for source_name, broker_url, broker_app in broker_sources:
             if broker_url in inspected_brokers:
                 continue
             inspected_brokers.add(broker_url)
 
-            broker_app = celery_app.__class__(
-                "compute-worker-monitor",
-                broker=broker_url,
-            )
-            broker_app.conf.update(
-                broker_connection_retry=False,
-                broker_connection_max_retries=0,
-            )
-
-            conn = Connection(
-                broker_url,
-                connect_timeout=10,
-                socket_timeout=10,
-            )
             try:
-                conn.ensure_connection(max_retries=1, timeout=10)
-            except Exception:
-                logger.warning(
-                    "Cannot connect to broker %s (%s), skipping",
-                    source_name,
-                    broker_url,
-                )
-                try:
-                    conn.release()
-                except Exception:
-                    pass
-                try:
-                    broker_app.close()
-                except Exception:
-                    pass
-                continue
-
-            try:
-                inspector = broker_app.control.inspect(timeout=10, connection=conn)
-                if inspector is None:
-                    continue
-
+                inspector = broker_app.control.inspect(timeout=10)
                 stats = inspector.stats() or {}
                 active = inspector.active() or {}
                 reserved = inspector.reserved() or {}
                 active_queues = inspector.active_queues() or {}
-
             except Exception:
                 logger.exception(
-                    "Unable to inspect Celery workers for broker %s",
-                    source_name,
+                    "Unable to inspect Celery workers for broker %s", source_name
                 )
                 continue
-            finally:
-                try:
-                    conn.release()
-                except Exception:
-                    pass
-                try:
-                    broker_app.close()
-                except Exception:
-                    pass
 
             for worker_name in stats.keys():
                 queues = active_queues.get(worker_name, []) or []
@@ -210,11 +170,10 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 running_jobs = len(active.get(worker_name, [])) + len(
                     reserved.get(worker_name, [])
                 )
-                status = "busy" if running_jobs > 0 else "available"
                 workers.append(
                     {
                         "hostname": worker_name,
-                        "status": status,
+                        "status": "busy" if running_jobs > 0 else "available",
                         "running_jobs": running_jobs,
                         "timestamp": time.time(),
                         "queue_source": source_name,

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -35,6 +35,31 @@ def _is_compute_worker(worker_name, queue_names, known_queue_names):
     )
 
 
+def _get_broker_host(broker_url):
+    if not broker_url or "@" not in broker_url:
+        return None
+    try:
+        return broker_url.split("@", 1)[1].split("/", 1)[0].split(":", 1)[0]
+    except Exception:
+        return None
+
+
+def _resolve_broker_url(celery_app, broker_url):
+    if not broker_url:
+        return broker_url
+
+    if "@localhost:" not in broker_url:
+        return broker_url
+
+    default_broker = getattr(celery_app.conf, "broker_url", None)
+    default_host = _get_broker_host(default_broker)
+
+    if not default_host or default_host == "localhost":
+        return broker_url
+
+    return broker_url.replace("@localhost:", f"@{default_host}:")
+
+
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         user = self.scope.get("user")
@@ -57,55 +82,111 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 await task
             except asyncio.CancelledError:
                 pass
+            except RuntimeError:
+                pass
 
     async def _push_workers_loop(self):
-        while self._running:
-            workers = await sync_to_async(self._load_snapshot)()
-            await self.send_json(
-                {
-                    "type": "workers.snapshot",
-                    "workers": workers,
-                }
-            )
-            await asyncio.sleep(3)
+        try:
+            while self._running:
+                workers = await sync_to_async(self._load_snapshot, thread_sensitive=True)()
+
+                if not self._running:
+                    break
+
+                try:
+                    await self.send_json(
+                        {
+                            "type": "workers.snapshot",
+                            "workers": workers,
+                        }
+                    )
+                except RuntimeError:
+                    break
+
+                await asyncio.sleep(3)
+
+        except asyncio.CancelledError:
+            pass
 
     def _load_snapshot(self):
         celery_app = app_or_default()
-        inspector = celery_app.control.inspect(timeout=2)
-
-        if inspector is None:
-            return []
-
-        try:
-            stats = inspector.stats() or {}
-            active = inspector.active() or {}
-            reserved = inspector.reserved() or {}
-            active_queues = inspector.active_queues() or {}
-        except Exception:
-            logger.exception("Unable to inspect Celery workers")
-            return []
-
         known_queue_names = _known_compute_queue_names()
+
         workers = []
+        seen = set()
+        inspected_brokers = set()
 
-        for worker_name in stats.keys():
-            queues = active_queues.get(worker_name, []) or []
-            queue_names = _extract_queue_names(queues)
+        broker_sources = []
 
-            if not _is_compute_worker(worker_name, queue_names, known_queue_names):
+        default_broker = getattr(celery_app.conf, "broker_url", None)
+        if default_broker:
+            broker_sources.append(("default", default_broker))
+
+        private_queues = (
+            Queue.objects.filter(competitions__isnull=False)
+            .exclude(name__isnull=True)
+            .exclude(name="")
+            .distinct()
+        )
+
+        for queue in private_queues:
+            broker_url = _resolve_broker_url(celery_app, queue.broker_url)
+            if broker_url:
+                broker_sources.append((queue.name, broker_url))
+
+        for source_name, broker_url in broker_sources:
+            if broker_url in inspected_brokers:
+                continue
+            inspected_brokers.add(broker_url)
+
+            try:
+                broker_app = celery_app.__class__(
+                    "compute-worker-monitor",
+                    broker=broker_url,
+                )
+
+                inspector = broker_app.control.inspect(timeout=2)
+
+                if inspector is None:
+                    continue
+
+                stats = inspector.stats() or {}
+                active = inspector.active() or {}
+                reserved = inspector.reserved() or {}
+                active_queues = inspector.active_queues() or {}
+
+            except Exception:
+                logger.exception(
+                    "Unable to inspect Celery workers for broker %s",
+                    source_name,
+                )
                 continue
 
-            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
-            status = "busy" if running_jobs > 0 else "available"
+            for worker_name in stats.keys():
+                queues = active_queues.get(worker_name, []) or []
+                queue_names = _extract_queue_names(queues)
 
-            workers.append(
-                {
-                    "hostname": worker_name,
-                    "status": status,
-                    "running_jobs": running_jobs,
-                    "timestamp": time.time(),
-                    "queue_names": sorted(queue_names),
-                }
-            )
+                if not _is_compute_worker(worker_name, queue_names, known_queue_names):
+                    continue
 
+                unique_key = (source_name, worker_name)
+                if unique_key in seen:
+                    continue
+                seen.add(unique_key)
+
+                running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+                status = "busy" if running_jobs > 0 else "available"
+
+                workers.append(
+                    {
+                        "hostname": worker_name,
+                        "status": status,
+                        "running_jobs": running_jobs,
+                        "timestamp": time.time(),
+                        "queue_source": source_name,
+                        "queue_names": sorted(queue_names),
+                    }
+                )
+
+        workers.sort(key=lambda x: (x.get("queue_source", ""), x.get("hostname", "")))
         return workers

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -25,7 +25,6 @@ def _load_snapshot():
             worker = json.loads(value)
         except Exception:
             continue
-        # Filtrer les workers dont le heartbeat est trop vieux
         last_seen = worker.get("last_seen", 0)
         if now - last_seen > WORKER_HEARTBEAT_TTL:
             continue

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -117,8 +117,8 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
         workers = []
         seen = set()
         inspected_brokers = set()
-
         broker_sources = []
+
         default_broker = getattr(celery_app.conf, "broker_url", None)
         if default_broker:
             broker_sources.append(("default", default_broker))
@@ -154,13 +154,33 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 socket_timeout=10,
             )
             try:
-                inspector = broker_app.control.inspect(timeout=2, connection=conn)
+                conn.ensure_connection(max_retries=1, timeout=10)
+            except Exception:
+                logger.warning(
+                    "Cannot connect to broker %s (%s), skipping",
+                    source_name,
+                    broker_url,
+                )
+                try:
+                    conn.release()
+                except Exception:
+                    pass
+                try:
+                    broker_app.close()
+                except Exception:
+                    pass
+                continue
+
+            try:
+                inspector = broker_app.control.inspect(timeout=10, connection=conn)
                 if inspector is None:
                     continue
+
                 stats = inspector.stats() or {}
                 active = inspector.active() or {}
                 reserved = inspector.reserved() or {}
                 active_queues = inspector.active_queues() or {}
+
             except Exception:
                 logger.exception(
                     "Unable to inspect Celery workers for broker %s",
@@ -186,6 +206,7 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 if unique_key in seen:
                     continue
                 seen.add(unique_key)
+
                 running_jobs = len(active.get(worker_name, [])) + len(
                     reserved.get(worker_name, [])
                 )

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -5,22 +5,33 @@ from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from celery._state import app_or_default
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
-        user = self.scope["user"]
+        user = self.scope.get("user")
 
         if user is None or user.is_anonymous:
             await self.close()
             return
+
         await self.accept()
         self._running = True
         self._task = asyncio.create_task(self._push_workers_loop())
 
     async def disconnect(self, close_code):
         self._running = False
-        if hasattr(self, "_task"):
-            self._task.cancel()
+
+        task = getattr(self, "_task", None)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def _push_workers_loop(self):
         while self._running:
@@ -46,6 +57,7 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             reserved = inspector.reserved() or {}
             active_queues = inspector.active_queues() or {}
         except Exception:
+            logger.exception("Unable to inspect Celery workers")
             return []
 
         workers = []
@@ -53,6 +65,7 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
         for worker_name in stats.keys():
             queues = active_queues.get(worker_name, []) or []
             queue_names = []
+
             for q in queues:
                 if isinstance(q, dict) and q.get("name"):
                     queue_names.append(q["name"])
@@ -66,8 +79,9 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             if not is_compute_worker:
                 continue
 
-            running_jobs = len(active.get(worker_name, [])) + len(
-                reserved.get(worker_name, [])
+            running_jobs = (
+                len(active.get(worker_name, []))
+                + len(reserved.get(worker_name, []))
             )
             status = "busy" if running_jobs > 0 else "available"
 

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -5,6 +5,7 @@ import time
 from asgiref.sync import sync_to_async
 from celery._state import app_or_default
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from kombu import Connection
 from queues.models import Queue
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,9 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def _push_workers_loop(self):
         try:
             while self._running:
-                workers = await sync_to_async(self._load_snapshot, thread_sensitive=True)()
+                workers = await sync_to_async(
+                    self._load_snapshot, thread_sensitive=True
+                )()
 
                 if not self._running:
                     break
@@ -140,14 +143,18 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 "compute-worker-monitor",
                 broker=broker_url,
             )
-            # Timeout de connexion court + pas de retry pour ne pas bloquer le WS
             broker_app.conf.update(
-                broker_connection_timeout=2,
                 broker_connection_retry=False,
                 broker_connection_max_retries=0,
             )
+
+            conn = Connection(
+                broker_url,
+                connect_timeout=10,
+                socket_timeout=10,
+            )
             try:
-                inspector = broker_app.control.inspect(timeout=2)
+                inspector = broker_app.control.inspect(timeout=2, connection=conn)
                 if inspector is None:
                     continue
                 stats = inspector.stats() or {}
@@ -161,7 +168,10 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 )
                 continue
             finally:
-                # Toujours libérer les ressources, même en cas d'erreur
+                try:
+                    conn.release()
+                except Exception:
+                    pass
                 try:
                     broker_app.close()
                 except Exception:
@@ -176,7 +186,9 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
                 if unique_key in seen:
                     continue
                 seen.add(unique_key)
-                running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+                running_jobs = len(active.get(worker_name, [])) + len(
+                    reserved.get(worker_name, [])
+                )
                 status = "busy" if running_jobs > 0 else "available"
                 workers.append(
                     {

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -1,0 +1,72 @@
+import asyncio
+import time
+
+from asgiref.sync import sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from celery._state import app_or_default
+
+
+class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        await self.accept()
+        self._running = True
+        self._task = asyncio.create_task(self._push_workers_loop())
+
+    async def disconnect(self, close_code):
+        self._running = False
+        if hasattr(self, "_task"):
+            self._task.cancel()
+
+    async def _push_workers_loop(self):
+        while self._running:
+            workers = await sync_to_async(self._load_snapshot)()
+            await self.send_json({
+                "type": "workers.snapshot",
+                "workers": workers,
+            })
+            await asyncio.sleep(3)
+
+    def _load_snapshot(self):
+        celery_app = app_or_default()
+        inspector = celery_app.control.inspect(timeout=2)
+
+        if inspector is None:
+            return []
+
+        try:
+            stats = inspector.stats() or {}
+            active = inspector.active() or {}
+            reserved = inspector.reserved() or {}
+            active_queues = inspector.active_queues() or {}
+        except Exception:
+            return []
+
+        workers = []
+
+        for worker_name in stats.keys():
+            queues = active_queues.get(worker_name, []) or []
+            queue_names = []
+            for q in queues:
+                if isinstance(q, dict) and q.get("name"):
+                    queue_names.append(q["name"])
+
+            is_compute_worker = (
+                "compute-worker" in queue_names
+                or worker_name.startswith("compute-worker")
+                or worker_name.startswith("CW")
+            )
+
+            if not is_compute_worker:
+                continue
+
+            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+            status = "busy" if running_jobs > 0 else "available"
+
+            workers.append({
+                "hostname": worker_name,
+                "status": status,
+                "running_jobs": running_jobs,
+                "timestamp": time.time(),
+            })
+
+        return workers

--- a/src/utils/consumers.py
+++ b/src/utils/consumers.py
@@ -25,10 +25,12 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
     async def _push_workers_loop(self):
         while self._running:
             workers = await sync_to_async(self._load_snapshot)()
-            await self.send_json({
-                "type": "workers.snapshot",
-                "workers": workers,
-            })
+            await self.send_json(
+                {
+                    "type": "workers.snapshot",
+                    "workers": workers,
+                }
+            )
             await asyncio.sleep(3)
 
     def _load_snapshot(self):
@@ -64,14 +66,18 @@ class ComputeWorkersConsumer(AsyncJsonWebsocketConsumer):
             if not is_compute_worker:
                 continue
 
-            running_jobs = len(active.get(worker_name, [])) + len(reserved.get(worker_name, []))
+            running_jobs = len(active.get(worker_name, [])) + len(
+                reserved.get(worker_name, [])
+            )
             status = "busy" if running_jobs > 0 else "available"
 
-            workers.append({
-                "hostname": worker_name,
-                "status": status,
-                "running_jobs": running_jobs,
-                "timestamp": time.time(),
-            })
+            workers.append(
+                {
+                    "hostname": worker_name,
+                    "status": status,
+                    "running_jobs": running_jobs,
+                    "timestamp": time.time(),
+                }
+            )
 
         return workers

--- a/src/utils/worker_utils.py
+++ b/src/utils/worker_utils.py
@@ -1,4 +1,4 @@
-from queue import Queue
+from queues.models import Queue
 
 
 def extract_queue_names(active_queues):
@@ -22,5 +22,4 @@ def is_compute_worker(worker_name, queue_names, known_queue_names):
         bool(queue_names & known_queue_names)
         or "compute-worker" in queue_names
         or worker_name.startswith("compute-worker")
-        or worker_name.startswith("CW")
     )

--- a/src/utils/worker_utils.py
+++ b/src/utils/worker_utils.py
@@ -1,5 +1,8 @@
 from queues.models import Queue
 
+WORKERS_REGISTRY_KEY = "workers:registry"
+WORKER_HEARTBEAT_TTL = 180
+
 
 def extract_queue_names(active_queues):
     names = set()

--- a/src/utils/worker_utils.py
+++ b/src/utils/worker_utils.py
@@ -1,0 +1,26 @@
+from queue import Queue
+
+
+def extract_queue_names(active_queues):
+    names = set()
+    for q in active_queues or []:
+        if isinstance(q, dict) and q.get("name"):
+            names.add(q["name"])
+    return names
+
+
+def known_compute_queue_names():
+    return set(
+        Queue.objects.exclude(name__isnull=True)
+        .exclude(name="")
+        .values_list("name", flat=True)
+    )
+
+
+def is_compute_worker(worker_name, queue_names, known_queue_names):
+    return (
+        bool(queue_names & known_queue_names)
+        or "compute-worker" in queue_names
+        or worker_name.startswith("compute-worker")
+        or worker_name.startswith("CW")
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -435,6 +435,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "pyyaml" },
+    { name = "redis-cli" },
     { name = "requests" },
     { name = "s3transfer" },
     { name = "setuptools" },
@@ -506,6 +507,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = "==2.9.0" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "redis-cli", specifier = ">=1.0.1" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "s3transfer", specifier = "==0.16.0" },
     { name = "setuptools", specifier = "==82.0.0" },
@@ -1660,6 +1662,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
+name = "redis-cli"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/7a/464077bce2a14cd8399776ae0c694e7c240b58ffe4b231413013f2fb48fe/redis-cli-1.0.1.tar.gz", hash = "sha256:6be46d8e6ae638fec27cb425d499b7f25b1592402c74d5d17f5b85b5e7f988a0", size = 5958, upload-time = "2023-10-02T05:58:36.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/29/33cbdafefd22613cc003f837b6f0295462b2e91696180f06c5210f576a1b/redis_cli-1.0.1-py3-none-any.whl", hash = "sha256:e9f6af4a8b7591d8bfd1e23be89bdd9666ce824df881748fb02b88dd30575dc8", size = 5851, upload-time = "2023-10-02T05:58:32.924Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,28 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
 name = "blessed"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +393,7 @@ dependencies = [
     { name = "argh" },
     { name = "azure-storage-blob" },
     { name = "azure-storage-common" },
+    { name = "black" },
     { name = "blessings" },
     { name = "boto3" },
     { name = "botocore" },
@@ -441,6 +464,7 @@ requires-dist = [
     { name = "argh", specifier = "==0.31.3" },
     { name = "azure-storage-blob", specifier = ">=12,<13" },
     { name = "azure-storage-common", specifier = "==2.1.0" },
+    { name = "black", specifier = ">=26.3.1" },
     { name = "blessings", specifier = "==1.7" },
     { name = "boto3", specifier = "==1.42.50" },
     { name = "botocore", specifier = "==1.42.50" },
@@ -1273,6 +1297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nh3"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1336,6 +1369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1420,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
     { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
     { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
 ]
 
 [[package]]
@@ -1550,6 +1601,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/4a/29feb8da6c44f77007dcd29518fea73a3d5653ee02a587ae1f17f1f5ddb5/python3-openid-3.2.0.tar.gz", hash = "sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf", size = 305600, upload-time = "2020-06-29T12:15:49.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a5/c6ba13860bdf5525f1ab01e01cc667578d6f1efc8a1dba355700fb04c29b/python3_openid-3.2.0-py3-none-any.whl", hash = "sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b", size = 133681, upload-time = "2020-06-29T12:15:47.502Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# @ mention of reviewers
@ObadaS 
@Didayolo 
@ihsaan-ullah 

# A brief description of the purpose of the changes contained in this PR.
This feature enables admin users, competition organizers and his/her collaborators to monitor compute worker activity (only default one for now).

Lastly added: 
Feature available only for competition organizers and collaborators.
Disabled by default and hided behind button by default (top / right).
When disabled or hided behind the button, the websocket connection is disabled for performance.
The Button needs to be behind the user menu. 

/!\ Deployed on Partages instance so you can try it live. /!\ 

<img width="787" height="395" alt="image" src="https://github.com/user-attachments/assets/7d374ff5-c8c4-4a9c-952c-0d56cf268b51" />

<img width="460" height="737" alt="image" src="https://github.com/user-attachments/assets/592b55cb-5012-4e90-a54e-ea9d343316a6" />

# Issues this PR resolves
Enables organizers to monitor compute workers activity to push them to use their own workers in case of high activity on codabench public compute workers.

# A checklist for hand testing
- [x] Try the panel as a organizer, you should be able to see it by pressing the button.
- [x] Submit and watch if the panel shows the activity of the compute worker
- [x] Verify websocket state when the panel is not displayed, the connection should be deactivated. 


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

