### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/compute_worker/celery_config.py
+++ b/compute_worker/celery_config.py
@@ -4,7 +4,8 @@ import ssl
 broker_url = os.environ.get('BROKER_URL')
 if os.environ.get('BROKER_USE_SSL', False):
     broker_use_ssl = {
-        "cert_reqs": ssl.CERT_NONE,
+        "cert_reqs": ssl.CERT_REQUIRED,
+        "ca_certs": os.environ.get('BROKER_SSL_CA_CERTS', ssl.get_default_verify_paths().cafile),
     }
 worker_concurrency = 1
 worker_prefetch_multiplier = 1

--- a/src/apps/commands/management/commands/upload_backup.py
+++ b/src/apps/commands/management/commands/upload_backup.py
@@ -1,6 +1,6 @@
 import os
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from utils.data import make_url_sassy, put_blob
 
@@ -13,7 +13,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         backup_file_name = options['backup_path']
-        backup_path = os.path.join("/app/backups", options['backup_path'])
+        backup_root = os.path.realpath("/app/backups")
+
+        if os.path.isabs(backup_file_name):
+            raise CommandError("backup_path must be relative to /app/backups")
+
+        backup_path = os.path.realpath(os.path.join(backup_root, backup_file_name))
+        if os.path.commonpath([backup_root, backup_path]) != backup_root:
+            raise CommandError("backup_path must be relative to /app/backups")
 
         # Upload it
         upload_url = make_url_sassy(


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `compute_worker/celery_config.py:L6`

The Celery SSL configuration explicitly sets `cert_reqs` to `ssl.CERT_NONE`, which disables server certificate validation. This allows man-in-the-middle interception of broker traffic (task payloads, credentials, and control messages) when SSL is enabled.

## Solution

Require certificate validation by setting `cert_reqs` to `ssl.CERT_REQUIRED`, and provide a trusted CA bundle (`ca_certs`). Optionally configure client cert/key for mTLS. Example: `broker_use_ssl = {'cert_reqs': ssl.CERT_REQUIRED, 'ca_certs': '/path/to/ca.pem'}`.

## Changes

- `compute_worker/celery_config.py` (modified)
- `src/apps/commands/management/commands/upload_backup.py` (modified)