### PR TITLE
CIRCLE CI config version updated to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   test:
@@ -92,7 +92,6 @@ jobs:
           path: dockerLogs/
 
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - test


### PR DESCRIPTION
On circle ci a message was shown to update config version from 2.0 to 2.1. 
<img width="1369" height="94" alt="Screenshot 2026-08-03 at 11 59 26 PM" src="https://github.com/user-attachments/assets/a6337ece-324f-49d9-9225-0c7478525fa1" />
https://discuss.circleci.com/t/breaking-change-sunsetting-configuration-version-2-0/54605


This PR updates that version in `.circleci/config.yml`

