### PR TITLE
Add description in dropdown selector (edit phase > select tasks)

### DIFF
--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -261,6 +261,24 @@
             // awesome markdown editor
             self.simple_markdown_editor = create_easyMDE(self.refs.description)
 
+            // Custom menu template that renders description under the item name
+            // data-text is set to name-only so that selected labels show only the title
+            var dropdown_menu_template = function(response, fields) {
+                var html = ''
+                $.each(response[fields.values], function(index, item) {
+                    var name = item[fields.name] || ''
+                    var value = item[fields.value] || ''
+                    var description = item.description
+                    html += '<div class="item" data-value="' + value + '" data-text="' + name + '">'
+                    html += '<strong>' + name + '</strong>'
+                    if (description) {
+                        html += '<div class="dropdown-item-description">' + description + '</div>'
+                    }
+                    html += '</div>'
+                })
+                return html
+            }
+
             // semantic multiselect
             $(self.refs.multiselect).dropdown({
                 apiSettings: {
@@ -270,6 +288,7 @@
                         return {success: true, results: _.values(data.results)}
                     },
                 },
+                templates: {menu: dropdown_menu_template},
                 onAdd: self.task_added,
                 onRemove: self.task_removed,
             })
@@ -282,10 +301,11 @@
                         return {success: true, results: _.values(data.results)}
                     },
                 },
+                templates: {menu: dropdown_menu_template},
                 onAdd: self.public_data_added,
                 onRemove: self.public_data_removed,
             })
-            
+
             $(self.refs.starting_kit_multiselect).dropdown({
                 apiSettings: {
                     url: `${URLS.API}datasets/?search={query}&type=starting_kit`,
@@ -294,6 +314,7 @@
                         return {success: true, results: _.values(data.results)}
                     },
                 },
+                templates: {menu: dropdown_menu_template},
                 onAdd: self.starting_kit_added,
                 onRemove: self.starting_kit_removed,
             })
@@ -858,5 +879,11 @@
     <style type="text/stylus">
         .chevron, .icon-button
             cursor pointer
+        .dropdown-item-description
+            font-size 0.85em
+            color rgba(0,0,0,0.5)
+            margin-top 2px
+            white-space normal
+            line-height 1.3
     </style>
 </competition-phases>

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -263,12 +263,13 @@
 
             // Custom menu template that renders description under the item name
             // data-text is set to name-only so that selected labels show only the title
-            var dropdown_menu_template = function(response, fields) {
+            var dropdown_menu_template = function(response) {
                 var html = ''
-                $.each(response[fields.values], function(index, item) {
-                    var name = item[fields.name] || ''
-                    var value = item[fields.value] || ''
-                    var description = item.description
+                //$.each(response[fields.values], function(index, item) {
+                $.each(response.values, function(index, item) {
+                    let name = item.name || ''
+                    let value = item.value || ''
+                    let description = item.description
                     html += '<div class="item" data-value="' + value + '" data-text="' + name + '">'
                     html += '<strong>' + name + '</strong>'
                     if (description) {

--- a/src/static/riot/competitions/editor/_phases.tag
+++ b/src/static/riot/competitions/editor/_phases.tag
@@ -265,7 +265,6 @@
             // data-text is set to name-only so that selected labels show only the title
             var dropdown_menu_template = function(response) {
                 var html = ''
-                //$.each(response[fields.values], function(index, item) {
                 $.each(response.values, function(index, item) {
                     let name = item.name || ''
                     let value = item.value || ''


### PR DESCRIPTION
# Description

Add description in the dropdown selector for tasks, public data and starting kit in the edit.

<img width="870" height="257" alt="Capture d’écran 2026-04-16 à 16 10 13" src="https://github.com/user-attachments/assets/747e8aa1-471c-4cde-a5e8-47c657a8cbe2" />

This way we can distinguish the objects with more convenience as organizer.

# Issues this PR resolves

- Point 5 of issue #2180 


# A checklist for hand testing
- [x] Try to select new task / public data / starting kit in the editor
- [x] Change the description of a task and check it's updated in the editor


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

