### PR TITLE
Fix data integrity: ensure FINISHED status only after successful score upload

### DIFF
--- a/compute_worker/compute_worker.py
+++ b/compute_worker/compute_worker.py
@@ -313,9 +313,13 @@ def run_wrapper(run_args):
     try:
         run.prepare()
         run.start()
+        # Upload scores and outputs before marking as finished
         if run.is_scoring:
             run.push_scores()
         run.push_output()
+        # Mark as finished only after successful upload
+        if run.is_scoring:
+            run._update_status(SubmissionStatus.FINISHED)
     except DockerImagePullException as e:
         msg = str(e).strip()
         if msg:
@@ -1445,7 +1449,7 @@ class Run:
                 )
                 # Raise so upstream marks failed immediately
                 raise SubmissionException("Child task failed or non-zero return code")
-            self._update_status(SubmissionStatus.FINISHED)
+            # Status will be set to FINISHED after successful upload
 
         else:
             self._update_status(SubmissionStatus.SCORING)
@@ -1483,9 +1487,29 @@ class Run:
             "scores": scores,
         }
         logger.info(f"Submitting these scores to {url}: {scores} with data = {data}")
-        resp = self.requests_session.post(url, json=data)
-        logger.info(resp)
-        logger.info(str(resp.content))
+        
+        # Retry score upload with exponential backoff
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                resp = self.requests_session.post(url, json=data, timeout=30)
+                resp.raise_for_status()
+                logger.info(f"Scores uploaded successfully: {resp.status_code}")
+                logger.info(str(resp.content))
+                return
+            except Exception as e:
+                wait_time = 2 ** attempt
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f"Score upload attempt {attempt + 1}/{max_retries} failed: {e}. "
+                        f"Retrying in {wait_time}s..."
+                    )
+                    time.sleep(wait_time)
+                else:
+                    logger.error(f"All {max_retries} score upload attempts failed")
+                    raise SubmissionException(
+                        f"Failed to upload scores after {max_retries} attempts: {e}"
+                    )
 
     def push_output(self):
         """Output is pushed at the end of both prediction and scoring steps."""


### PR DESCRIPTION
Original PR: #2424

# Description
Fixes a data integrity bug where submissions were marked as `FINISHED` before their scores were successfully uploaded to the server, resulting in `FINISHED` submissions with no scores.

**Problem:** The compute worker set submission status to `FINISHED` before uploading scores to the Django server. If the score upload failed (network error, server timeout, etc.), the submission would be marked `FINISHED` but have no scores in the database.

**Root cause:**
```python
# Old code (compute_worker.py)
run._update_status(SubmissionStatus.FINISHED)  # Mark FINISHED first
run.push_scores()  # Upload scores second - might fail!
```

**Solution:**
1. **Reorder operations**: Upload scores BEFORE setting FINISHED status
2. **Add retry logic**: Exponential backoff (3 retries) for transient failures
3. **Preserve atomicity**: Status update only happens after successful upload

**Code changes:**
- `compute_worker/compute_worker.py`:
  - Moved `push_scores()` before `_update_status(FINISHED)` in `run_wrapper()`
  - Added retry logic with exponential backoff in `push_scores()`
  - Added 30s timeout for score POST requests

```python
# New code
if run.is_scoring:
    run.push_scores()  # Upload scores first with retry logic
run.push_output()
if run.is_scoring:
    run._update_status(SubmissionStatus.FINISHED)  # Mark FINISHED only after success
```

# Issues this PR resolves
Fixes #2423

# Background
This bug was discovered during the EEG Foundation Challenge incident analysis (8,328 submissions, 51% failure rate). Analysis showed submissions stuck in `FINISHED` state with no scores in the database.

# Checklist for hand testing
- [ ] Create a competition with at least one scoring phase
- [ ] Submit a valid submission
- [ ] Verify submission reaches `FINISHED` status
- [ ] Verify scores are present in the database and displayed on leaderboard
- [ ] Test with network interruptions to verify retry logic

# Checklist
- [x] Code review by me
- [x] Hand tested by me
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] CircleCI tests are passing
- [ ] Ready to merge