### PR TITLE
Add guard for submission datafile

### DIFF
--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -187,6 +187,10 @@ def _send_to_compute_worker(submission, is_scoring):
     if is_scoring:
         run_args['scoring_program_data'] = make_url_sassy(path=task.scoring_program.data_file.name)
 
+    if not submission.data:
+        logger.error("Submission %s has no data file; marking as failed.", submission.pk)
+        submission.cancel(status=Submission.FAILED)
+        return
     run_args['submission_data'] = make_url_sassy(path=submission.data.data_file.name)
 
     if not is_scoring:


### PR DESCRIPTION
To fix this:

```python
site_worker  | 2026-05-26 13:08:47.475 | ERROR    | celery.app.trace:_log_error:285 - Task competitions.tasks._run_submission[22944d0d-5232-4e26-8cd6-8bf0fc4aecd8] raised unexpected: AttributeError("'NoneType' object has no attribute 'data_file'")
site_worker  | Traceback (most recent call last):
site_worker  |
site_worker  | > File "/.venv/lib/python3.13/site-packages/celery/app/trace.py", line 479, in trace_task
site_worker  |     R = retval = fun(*args, **kwargs)
site_worker  |   File "/.venv/lib/python3.13/site-packages/celery/app/trace.py", line 779, in __protected_call__
site_worker  |     return self.run(*args, **kwargs)
site_worker  |
site_worker  |   File "/app/src/apps/competitions/tasks.py", line 341, in _run_submission
site_worker  |     _send_to_compute_worker(submission, is_scoring)
site_worker  |
site_worker  |   File "/app/src/apps/competitions/tasks.py", line 191, in _send_to_compute_worker
site_worker  |     run_args['submission_data'] = make_url_sassy(path=submission.data.data_file.name)
site_worker  |
site_worker  | AttributeError: 'NoneType' object has no attribute 'data_file'
```