### PR TITLE
Avoid 404 error after maintenance mode is disabled

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -26,6 +26,15 @@
       status 503
     }
   }
+  # When maintenance ends, redirect stale /maintenance.html requests back to home
+  @staleMaintenancePage {
+    path /maintenance.html
+    not file {
+      root /srv
+      try_files maintenance.on
+    }
+  }
+  redir @staleMaintenancePage / 302
 
   # Serves static files, should be the same as `STATIC_ROOT` setting:
   root * /var/www/django


### PR DESCRIPTION
# Description

After removing the maintenance mode, refreshing the maintenance page returns a 404 error on the page `maintenance.html`.

With this change, the refresh redirects to the home page.


# A checklist for hand testing
- [x] `touch maintenance_mode/maintenance.on`
- [x] Refresh and check that the platform is replaced by the maintenance page
- [x] `rm maintenance_mode/maintenance.on`
- [x] Refresh and check that you get redirected to the homepage



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

