### PR TITLE
Ignore flake8 rule W503

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E501,F405,W504,F541
+ignore = E501,F405,W504,F541,W503
 
 # Flake plugins:
 inline-quotes = single


### PR DESCRIPTION
Rule W503 is "line break before binary operator", and typically raise an error for syntax like this:

```python
is_compute_worker = ( 
        "compute-worker" in queue_names 
        or worker_name.startswith("compute-worker") 
        or worker_name.startswith("CW")
 )

Which is actually fine.