### PR TITLE
Fix show counts in Django admin

### DIFF
--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -25,6 +25,10 @@ class InputFilter(admin.SimpleListFilter):
         )
         yield all_choice
 
+    def get_facet_counts(self, pk_attname, filtered_qs):
+        # Text-input filters have no predefined choices to count (Django 5.0+ facets).
+        return {}
+
 
 class SubmissionsCountFilter(InputFilter):
     # Human-readable title which will be displayed in the

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -25,6 +25,10 @@ class InputFilter(admin.SimpleListFilter):
         )
         yield all_choice
 
+    def get_facet_counts(self, pk_attname, filtered_qs):
+        # Text-input filters have no predefined choices to count (Django 5.0+ facets).
+        return {}
+
 
 class QuotaFilter(InputFilter):
     # Human-readable title which will be displayed in the


### PR DESCRIPTION
# Description

Fix the Server Error (500) that occured when clicking on "Show counts" in some Django admin pages (competitions, submissions, ...).

The root cause: `InputFilter.lookups() returns ((),)`, a dummy single empty tuple to trick Django into displaying the filter. Django 5.0 added the facets/count feature which calls `get_facet_counts()`, which iterates over those lookup tuples and tries to unpack each as (value, label). The empty tuple () raises an `IndexError`, producing the 500.

# Issues this PR resolves
- Closes #2355



# A checklist for hand testing
- [x] Go to Django admin > Competitions / Submissions / Users
- [x] Click on "Show counts" (it should not return a Server Error (500))


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

