### PR TITLE
Put back flake8 rules F405 and F541

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E501,F405,W504,F541,W503
+ignore = E501,W504,W503
 
 # Flake plugins:
 inline-quotes = single

--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -348,7 +348,7 @@ class SubmissionViewSet(ModelViewSet):
         submission = self.get_object()
         if not self.has_admin_permission(request.user, submission):
             if submission.owner != request.user:
-                raise PermissionDenied(f'You do not have permission to cancel submissions')
+                raise PermissionDenied('You do not have permission to cancel submissions')
         for child in submission.children.all():
             child.cancel()
         canceled = submission.cancel()

--- a/src/apps/api/views/tasks.py
+++ b/src/apps/api/views/tasks.py
@@ -236,15 +236,15 @@ class TaskViewSet(ModelViewSet):
 
                     # Check if task has a name
                     if "name" not in task_data:
-                        return Response({"error": f"Missing: name, task must have a name"}, status=status.HTTP_400_BAD_REQUEST)
+                        return Response({"error": "Missing: name, task must have a name"}, status=status.HTTP_400_BAD_REQUEST)
 
                     # Check if task has a description
                     if "description" not in task_data:
-                        return Response({"error": f"Missing: description, task must have a description"}, status=status.HTTP_400_BAD_REQUEST)
+                        return Response({"error": "Missing: description, task must have a description"}, status=status.HTTP_400_BAD_REQUEST)
 
                     # Check if task has a scoring program
                     if Data.SCORING_PROGRAM not in task_data:
-                        return Response({"error": f"Missing: scoring_program, task must have a scoring_program"}, status=status.HTTP_400_BAD_REQUEST)
+                        return Response({"error": "Missing: scoring_program, task must have a scoring_program"}, status=status.HTTP_400_BAD_REQUEST)
 
                     # ------------------------------
                     # Process datasets and programs

--- a/src/apps/commands/management/commands/upload_backup.py
+++ b/src/apps/commands/management/commands/upload_backup.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         resp = put_blob(upload_url, backup_path)
 
         if resp.status_code == 200:
-            print(f"Success!")
+            print("Success!")
         else:
             print(f"FAILED TO SEND! Result ({resp.status_code}):\n{resp.content}")
 

--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -375,9 +375,9 @@ class Phase(models.Model):
                 self.competition.apply_phase_migration(current_phase, next_phase)
 
         except next_phase.DoesNotExist:
-            logger.error(f"This competition is missing the next phase to migrate to.")
+            logger.error("This competition is missing the next phase to migrate to.")
         except current_phase.DoesNotExist:
-            logger.error(f"This competition is missing the previous phase to migrate from.")
+            logger.error("This competition is missing the previous phase to migrate from.")
 
 
 class PhaseTaskInstance(models.Model):

--- a/src/apps/competitions/unpackers/v2.py
+++ b/src/apps/competitions/unpackers/v2.py
@@ -204,7 +204,7 @@ class V2Unpacker(BaseUnpacker):
             try:
                 new_phase['tasks'] = phase_data['tasks']
             except KeyError:
-                raise CompetitionUnpackingException(f'Phases must contain at least one task to be valid')
+                raise CompetitionUnpackingException('Phases must contain at least one task to be valid')
 
             execution_time_limit = phase_data.get('execution_time_limit')
             if execution_time_limit:

--- a/src/apps/profiles/views.py
+++ b/src/apps/profiles/views.py
@@ -94,15 +94,15 @@ def activate(request, uidb64, token):
         user = User.objects.get(pk=uid)
     except User.DoesNotExist:
         user = None
-        messages.error(request, f"User not found. Please sign up again.")
+        messages.error(request, "User not found. Please sign up again.")
         return redirect('accounts:signup')
     if user is not None and account_activation_token.check_token(user, token):
         user.is_active = True
         user.save()
-        messages.success(request, f'Your account is fully setup! Please login.')
+        messages.success(request, "Your account is fully setup! Please login.")
         return redirect('accounts:login')
     else:
-        messages.error(request, f"Activation link is invalid or expired. Please double check your link.")
+        messages.error(request, "Activation link is invalid or expired. Please double check your link.")
         return redirect('accounts:resend_activation')
     return redirect('pages:home')
 
@@ -134,7 +134,7 @@ def send_delete_account_confirmation_mail(request, user):
     }
     codalab_send_mail(
         context_data=context,
-        subject=f'Confirm Your Account Deletion Request',
+        subject="Confirm Your Account Deletion Request",
         html_file="profiles/emails/template_delete_account.html",
         text_file="profiles/emails/template_delete_account.txt",
         to_email=[user.email]
@@ -181,7 +181,7 @@ def send_user_deletion_notice_to_admin(user):
 def send_user_deletion_confirmed(email):
     codalab_send_mail(
         context_data={},
-        subject=f'Codabench: your account has been successfully removed',
+        subject="Codabench: your account has been successfully removed",
         html_file="profiles/emails/template_delete_account_confirmed.html",
         text_file="profiles/emails/template_delete_account_confirmed.txt",
         to_email=[email]
@@ -194,15 +194,15 @@ def delete(request, uidb64, token):
         user = User.objects.get(pk=uid)
     except User.DoesNotExist:
         user = None
-        messages.error(request, f"User not found.")
+        messages.error(request, "User not found.")
         return redirect('accounts:user_account')
     if user is not None and account_deletion_token.check_token(user, token):
         # Soft delete the user
         user.delete()
-        messages.success(request, f'Your account has been removed!')
+        messages.success(request, "Your account has been removed!")
         return redirect('accounts:logout')
     else:
-        messages.error(request, f"Confirmation link is invalid or expired.")
+        messages.error(request, "Confirmation link is invalid or expired.")
         return redirect('pages:home')
 
 

--- a/src/settings/heroku.py
+++ b/src/settings/heroku.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlsplit
-
-from .production import *  # noqa: F401,F403
+from .production import MIDDLEWARE
+import os
 
 # Example structure:
 #   amqps://username:password@toad.rmq.cloudamqp.com/vhost

--- a/src/settings/production.py
+++ b/src/settings/production.py
@@ -1,4 +1,5 @@
-from .base import *  # noqa: F401,F403
+from .base import INSTALLED_APPS, STORAGES, MIDDLEWARE
+import os
 
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS").split(",")

--- a/src/settings/test.py
+++ b/src/settings/test.py
@@ -1,4 +1,4 @@
-from settings.base import *  # noqa: F401,F403
+from settings.base import INSTALLED_APPS, MIDDLEWARE, STORAGES
 # these noqa comments are for flake8 ignores
 
 DEBUG = True


### PR DESCRIPTION
# Description

- Rule F405: `from ... import *` may hide names.
- Rule F541: f-string without placeholders.

Removing the "ignore" for these rules to get rid of them.
Fixing the consequent warnings raised by flake8.

# Checklist
- [x] Code review by me 
- [ ] I'm proud of my work
- [ ] Tested by me
- [ ] Code review by reviewer
- [ ] Tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

