### PR TITLE
Add ordering by ID to all admin pages

### DIFF
--- a/src/apps/announcements/admin.py
+++ b/src/apps/announcements/admin.py
@@ -11,6 +11,7 @@ class NewsPostExpansion(admin.ModelAdmin):
 class AnnouncementExpansion(admin.ModelAdmin):
     list_display = ["id", "text_limited"]
     list_display_links = ["id", "text_limited"]
+    ordering = ('-id',)
 
     @admin.display(description="text", ordering="text")
     def text_limited(self, obj):

--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -188,6 +188,7 @@ class CompetitionExpansion(admin.ModelAdmin):
     list_display_links = ["id", "title"]
     actions = [CompetitionExport_as_json, CompetitionExport_as_csv]
     raw_id_fields = ["created_by", "collaborators", "queue"]
+    ordering = ('-id',)
     list_filter = [
         "published",
         "is_featured",
@@ -268,6 +269,7 @@ class SubmissionExpansion(admin.ModelAdmin):
         "scores",
     ]
     search_fields = ["id", "owner__username", "phase__competition__title", "task__name"]
+    ordering = ('-id',)
     actions = [SubmissionsExport_as_csv]
     list_display = [
         "id",
@@ -351,6 +353,7 @@ class CompetitionCreationTaskStatusExpansion(admin.ModelAdmin):
     list_display = ["id", "created_by", "resulting_competition", "status"]
     search_fields = ["id", "created_by__username"]
     list_filter = ["status"]
+    ordering = ('-id',)
 
 
 class CompetitionParticipantExpansion(admin.ModelAdmin):
@@ -358,18 +361,21 @@ class CompetitionParticipantExpansion(admin.ModelAdmin):
     list_display = ["id", "user", "competition", "status"]
     list_filter = ["status"]
     search_fields = ["id", "user__username", "competition"]
+    ordering = ('-id',)
 
 
 class PageExpansion(admin.ModelAdmin):
     raw_id_fields = ["competition"]
     list_display = ["id", "competition"]
     search_fields = ["id", "competition", "content"]
+    ordering = ('-id',)
 
 
 class PhaseExpansion(admin.ModelAdmin):
     raw_id_fields = ["competition", "leaderboard", "public_data", "starting_kit"]
     list_display = ["id", "competition", "name"]
     search_fields = ["id", "competition", "name"]
+    ordering = ('-id',)
     fieldsets = [
         (
             None,

--- a/src/apps/datasets/admin.py
+++ b/src/apps/datasets/admin.py
@@ -15,6 +15,7 @@ def DeactivateAccount(modeladmin, request, queryset):
 
 class DataExpansion(admin.ModelAdmin):
     raw_id_fields = ["created_by", "competition"]
+    ordering = ('-id',)
     list_display = [
         "id",
         "name",

--- a/src/apps/forums/admin.py
+++ b/src/apps/forums/admin.py
@@ -25,6 +25,7 @@ class ForumsExpansion(admin.ModelAdmin):
     raw_id_fields = ["competition"]
     list_display = ["id", "competition"]
     search_fields = ["id", "competition"]
+    ordering = ('-id',)
 
 
 class ThreadExpansion(admin.ModelAdmin):
@@ -32,6 +33,7 @@ class ThreadExpansion(admin.ModelAdmin):
     list_display = ["id", "title", "started_by"]
     search_fields = ["id", "title", "started_by__username"]
     actions = [DeactivateAccountThread]
+    ordering = ('-id',)
 
 
 class PostExpansion(admin.ModelAdmin):
@@ -39,6 +41,7 @@ class PostExpansion(admin.ModelAdmin):
     list_display = ["id", "content_limited", "posted_by"]
     search_fields = ["id", "content", "posted_by__username"]
     actions = [DeactivateAccountPost]
+    ordering = ('-id',)
 
     @admin.display(description="Content", ordering="content")
     def content_limited(self, obj):

--- a/src/apps/leaderboards/admin.py
+++ b/src/apps/leaderboards/admin.py
@@ -7,6 +7,7 @@ class LeaderboardExpansion(admin.ModelAdmin):
     list_display = ["id", "title", "submission_rule", "hidden"]
     search_fields = ["id", "title"]
     list_filter = ["hidden"]
+    ordering = ('-id',)
 
 
 class ColumExpansion(admin.ModelAdmin):
@@ -14,12 +15,14 @@ class ColumExpansion(admin.ModelAdmin):
     list_display = ["id", "title", "hidden"]
     search_fields = ["id", "title"]
     list_filter = ["hidden"]
+    ordering = ('-id',)
 
 
 class SubmissionScoreExpansion(admin.ModelAdmin):
     raw_id_fields = ["column"]
     list_display = ["id", "column", "score"]
     search_fields = ["id", "column"]
+    ordering = ('-id',)
 
 
 admin.site.register(models.Leaderboard, LeaderboardExpansion)

--- a/src/apps/oidc_configurations/admin.py
+++ b/src/apps/oidc_configurations/admin.py
@@ -5,6 +5,7 @@ from .models import Auth_Organization
 class Auth_OrganizationExpansion(admin.ModelAdmin):
     list_display = ["id", "name", "client_id"]
     search_fields = ["id", "name", "client_id"]
+    ordering = ('-id',)
 
 
 admin.site.register(Auth_Organization, Auth_OrganizationExpansion)

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -71,6 +71,23 @@ def export_as_json(modeladmin, request, queryset):
         email_list.update({obj.username: obj.email})
     return HttpResponse(json.dumps(email_list), content_type="application/json")
 
+@admin.display(description="Ban User(s)")
+def ban_users(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.is_banned = True
+        obj.save()
+
+@admin.display(description="Unban User(s)")
+def unban_users(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.is_banned = False
+        obj.save()
+
+@admin.display(description="Activate User(s)")
+def activate_users(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.is_active = True
+        obj.save()
 
 class UserExpansion(UserAdmin):
     # The following two lines are needed for Django-su:
@@ -83,6 +100,7 @@ class UserExpansion(UserAdmin):
         "is_superuser",
         "is_deleted",
         "is_bot",
+        "is_active",
         "is_banned",
         QuotaFilter,
     ]
@@ -91,13 +109,14 @@ class UserExpansion(UserAdmin):
         "username",
         "email",
         "quota",
+        "is_active",
         "is_staff",
         "is_superuser",
         "is_banned",
     ]
     list_display_links = ["id", "username"]
     raw_id_fields = ["oidc_organization", "groups"]
-    actions = [export_as_csv, export_as_json]
+    actions = [activate_users, ban_users, unban_users, export_as_csv, export_as_json]
     fieldsets = [
         (
             None,

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -77,6 +77,7 @@ class UserExpansion(UserAdmin):
     change_form_template = "admin/auth/user/change_form.html"
     change_list_template = "admin/auth/user/change_list.html"
     search_fields = ["id", "username", "email"]
+    ordering = ('-id',)
     list_filter = [
         "is_staff",
         "is_superuser",
@@ -180,18 +181,21 @@ class DeletedUserExpansion(admin.ModelAdmin):
     list_display = ("user_id", "username", "email", "deleted_at")
     search_fields = ("id", "username", "email")
     list_filter = ("deleted_at",)
+    ordering = ('-id',)
 
 
 class MembershipExpansion(admin.ModelAdmin):
     raw_id_fields = ["organization", "user"]
     list_display = ["id", "organization", "user", "group"]
     search_fields = ["id", "user__username", "token"]
+    ordering = ('-id',)
 
 
 class OrganizationExpansion(admin.ModelAdmin):
     raw_id_fields = ["user_record"]
     list_display = ["id", "name", "email", "description"]
     search_fields = ["name", "email", "description"]
+    ordering = ('-id',)
 
 
 admin.site.register(User, UserExpansion)

--- a/src/apps/profiles/admin.py
+++ b/src/apps/profiles/admin.py
@@ -71,11 +71,13 @@ def export_as_json(modeladmin, request, queryset):
         email_list.update({obj.username: obj.email})
     return HttpResponse(json.dumps(email_list), content_type="application/json")
 
+
 @admin.display(description="Ban User(s)")
 def ban_users(modeladmin, request, queryset):
     for obj in queryset:
         obj.is_banned = True
         obj.save()
+
 
 @admin.display(description="Unban User(s)")
 def unban_users(modeladmin, request, queryset):
@@ -83,11 +85,13 @@ def unban_users(modeladmin, request, queryset):
         obj.is_banned = False
         obj.save()
 
+
 @admin.display(description="Activate User(s)")
 def activate_users(modeladmin, request, queryset):
     for obj in queryset:
         obj.is_active = True
         obj.save()
+
 
 class UserExpansion(UserAdmin):
     # The following two lines are needed for Django-su:

--- a/src/apps/queues/admin.py
+++ b/src/apps/queues/admin.py
@@ -42,6 +42,7 @@ class QueueExpansion(admin.ModelAdmin):
     list_filter = ["is_public"]
     search_fields = ["id", "name", "owner__username", "organizers__username"]
     actions = [export_as_csv, export_as_json]
+    ordering = ('-id',)
 
 
 admin.site.register(models.Queue, QueueExpansion)

--- a/src/apps/tasks/admin.py
+++ b/src/apps/tasks/admin.py
@@ -26,6 +26,7 @@ class TaskExpansion(admin.ModelAdmin):
         "name",
         "created_by__username",
     ]
+    ordering = ('-id',)
 
 
 class SolutionExpansion(admin.ModelAdmin):
@@ -35,6 +36,7 @@ class SolutionExpansion(admin.ModelAdmin):
     search_fields = [
         "id",
     ]
+    ordering = ('-id',)
 
 
 admin.site.register(models.Task, TaskExpansion)


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
A while back, we lost the default ordering by ID in the Django admin interface. 
It is now back.

Also added options to mass ban/unban users and mass activate accounts.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

