### PR TITLE
Manual image scan run option

### DIFF
--- a/.github/workflows/image_scan.yml
+++ b/.github/workflows/image_scan.yml
@@ -1,8 +1,10 @@
 name: scan_image_for_CVE
 on:
+  workflow_dispatch:
   # Every day at  00:00
   schedule:
-   - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
+
 jobs:
   scan_image:
     name: Scan compute worker image with Trivy
@@ -14,6 +16,6 @@ jobs:
           image-ref: 'codalab/codabench-compute-worker:latest'
           format: 'table'
           exit-code: '1'
-          pkg-types: 'os,library'
+          vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
           scanners: 'vuln'


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Add an option to manually launch the image trivy image scan Github Action

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

