### PR TITLE
Minor UI change: Move and rename save button in task editor

### DIFF
--- a/src/static/riot/tasks/management.tag
+++ b/src/static/riot/tasks/management.tag
@@ -362,8 +362,8 @@
             </div>
         </div>
         <div class="actions">
-            <div class="ui primary button {disabled: !edit_modal_is_valid}" onclick="{ update_task }">Update</div>
             <div class="ui basic red cancel button">Cancel</div>
+            <div class="ui primary button {disabled: !edit_modal_is_valid}" onclick="{ update_task }">Save</div>
         </div>
     </div>
 


### PR DESCRIPTION
# Description

In the "Update Task" modal:
- Reverse order of the "Cancel" and "Update" buttons
- Rename "Update" to "Save"

<img width="1019" height="572" alt="Capture d’écran 2026-06-26 à 15 15 23" src="https://github.com/user-attachments/assets/eed3db30-7dc7-4cba-9127-0e6d61474631" />



# A checklist for hand testing
- [ ] Go to the task editor and check that it works well


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [ ] Ready to merge

