### PR TITLE
Cleanup leaderboard ordering and N/a scores

### DIFF
--- a/src/apps/api/serializers/leaderboards.py
+++ b/src/apps/api/serializers/leaderboards.py
@@ -1,4 +1,4 @@
-from django.db.models import Sum, Q
+from django.db.models import Sum, Q, F
 from drf_writable_nested import WritableNestedModelSerializer
 from rest_framework import serializers
 
@@ -102,7 +102,11 @@ class LeaderboardEntriesSerializer(serializers.ModelSerializer):
         # asc == colname
         primary_col = instance.columns.get(index=instance.primary_index)
         # Order first by primary column. Then order by other columns after for tie breakers.
-        ordering = [f'{"-" if primary_col.sorting == "desc" else ""}primary_col']
+        ordering = [
+            F('primary_col').desc(nulls_last=True)
+            if primary_col.sorting == 'desc'
+            else F('primary_col').asc(nulls_last=True)
+        ]
         submissions = (
             Submission.objects.filter(
                 leaderboard=instance,
@@ -114,7 +118,11 @@ class LeaderboardEntriesSerializer(serializers.ModelSerializer):
         )
         for column in instance.columns.exclude(id=primary_col.id).order_by('index'):
             col_name = f'col{column.index}'
-            ordering.append(f'{"-" if column.sorting == "desc" else ""}{col_name}')
+            ordering.append(
+                F(col_name).desc(nulls_last=True)
+                if column.sorting == 'desc'
+                else F(col_name).asc(nulls_last=True)
+            )
             kwargs = {
                 col_name: Sum('scores__score', filter=Q(scores__column__index=column.index))
             }
@@ -157,7 +165,11 @@ class LeaderboardPhaseSerializer(serializers.ModelSerializer):
         # desc == -colname
         # asc == colname
         primary_col = instance.leaderboard.columns.get(index=instance.leaderboard.primary_index)
-        ordering = [f'{"-" if primary_col.sorting == "desc" else ""}primary_col']
+        ordering = [
+            F('primary_col').desc(nulls_last=True)
+            if primary_col.sorting == 'desc'
+            else F('primary_col').asc(nulls_last=True)
+        ]
         submissions = (
             Submission.objects.filter(
                 phase=instance,
@@ -177,7 +189,11 @@ class LeaderboardPhaseSerializer(serializers.ModelSerializer):
             .order_by('index')
         ):
             col_name = f'col{column.index}'
-            ordering.append(f'{"-" if column.sorting == "desc" else ""}{col_name}')
+            ordering.append(
+                F(col_name).desc(nulls_last=True)
+                if column.sorting == 'desc'
+                else F(col_name).asc(nulls_last=True)
+            )
             kwargs = {
                 col_name: Sum('scores__score', filter=Q(scores__column__index=column.index))
             }

--- a/src/static/riot/competitions/detail/leaderboards.tag
+++ b/src/static/riot/competitions/detail/leaderboards.tag
@@ -63,7 +63,9 @@
                     { pretty_date(submission.created_when) }
                 </td>
                 <td>{submission.id}</td>
-                <td each="{ column in filtered_columns }">
+                <td each="{ column in filtered_columns }"
+                    data-sort="{ get_score_sort_value(column, submission) }"
+                    data-sort-value="{ get_score_sort_value(column, submission) }">
                     <a if="{column.title == 'Detailed Results'}" href="detailed_results/{get_detailed_result_submisison_id(column, submission)}" target="_blank" class="eye-icon-link">
                         <i class="icon grey eye eye-icon"></i>
                     </a>
@@ -227,6 +229,18 @@
             return dt.isValid ? dt.toMillis() : 0
         }
 
+        self.get_score_sort_value = function(column, submission) {
+            if (column.task_id === -1) {
+                let value = _.get(submission, 'fact_sheet_answers[' + column.key + ']')
+                return (value !== null && typeof value !== 'undefined' && value !== '') ? value : ''
+            }
+            let score = _.get(_.find(submission.scores, {
+                task_id: column.task_id,
+                column_key: column.key
+            }), 'score')
+            return (score !== null && typeof score !== 'undefined' && score !== '') ? score : ''
+        }
+
         self.bold_class = function(column, submission){
             return_class = ''
             if(column.task_id != -1){
@@ -245,7 +259,7 @@
                 return _.get(submission, 'fact_sheet_answers[' + column.key + ']', 'n/a')
             } else {
                 let score = _.get(_.find(submission.scores, {'task_id': column.task_id, 'column_key': column.key}), 'score')
-                if (score) {
+                if (score !== null && typeof score !== 'undefined' && score !== '') {
                     return score
                 }
             }


### PR DESCRIPTION
# Description

- Fix logic `if (score)` that returns `N/a` when score is 0
- Add helpers in the front-end to sort values instead of displayed strings
- Makes the back-end robust and use `nulls_last=True` filter to have N/a at the bottom of the sorting even if the rule is "descending".

# Issue the PR resolves

- Closes #2321


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

