### PR TITLE
Manual CW image creation

### DIFF
--- a/.github/workflows/build_cw_image-prod.yml
+++ b/.github/workflows/build_cw_image-prod.yml
@@ -1,5 +1,6 @@
 name: build_CW_docker_image_master
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -13,7 +14,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5
-      - name: Build Image
+      - name: Build Image with Codabench Version as tag
         run: docker build -t codalab/codabench-compute-worker:${{ github.ref_name }} -f packaging/container/Containerfile.compute_worker .
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -22,7 +23,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push image with prod release tag
         run: docker push codalab/codabench-compute-worker:${{ github.ref_name }}
-      - name: Change tag to latest
+      - name: Change tag to latest and push
         run: |
           docker tag codalab/codabench-compute-worker:${{ github.ref_name }} codalab/codabench-compute-worker:latest
           docker push codalab/codabench-compute-worker:latest
+      - name: Change tag to prod release tag + date for CVEs versioning and push
+        run: |
+          NOW=$(date "+%Y-%m-%dT%H-%M-%S")
+          docker tag codalab/codabench-compute-worker:latest codalab/codabench-compute-worker:${{ github.ref_name }}-${NOW}
+          docker push codalab/codabench-compute-worker:${{ github.ref_name }}-${NOW}


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
- Add a timestamp for image creation for the production branch (master)
- Add an option to manually run the Image creation workflow for production (with the production tag)


# Issues this PR resolves
Closes #2471

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

