### PR TITLE
Remove volume when removing container

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -968,7 +968,7 @@ class Run:
                     await websocket.wait_closed()
                 except Exception as e:
                     logger.error(e)
-            client.remove_container(container, force=True)
+            client.remove_container(container, v=True, force=True)
 
             logger.debug(f"Container {container.get('Id')} exited with status code : {str(return_Code['StatusCode'])}")
 
@@ -983,7 +983,7 @@ class Run:
         finally:
             try:
                 # Last chance of removing container
-                client.remove_container(container.get("Id"), force=True)
+                client.remove_container(container.get("Id"), v=True, force=True)
             except Exception:
                 pass
 
@@ -1347,7 +1347,7 @@ class Run:
 
             for container in containers_to_kill:
                 try:
-                    client.remove_container(str(container), force=True)
+                    client.remove_container(str(container), v=True, force=True)
                 except docker.errors.APIError as e:
                     logger.error(e)
                 except Exception as e:
@@ -1398,7 +1398,7 @@ class Run:
                         containers_to_kill = self.scoring_program_container_name
                     try:
                         client.kill(containers_to_kill)
-                        client.remove_container(containers_to_kill, force=True)
+                        client.remove_container(containers_to_kill, v=True, force=True)
                     except docker.errors.APIError as e:
                         logger.error(e)
                     except Exception as e:


### PR DESCRIPTION
# Original PR

- #2378

# Description

This change resolves an issue, which occured with our codabench_worker using Podman. (Not sure if the same happens with Docker at some point)

# The problem

Our worker stopped working after couple of weeks and it took some time to understand the root cause of the problem, since the worker got always stuck when creating the container. We only recognized after we investigated several options that `podman volume ls | wc -l` resulted in 2047 entries, which was too close to a "threshold".  As it turns out, the `create_container` was failing as podman could not create additional volumes and therefore our process was always running into an execution timeout.

We could resolve the problem by removing all dangling volumes that have been created (`podman volumes rm --all`). After that "cleaning", the worker is now operational again.

# The fix

Therefore, we propose the change to have `remove_container` also remove the volumes via the option `v=True`. In our tests, this helps to avoid the problem described above.

# Checklist
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

