### PR TITLE
Queue creation error improved

### DIFF
--- a/src/apps/api/serializers/queues.py
+++ b/src/apps/api/serializers/queues.py
@@ -51,9 +51,16 @@ class QueueCreationSerializer(QueueOwnerMixin, DefaultUserCreateMixin, serialize
         )
 
     def validate(self, attrs):
-        request = self.context.get('request')
-        if request.user.queues.count() == request.user.rabbitmq_queue_limit and not request.user.is_superuser:
-            raise PermissionDenied("User has reached queue limit!")
+        # Only check the limit on creation (when self.instance is None)
+        if self.instance is None:
+            request = self.context.get('request')
+            if (
+                request
+                and not request.user.is_superuser
+                and request.user.queues.count() >= request.user.rabbitmq_queue_limit
+            ):
+                raise PermissionDenied("User has reached queue limit!")
+
         return super().validate(attrs)
 
 

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -124,7 +124,7 @@ class CompetitionViewSet(ModelViewSet):
                     # And competitions where you are admin
                     # And public competitions
                     # And competitions where you are approved participant
-                    # this filters out all private compettions from other users
+                    # this filters out all private competitions from other users
                     base_qs = qs.filter(
                         (Q(created_by=self.request.user)) |
                         (Q(collaborators__in=[self.request.user])) |

--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -64,14 +64,21 @@ class GetMyProfile(RetrieveAPIView, GenericAPIView):
 @login_required
 def user_lookup(request):
     search = request.GET.get('q', '')
-    filters = Q()
     is_admin = request.user.is_superuser or request.user.is_staff
 
-    if search:
-        filters |= Q(username__icontains=search)
-        filters |= Q(email__icontains=search) if is_admin else Q(email__iexact=search)
+    # Start with base query strictly excluding deleted & current user
+    queryset = User.objects.filter(is_deleted=False).exclude(id=request.user.id)
 
-    users = User.objects.exclude(id=request.user.id).filter(filters)[:5]
+    if search:
+        search_filter = Q(username__icontains=search)
+        if is_admin:
+            search_filter |= Q(email__icontains=search)
+        else:
+            search_filter |= Q(email__iexact=search)
+
+        queryset = queryset.filter(search_filter)
+
+    users = queryset[:5]
 
     # Helper to print username with email for admins
     def _get_data(user):

--- a/src/static/riot/queues/management.tag
+++ b/src/static/riot/queues/management.tag
@@ -276,7 +276,14 @@
                     self.update_queues()
                 })
                 .fail(function (response) {
-                    toastr.error("An error occurred!")
+                    let errorMsg = 
+                        _.get(response, 'responseJSON.detail') || 
+                        _.get(response, 'responseJSON.error') || 
+                        _.get(response, 'responseJSON.message') || 
+                        _.get(response, 'statusText') || 
+                        "An unknown error occurred!"
+
+                    toastr.error(errorMsg)
                 })
         }
 


### PR DESCRIPTION
# Description
Queue creation has a limit for users (5/user). If user wanted to create 6th queue this error was shown:
<img width="1259" height="563" alt="Screenshot 2026-08-04 at 5 22 23 PM" src="https://github.com/user-attachments/assets/1f42ebe7-4ff3-4633-96a4-f6e4e80a3c6d" />

Now users will see the actual error:
<img width="1304" height="558" alt="Screenshot 2026-08-04 at 5 23 41 PM" src="https://github.com/user-attachments/assets/c387f8da-d599-4457-baa1-61b4dbac8cd9" />


### Addional Fixes:
- restriction removed for adding collaborators when queue creation limit is reached
- fixed user lookup for collaborators to not show deleted users


# Issues this PR resolves
- #2468




# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

