### PR TITLE
fix pg_dump.py not using the new container names

### DIFF
--- a/bin/pg_dump.py
+++ b/bin/pg_dump.py
@@ -17,7 +17,7 @@ print(f"Making dump {dump_name}")
 call([
     'docker',
     'exec',
-    'codabench-db-1',
+    'db',
     'bash',
     '-c',
     f'PGPASSWORD=$DB_PASSWORD pg_dump -Fc -U $DB_USERNAME $DB_NAME > /app/backups/{dump_name}'
@@ -25,5 +25,5 @@ call([
 
 # Push/destroy dump
 call([
-    'docker', 'exec', 'codabench-django-1', 'python', 'manage.py', 'upload_backup', f'{dump_name}'
+    'docker', 'exec', 'django', 'python', 'manage.py', 'upload_backup', f'{dump_name}'
 ])


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Fix pg_dump.py not using the new container names defined in #2200 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

