### PR TITLE
Add update pull_policy for site_worker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,7 @@ services:
     working_dir: /app/src
     container_name: site_worker
     image: django_site-worker
+    pull_policy: never
     depends_on:
       - rabbit
       - db


### PR DESCRIPTION
# Description

Recent change in `docker-compose.yml` made the image build only for django and not site_worker (#2200).

On CircleCI, if tries to pull it instead of using the previously built image, it leads to a failure:

```python
WARN[0000] The "RABBITMQ_HTTP_PROXY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "RABBITMQ_HTTPS_PROXY" variable is not set. Defaulting to a blank string. 
WARN[0000] The "RABBITMQ_NO_PROXY" variable is not set. Defaulting to a blank string. 
[+] Running 2/8
 ⠙ db Pulling            0.1s 
[+] Running 2/8g         0.1s 
 ⠹ db Pulling            0.2s 
[+] Running 2/8g         0.2s access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ⠸ db Pulling            0.3s 
[+] Running 3/17         0.3s access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ⠼ db [⠀⠀⠀⠀⠀⠀⠀⠀⠀] Pulling 0.3s ccess denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ⠼ minio Pulling      0.3s ll access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ⠼ redis Pulling      0.3s ll access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ✘ site_worker Error  pull access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied0.1s   pull access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to t
 ✘ createbuckets Error Head "https://registry-1.docker.io/v2/minio/mc/manifests/RELEASE.2025-07-21T05-28-08Z": received unexpected HTTP status: 503 Service Temporarily Unavailable0.3s 
 ! django Warning     pull access denied for django_site-worker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied0.1s 
 ⠸ caddy Pulling      0.3s 
 ⠸ flower Pulling     0.3s 
Error response from daemon: Head "https://registry-1.docker.io/v2/minio/mc/manifests/RELEASE.2025-07-21T05-28-08Z": received unexpected HTTP status: 503 Service Temporarily Unavailable

Exited with code exit status 1
```

By fixing `pull_policy: never` on site_worker we avoid this problem.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] CircleCi tests are passing
- [x] Ready to merge

