### PR TITLE
fix(site_worker): remove watchmedo auto-restart causing BrokenPipeError loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
   #----------------------------------------------------------------------------------------------------
   site_worker:
     # This auto-reloads
-    command: ["watchmedo auto-restart -p '*.py' --recursive -- celery -A celery_config worker -B -Q site-worker -l info -n site-worker@%n --concurrency=2"]
+    command: ["celery -A celery_config worker -B -Q site-worker -l info -n site-worker@%n --concurrency=2"]
     working_dir: /app/src
     container_name: site_worker
     image: django_site-worker


### PR DESCRIPTION
# Description

Uploading a competition bundle leaves the "unpacking" step spinning forever. The `unpack_competition` Celery task is enqueued on the `site-worker` queue but never executed, because the `site_worker` container — although reported as `Up` by Docker — has **no consumer** attached to RabbitMQ.

## Root cause

The previous `site_worker` command wrapped Celery in `watchmedo` so that task code edits would auto-reload:

```yaml
command: ["watchmedo auto-restart -p '*.py' --recursive -- celery -A celery_config worker -B -Q site-worker -l info -n site-worker@%n --concurrency=2"]
```

`watchmedo` watches the entire mounted `/app` tree, which includes:

- `__pycache__/*.pyc` files written by Python on every import
- `src/celerybeat-schedule*` SQLite files written continuously by Celery beat itself

These files keep changing **faster than Celery can finish initializing its prefork pool**. Each aborted startup leaks pool worker processes and produces a `BrokenPipeError` in `billiard`. As a result no consumer ever attaches to the `site-worker` queue and tasks pile up indefinitely.

## Fix

Remove the `watchmedo` wrapper from the `site_worker` command in `docker-compose.yml`:

```diff
   site_worker:
-    # This auto-reloads
-    command: ["watchmedo auto-restart -p '*.py' --recursive -- celery -A celery_config worker -B -Q site-worker -l info -n site-worker@%n --concurrency=2"]
+    command: ["celery -A celery_config worker -B -Q site-worker -l info -n site-worker@%n --concurrency=2"]
     working_dir: /app/src
```

# Issue solved

- Closes #2417

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

