### PR TITLE
Add Ceph storage backend compatibility

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -353,7 +353,7 @@ def unpack_competition(status_pk):
             try:
                 with NamedTemporaryFile(mode="w+b") as temp_file:
                     logger.info(f"Download competition bundle: {competition_dataset.data_file.name}")
-                    competition_bundle_url = make_url_sassy(competition_dataset.data_file.url)
+                    competition_bundle_url = make_url_sassy(competition_dataset.data_file.name)
                     try:
                         with requests.get(competition_bundle_url, stream=True) as r:
                             r.raise_for_status()


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Add Ceph compatibility

You might need to run the following command to update the CORS origin and method allowed on the Ceph endpoint :
```
aws s3api put-bucket-cors \
      --bucket codabench-private \
      --cors-configuration '{
    "CORSRules": [
      {
        "AllowedOrigins": ["http://localhost"],
        "AllowedMethods": ["GET", "HEAD", "PUT"],
        "AllowedHeaders": ["*"],
        "ExposeHeaders": ["ETag"],
        "MaxAgeSeconds": 3000
      }
    ]
  }'
```

You can check the current configuration with : 
```
aws s3api get-bucket-cors --bucket codabench-private
```
You can use `aws` or any other cli which has this kind of command and supports Ceph as an endpoint

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

