### PR TITLE
Fix AttributeError in SubmissionCreationSerializer when data is None

### DIFF
--- a/src/apps/api/serializers/submissions.py
+++ b/src/apps/api/serializers/submissions.py
@@ -118,7 +118,9 @@ class SubmissionCreationSerializer(DefaultUserCreateMixin, serializers.ModelSeri
         }
 
     def get_filename(self, instance):
-        return basename(instance.data.data_file.name)
+        if instance.data and instance.data.data_file:
+            return basename(instance.data.data_file.name)
+        return None
 
     def create(self, validated_data):
         tasks = validated_data.pop('tasks', None)


### PR DESCRIPTION
# Description

`SubmissionCreationSerializer.get_filename()` (line 121) crashes with `AttributeError: 'NoneType' object has no attribute 'data_file'` when `submission.data` is `None`.

The same file already handles this case correctly in `SubmissionListSerializer` (line 69-73):

```python
def get_filename(self, instance):
    if instance.data and instance.data.data_file:
        return basename(instance.data.data_file.name)
    return "Deleted File"
```

But `SubmissionCreationSerializer` does not:

```python
def get_filename(self, instance):
    return basename(instance.data.data_file.name)  # crashes if data is None
```

**Impact:** A single incomplete API submission causes a 500 Internal Server Error on the competition detail page for **all** users, not just the caller.

### Original PR

- #2396

# Reproduction steps

The REST API submission flow uses pre-signed S3 URLs in 4 steps:

```bash
# Step 1 - Create dataset record (returns pre-signed S3 URL)
curl -X POST \
  -H "Authorization: Token $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"type": "submission", "name": "My Run", "file_name": "predictions.zip", "file_size": 1234, "request_sassy_file_name": "predictions.zip"}' \
  https://<host>/api/datasets/
# Response: {"key": "<uuid>", "sassy_url": "https://s3..."}

# Step 2 - Upload file to S3
curl -X PUT -H "Content-Type: application/zip" --data-binary @predictions.zip "<sassy_url>"

# Step 3 - Mark upload complete
curl -X PUT -H "Authorization: Token $TOKEN" https://<host>/api/datasets/completed/<key>/

# Step 4 - Create submission
curl -X POST \
  -H "Authorization: Token $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"phase": 3, "data": "<key>"}' \
  https://<host>/api/submissions/
```

**To trigger the bug:** Skip steps 2-3 (S3 upload fails or is never completed) and go directly to step 4. The API happily creates a `Submission` record with `data_id=None`. Then visit `/competitions/<id>/` - the page returns 500 for every user.

The traceback from Django logs:

```
File "/app/src/apps/api/serializers/submissions.py", line 121, in get_filename
    return basename(instance.data.data_file.name)
AttributeError: 'NoneType' object has no attribute 'data_file'
```

# Fix

Apply the same null-check pattern from `SubmissionListSerializer`:

```python
def get_filename(self, instance):
    if instance.data and instance.data.data_file:
        return basename(instance.data.data_file.name)
    return None
```

# Checklist
- [x] Code review by me
- [x] Hand tested by me
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge