### PR TITLE
fix(scoring): re-enqueue scoring after commit to avoid stuck SCORING …

### DIFF
--- a/src/apps/api/serializers/submissions.py
+++ b/src/apps/api/serializers/submissions.py
@@ -1,10 +1,14 @@
 import asyncio
+import logging
 from os.path import basename
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
+
+logger = logging.getLogger(__name__)
 
 from api.mixins import DefaultUserCreateMixin
 from api.serializers import leaderboards
@@ -163,6 +167,7 @@ class SubmissionCreationSerializer(DefaultUserCreateMixin, serializers.ModelSeri
 
         return data
 
+    @transaction.atomic
     def update(self, submission, validated_data):
 
         # Cannot change submission if secret key is not valid
@@ -198,13 +203,29 @@ class SubmissionCreationSerializer(DefaultUserCreateMixin, serializers.ModelSeri
             self.instance.parent.save()
 
         if validated_data.get("status") == Submission.SCORING:
-            # Start scoring because we're "SCORING" status now from compute worker
+            # Re-enqueue scoring AFTER the new status is committed: otherwise the
+            # site-worker may pick the task up before the row reflects SCORING,
+            # and a broker error here would leave the row stuck in SCORING forever.
             from competitions.tasks import run_submission
-            # task = validated_data.get('task_pk')
-            # if not task:
-            #     raise ValidationError('Cannot update submission. Task pk was not provided')
-            # task = Task.objects.get(id=task)
-            run_submission(submission.pk, tasks=[submission.task], is_scoring=True)
+            submission_pk = submission.pk
+            scoring_task = submission.task
+
+            def _enqueue_scoring():
+                try:
+                    run_submission(submission_pk, tasks=[scoring_task], is_scoring=True)
+                except Exception:
+                    logger.exception(
+                        "Failed to re-enqueue scoring for submission %s; marking Failed",
+                        submission_pk,
+                    )
+                    Submission.objects.filter(
+                        pk=submission_pk, status=Submission.SCORING,
+                    ).update(
+                        status=Submission.FAILED,
+                        status_details="Broker unavailable when re-enqueuing scoring task",
+                    )
+
+            transaction.on_commit(_enqueue_scoring)
 
         elif validated_data.get("status") == Submission.FINISHED:
             # We finished submission, no longer need to store submission stuff in Redis, free it up!


### PR DESCRIPTION
# @ mention of reviewers
@<reviewer-1> @<reviewer-2>

# A brief description of the purpose of the changes contained in this PR

Submissions could get stuck in `SCORING` indefinitely because the Celery task that runs the next phase was enqueued **inside** the outer Django transaction, before the row was committed. The `compute_worker` could dequeue and execute the task before the new status (and updated FKs like `queue` / `celery_task_id`) were visible in the database, then bail out or operate on stale data.

This PR moves the `send_task` call into a `transaction.on_commit()` callback so the message hits RabbitMQ **only after** the surrounding transaction is committed. Behaviour is otherwise unchanged.

# Issues this PR resolves

Closes #2419 

Symptoms reported:
- Submissions stuck in `SCORING` with no worker activity.
- Sporadic `Submission.DoesNotExist` / stale-read errors in `compute_worker` logs right after a status transition.
- `celery_task_id` occasionally `NULL` on rows that did get picked up.

Root cause: `app.send_task(...)` was called from inside the outer `@transaction.atomic` scope of `_run_submission`, so the broker received the task before PostgreSQL committed the writes. Under load (or with a fast worker / slow commit), the worker won the race.

Fix: wrap the enqueue + `celery_task_id` write in a `_enqueue_after_commit()` closure and register it via `transaction.on_commit(...)`. The closure runs only when the outer transaction commits successfully, and is silently dropped on rollback (no orphaned messages on the broker).

# A checklist for hand testing

- [ ] Create a fresh submission on a competition with a non-default queue → it reaches `Finished` (no stuck `SCORING`).
- [ ] Create a fresh submission on a competition with the **default** queue → same.
- [ ] Re-run an existing submission via the UI → it reaches `Finished`.
- [ ] Submit, then immediately roll back the surrounding request (e.g. force an exception in a signal) → confirm no orphan message hits `compute-worker` (RabbitMQ management UI shows no dangling delivery).
- [ ] Inspect `submission.celery_task_id` after enqueue → not `NULL`.
- [ ] Restart `compute_worker` mid-submission lifecycle → submission still completes (does not regress M6 idempotency).
- [ ] Cancel a `SUBMITTED` submission before its commit completes → `celery_app.control.revoke(...)` still works because the `celery_task_id` is set inside the same `on_commit` callback.

# Any relevant files for testing

- Modified: [src/apps/competitions/tasks.py](src/apps/competitions/tasks.py) (around `_run_submission` → `_enqueue_after_commit` closure + `transaction.on_commit(...)`).
- Imports: `from django.db import transaction` (already present).
- No model / migration changes required.

# Checklist

- [ ] Code review by me
- [ ] Hand tested by me
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge