### PR TITLE
fix: allow organizers to hard-delete soft-deleted submissions

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -536,9 +536,10 @@ class Submission(models.Model):
             detail.delete()  # Remove record from DB
 
         # Clear the data field if no other submissions are using it
-        other_submissions_using_data = Submission.objects.filter(data=self.data).exclude(pk=self.pk).exists()
-        if not other_submissions_using_data:
-            self.data.delete()
+        if self.data:
+            other_submissions_using_data = Submission.objects.filter(data=self.data).exclude(pk=self.pk).exists()
+            if not other_submissions_using_data:
+                self.data.delete()
 
         # Clear the data field for this submission
         self.data = None
@@ -554,11 +555,12 @@ class Submission(models.Model):
     def delete(self, **kwargs):
 
         # Check if any other submissions are using the same data
-        other_submissions_using_data = Submission.objects.filter(data=self.data).exclude(pk=self.pk).exists()
+        if self.data:
+            other_submissions_using_data = Submission.objects.filter(data=self.data).exclude(pk=self.pk).exists()
 
-        if not other_submissions_using_data:
-            # If no other submissions are using the same data, delete it
-            self.data.delete()
+            if not other_submissions_using_data:
+                # If no other submissions are using the same data, delete it
+                self.data.delete()
 
         # Also clean up details on delete
         self.details.all().delete()

--- a/src/static/riot/competitions/detail/submission_manager.tag
+++ b/src/static/riot/competitions/detail/submission_manager.tag
@@ -123,8 +123,15 @@
                     </a>
                 </td>
                 <!--  Show Action buttons when submission is not soft deleted  -->
-                <!--  Otherwise show empty <td>  -->
-                <td if="{ submission.is_soft_deleted }"></td>
+                <!--  For soft-deleted submissions, organizers can still hard-delete  -->
+                <td if="{ submission.is_soft_deleted }">
+                    <virtual if="{ opts.admin }">
+                        <span data-tooltip="Delete Submission" data-inverted=""
+                            onclick="{ delete_submission.bind(this, submission) }">
+                            <i class="icon red trash alternate"></i>
+                        </span>
+                    </virtual>
+                </td>
                 <td class="center aligned" if="{ !submission.is_soft_deleted }">
                     <virtual if="{ opts.admin}">
                         <!-- run/rerun submission -->


### PR DESCRIPTION
Original PR: #2422

# Description

Following feedback on the original approach (excluding Cancelled from quota),
this PR takes the suggested route: let organizers hard-delete soft-deleted
submissions so they can free up quota manually.

# Issues this PR resolves

- Point 2 from #2249

# Changes

- **Frontend** (`submission_manager.tag`): Add a delete button (trash icon)
  on soft-deleted submissions, visible to organizers only.
- **Backend** (`models.py`): Guard `self.data` access in `delete()` and
  `soft_delete()` — after a soft-delete, `self.data` is `None`, which caused
  an `AttributeError` when trying to hard-delete.

# A checklist for hand testing

- [x] As an organizer, soft-delete a submission, then confirm the trash icon appears
- [x] Click the trash icon and confirm the submission is permanently deleted
- [x] Verify quota is freed after hard-delete
- [x] Confirm non-organizers do not see the delete button on soft-deleted submissions

# Checklist

- [x] Code review by me
- [x] Hand tested by me
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge