### PR TITLE
Fix submission cleanup: recover all non-terminal states, not just Running

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -116,3 +116,7 @@ ENABLE_SIGN_IN=True
 # -----------------------------------------------------------------------------
 LOG_LEVEL=info
 SERIALIZED=false
+
+
+# Data Upload limit (used in django admin when selecing multiple items, or when adding multiple participants in the Participant Routing feature)
+#DJANGO_DATA_UPLOAD_MAX_NUMBER_FIELDS=2000

--- a/src/apps/competitions/admin.py
+++ b/src/apps/competitions/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.contrib.auth.models import Group
-
+from competitions.models import Submission
 from django.utils.translation import gettext_lazy as _
 import json
 import csv
@@ -166,6 +166,15 @@ def CompetitionExport_as_json(modeladmin, request, queryset):
     return HttpResponse(json.dumps(email_list), content_type="application/json")
 
 
+# This will export the email of all the selected competition creators, removing duplications and banned users
+@admin.display(description="Fail Submissions")
+def Fail_submissions(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.cancel(status=Submission.FAILED)
+        obj.status_details = "Failed Manually by Site Admin action"
+        obj.save()
+
+
 class QueueFilter(InputFilter):
     # Human-readable title which will be displayed in the
     # right admin sidebar just above the filter options.
@@ -253,6 +262,19 @@ class CompetitionOrganizerFilter(InputFilter):
             return queryset.filter(phase__competition__created_by__username=value)
 
 
+class StatusDetailsFilter(InputFilter):
+    # Human-readable title which will be displayed in the
+    # right admin sidebar just above the filter options.
+    title = _("Status Details")
+    # Parameter for the filter that will be used in the URL query.
+    parameter_name = "status_details"
+
+    def queryset(self, request, queryset):
+        if self.value() is not None:
+            value = self.value()
+            return queryset.filter(status_details=value)
+
+
 class SubmissionExpansion(admin.ModelAdmin):
     # Raw Id Fields changes the field from displaying everything in a drop down menu into an id fields, which makes the page loads much faster (removes huge SELECT from the database)
     raw_id_fields = [
@@ -270,7 +292,7 @@ class SubmissionExpansion(admin.ModelAdmin):
     ]
     search_fields = ["id", "owner__username", "phase__competition__title", "task__name"]
     ordering = ('-id',)
-    actions = [SubmissionsExport_as_csv]
+    actions = [SubmissionsExport_as_csv, Fail_submissions]
     list_display = [
         "id",
         "owner",
@@ -287,6 +309,7 @@ class SubmissionExpansion(admin.ModelAdmin):
         "status",
         CompetitionOrganizerFilter,
         QueueFilter,
+        StatusDetailsFilter,
     ]
     fieldsets = [
         (

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -937,7 +937,7 @@ def submission_status_cleanup():
 
     for sub in submissions:
         # Use started_when for Running submissions, created_when as fallback for others
-	    # The deadline waits for 10 minutes after the phase execution time limit before failing submissions
+        # The deadline waits for 10 minutes after the phase execution time limit before failing submissions
         reference_time = sub.started_when if sub.started_when else sub.created_when
         deadline = reference_time + timedelta(
             milliseconds=(60000 * 10) + sub.phase.execution_time_limit

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -923,14 +923,21 @@ def update_phase_statuses():
 
 @app.task(queue="site-worker")
 def submission_status_cleanup():
+    # Recover submissions stuck in any non-terminal state
+    non_terminal_statuses = [
+        Submission.SUBMITTED,
+        Submission.PREPARING,
+        Submission.RUNNING,
+        Submission.SCORING,
+    ]
     submissions = Submission.objects.filter(
-        status=Submission.RUNNING, has_children=False
-    ).select_related("phase", "parent")
+        status__in=non_terminal_statuses,
+        has_children=False,
+    ).select_related('phase', 'parent')
 
     for sub in submissions:
-        if sub.started_when < now() - timedelta(
-            milliseconds=(3600000 * 24) + sub.phase.execution_time_limit
-        ):
+        # Check if the submission has been running for 24 hours longer than execution_time_limit
+        if sub.started_when < now() - timedelta(milliseconds=(3600000 * 24) + sub.phase.execution_time_limit):
             if sub.parent is not None:
                 sub.parent.cancel(status=Submission.FAILED)
             else:

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -936,8 +936,14 @@ def submission_status_cleanup():
     ).select_related('phase', 'parent')
 
     for sub in submissions:
-        # Check if the submission has been running for 24 hours longer than execution_time_limit
-        if sub.started_when < now() - timedelta(milliseconds=(3600000 * 24) + sub.phase.execution_time_limit):
+        # Use started_when for Running submissions, created_when as fallback for others
+	    # The deadline waits for 10 minutes after the phase execution time limit before failing submissions
+        reference_time = sub.started_when if sub.started_when else sub.created_when
+        deadline = reference_time + timedelta(
+            milliseconds=(60000 * 10) + sub.phase.execution_time_limit
+        )
+
+        if now() > deadline:
             if sub.parent is not None:
                 sub.parent.cancel(status=Submission.FAILED)
             else:

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -924,6 +924,14 @@ def update_phase_statuses():
 @app.task(queue="site-worker")
 def submission_status_cleanup():
     # Recover submissions stuck in any non-terminal state
+    # There are multiple special cases that we have to deal with:
+    # - Submission stuck in Submitted, Preparing, Running or Scoring because of a network error or a problem on the compute worker (simple case this code aims to fix)
+    # - RabbitMQ failure (usually means submissions are stuck in Submitting)
+    # - Competitions with Auto Run-Submissions disabled (submissions appear "stuck" in Submitted until an organizer runs them manually)
+    # - Submission that appear to be stuck in Submitted, Preparing, Running, Scoring but are not for multiple reasons :
+    #       - Lack of Compute workers in a queue, the submission is not stuck but waiting its turn
+    #       - Submission file is heavy and/or the compute worker has slow network speeds
+    #       - Combination of few compute workers + long submission execution time (allowed by a high execution time limit in the competition settings)
     non_terminal_statuses = [
         Submission.SUBMITTING,
         Submission.SUBMITTED,
@@ -939,13 +947,62 @@ def submission_status_cleanup():
     for sub in submissions:
         # Use started_when for Running submissions, created_when as fallback for others
         # The deadline waits for 30 minutes after the phase execution time limit before failing submissions (making sure big submissions have time to upload)
-        reference_time = sub.started_when if sub.started_when else sub.created_when
-        deadline = reference_time + timedelta(
-            milliseconds=(60000 * 30) + sub.phase.execution_time_limit
-        )
+        if sub.started_when is not None:
+            reference_time = sub.started_when
+            deadline = reference_time + timedelta(
+                milliseconds=(60000 * 30) + sub.phase.execution_time_limit
+            )
 
-        if now() > deadline:
-            if sub.parent is not None:
-                sub.parent.cancel(status=Submission.FAILED)
+            if now() > deadline:
+                if sub.parent is not None:
+                    sub.parent.cancel(status=Submission.FAILED)
+                    sub_edit = Submission.objects.get(id=sub.id)
+                    sub_edit.status_details = "Stuck submission was automatically failed"
+                    sub_edit.save()
+                else:
+                    sub.cancel(status=Submission.FAILED)
+                    sub_edit = Submission.objects.get(id=sub.id)
+                    sub_edit.status_details = "Stuck submission was automatically failed"
+                    sub_edit.save()
+        # The first if will filter out Preparing, Running and Scoring submissions. Only Submitting and Submitted are left to deal with
+        else:
+            # If a submission is stuck in SUBMITTING for 10 minutes after its creation
+            # then Rabbit might have failed, in which case the submission is unrecoverable
+            if sub.status == "SUBMITTING":
+                reference_time = sub.created_when
+                deadline = reference_time + timedelta(
+                    milliseconds=(60000 * 10)
+                )
+
+                if now() > deadline:
+                    if sub.parent is not None:
+                        sub.parent.cancel(status=Submission.FAILED)
+                        sub_edit = Submission.objects.get(id=sub.id)
+                        sub_edit.status_details = "Stuck submission was automatically failed (Check RabbitMQ health)"
+                        sub_edit.save()
+                    else:
+                        sub.cancel(status=Submission.FAILED)
+                        sub_edit = Submission.objects.get(id=sub.id)
+                        sub_edit.status_details = "Stuck submission was automatically failed (Check RabbitMQ health)"
+                        sub_edit.save()
             else:
-                sub.cancel(status=Submission.FAILED)
+                # Special case where the competition has Auto Run Submission set to True.
+                # Otherwise, we might fail submissions if the organizer is not fast enough to start the submission
+                # TODO: Better logic to not Fail submissions that are stuck because of low Queue capacity
+                if sub.phase.competition.auto_run_submissions:
+                    reference_time = sub.created_when
+                    deadline = reference_time + timedelta(
+                        milliseconds=(60000 * 30) + sub.phase.execution_time_limit
+                    )
+
+                    if now() > deadline:
+                        if sub.parent is not None:
+                            sub.parent.cancel(status=Submission.FAILED)
+                            sub_edit = Submission.objects.get(id=sub.id)
+                            sub_edit.status_details = "Stuck submission was automatically failed"
+                            sub_edit.save()
+                        else:
+                            sub.cancel(status=Submission.FAILED)
+                            sub_edit = Submission.objects.get(id=sub.id)
+                            sub_edit.status_details = "Stuck submission was automatically failed"
+                            sub_edit.save()

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -925,6 +925,7 @@ def update_phase_statuses():
 def submission_status_cleanup():
     # Recover submissions stuck in any non-terminal state
     non_terminal_statuses = [
+        Submission.SUBMITTING,
         Submission.SUBMITTED,
         Submission.PREPARING,
         Submission.RUNNING,
@@ -937,10 +938,10 @@ def submission_status_cleanup():
 
     for sub in submissions:
         # Use started_when for Running submissions, created_when as fallback for others
-        # The deadline waits for 10 minutes after the phase execution time limit before failing submissions
+        # The deadline waits for 30 minutes after the phase execution time limit before failing submissions (making sure big submissions have time to upload)
         reference_time = sub.started_when if sub.started_when else sub.created_when
         deadline = reference_time + timedelta(
-            milliseconds=(60000 * 10) + sub.phase.execution_time_limit
+            milliseconds=(60000 * 30) + sub.phase.execution_time_limit
         )
 
         if now() > deadline:

--- a/src/apps/competitions/tests/test_submissions.py
+++ b/src/apps/competitions/tests/test_submissions.py
@@ -427,6 +427,51 @@ class TestSubmissionTasks(SubmissionTestCase):
         assert self.submission_pass.status == Submission.RUNNING
         assert self.submission_fail.status == Submission.FAILED
 
+    def test_cleanup_recovers_stuck_submitted_submissions(self):
+        """Submissions stuck in Submitted should be recovered by cleanup."""
+        sub = self.make_submission()
+        sub.status = Submission.SUBMITTED
+        sub.created_when = timezone.now() - timedelta(hours=48)
+        sub.save(ignore_submission_limit=True)
+
+        submission_status_cleanup()
+        sub.refresh_from_db()
+        assert sub.status == Submission.FAILED
+
+    def test_cleanup_recovers_stuck_preparing_submissions(self):
+        """Submissions stuck in Preparing should be recovered by cleanup."""
+        sub = self.make_submission()
+        sub.status = Submission.PREPARING
+        sub.created_when = timezone.now() - timedelta(hours=48)
+        sub.save(ignore_submission_limit=True)
+
+        submission_status_cleanup()
+        sub.refresh_from_db()
+        assert sub.status == Submission.FAILED
+
+    def test_cleanup_recovers_stuck_scoring_submissions(self):
+        """Submissions stuck in Scoring should be recovered by cleanup."""
+        sub = self.make_submission()
+        sub.status = Submission.SCORING
+        sub.created_when = timezone.now() - timedelta(hours=48)
+        sub.save(ignore_submission_limit=True)
+
+        submission_status_cleanup()
+        sub.refresh_from_db()
+        assert sub.status == Submission.FAILED
+
+    def test_cleanup_does_not_touch_recent_non_terminal_submissions(self):
+        """Recent submissions in non-terminal states should NOT be cleaned up."""
+        for status in [Submission.SUBMITTED, Submission.PREPARING, Submission.SCORING]:
+            sub = self.make_submission()
+            sub.status = status
+            sub.created_when = timezone.now()
+            sub.save(ignore_submission_limit=True)
+
+            submission_status_cleanup()
+            sub.refresh_from_db()
+            assert sub.status == status, f"Recent {status} submission should not be cleaned up"
+
     def test_cancelling_parent_submission_cancels_all_children(self):
         self.parent_submission = self.make_submission()
         self.parent_submission.has_children = True

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -584,3 +584,6 @@ RERUN_SUBMISSION_LIMIT = os.environ.get('RERUN_SUBMISSION_LIMIT', 30)
 # =============================================================================
 ENABLE_SIGN_UP = os.environ.get('ENABLE_SIGN_UP', 'True').lower() == 'true'
 ENABLE_SIGN_IN = os.environ.get('ENABLE_SIGN_IN', 'True').lower() == 'true'
+
+# Data Upload limit (used in django admin when selecing multiple items, or when adding multiple participants in the Participant Routing feature)
+DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.environ.get('DJANGO_DATA_UPLOAD_MAX_NUMBER_FIELDS', 2000))

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -257,7 +257,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'submission_status_cleanup': {
         'task': 'competitions.tasks.submission_status_cleanup',
-        'schedule': timedelta(seconds=3600)
+        'schedule': timedelta(seconds=7200)
     },
     'create_storage_analytics_snapshot': {
         'task': 'analytics.tasks.create_storage_analytics_snapshot',


### PR DESCRIPTION
Original PR  #2414 
# Description
Fixes a bug where submissions stuck in non-terminal states (Submitted, Preparing, Scoring) would hang forever instead of being recovered by the cleanup task.

**Problem:** The `submission_status_cleanup()` task only recovered submissions stuck in `Running` state. Submissions that never reached `Running` (stuck in `Submitted`, `Preparing`, or `Scoring`) would never be cleaned up.

**Root cause:** 
- Cleanup only checked for `Running` status
- No fallback for submissions without `started_when` (those that never reached Running)

**Solution:**
1. Extend cleanup to cover **all** non-terminal states: `Submitted`, `Preparing`, `Running`, `Scoring`
2. Use `created_when` as fallback when `started_when` is null
3. All non-terminal submissions now recovered after 24h + execution_time_limit

**Code changes:**
- `src/apps/competitions/tasks.py`:
  - Extended non_terminal_statuses list to include all states
  - Added created_when fallback: `reference_time = started_when if started_when else created_when`

- `src/apps/competitions/tests/test_submissions.py`:
  - Added 4 unit tests for new states (Submitted, Preparing, Scoring)
  - Added negative test for recent submissions
  - All tests pass

# Issues this PR resolves
Fixes #2413

# Background
This bug was discovered during the EEG Foundation Challenge incident analysis where submissions were observed stuck in non-Running states for extended periods with no recovery mechanism.

# Checklist for hand testing
- [ ] Create a competition with at least one phase
- [ ] Submit submissions and verify they get stuck when compute_worker is stopped
- [ ] Age submissions to >24h
- [ ] Run cleanup task: `docker compose exec django python manage.py shell -c "from competitions.tasks import submission_status_cleanup; submission_status_cleanup()"`
- [ ] Verify all stuck submissions marked as Failed

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCI tests are passing
- [ ] Ready to merge