### PR TITLE
Patch monitor feature from v1.27

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -41,6 +41,7 @@ from asgiref.sync import async_to_sync
 
 import logging
 
+from billiard.exceptions import SoftTimeLimitExceeded
 from utils.worker_utils import WORKER_HEARTBEAT_TTL, WORKERS_REGISTRY_KEY, extract_queue_names, is_compute_worker, known_compute_queue_names
 logger = logging.getLogger(__name__)
 
@@ -846,24 +847,20 @@ def refresh_compute_worker_health():
         inspected_brokers.add(broker_url)
 
         try:
-            # timeout=5 : 4 appels × 5s × N brokers
-            inspector = broker_app.control.inspect(timeout=5)
-            if inspector is None:
-                logger.warning(
-                    "Celery inspect returned None for broker=%s", source_name
-                )
-                continue
-            stats = inspector.stats() or {}
+            # timeout=2 : 3 calls × 2s × N brokers
+            inspector = broker_app.control.inspect(timeout=2)
             active = inspector.active() or {}
             reserved = inspector.reserved() or {}
             active_queues = inspector.active_queues() or {}
+        except SoftTimeLimitExceeded:
+            raise
         except Exception:
             logger.exception(
                 "Unable to inspect Celery workers for broker %s", source_name
             )
             continue
 
-        for worker_name in stats.keys():
+        for worker_name in active_queues.keys():
             queues = active_queues.get(worker_name, []) or []
             queue_names = extract_queue_names(queues)
             if not is_compute_worker(worker_name, queue_names, known_queue_names):


### PR DESCRIPTION
### Changes

1. except `SoftTimeLimitExceeded`: raise (line 855-856): `billiard.exceptions.SoftTimeLimitExceeded` inherits from Exception, so the old except Exception was silently swallowing the soft limit signal, letting the task run indefinitely past 120s. Two concurrent instances were stuck, blocking the worker slots while beat kept queuing new ones every 60s.

2. Removed `stats()` call: it was only used for stats.keys() to iterate worker names; active_queues.keys() covers the same set for compute workers and saves one round-trip per broker.

3. Timeout 5s → 2s: reduces per-broker cost from ~20s (4 calls × 5s) to ~6s (3 calls × 2s), so the task can handle ~20 distinct brokers within the 120s limit instead of ~6.