### PR TITLE
Support HTTPS RabbitMQ management endpoints

### DIFF
--- a/src/utils/context_processors.py
+++ b/src/utils/context_processors.py
@@ -50,7 +50,10 @@ def common_settings(request):
         'STORAGE_TYPE': settings.STORAGE_TYPE,
         'MAX_EXECUTION_TIME_LIMIT': settings.MAX_EXECUTION_TIME_LIMIT,
         'USER_JSON_DATA': json.dumps(user_json_data),
-        'RABBITMQ_MANAGEMENT_URL': f"http://{settings.DOMAIN_NAME}:{settings.RABBITMQ_MANAGEMENT_PORT}",
+        'RABBITMQ_MANAGEMENT_URL': (
+            f"{settings.RABBITMQ_SCHEME}://"
+            f"{settings.RABBITMQ_HOST}:{settings.RABBITMQ_MANAGEMENT_PORT}"
+        ),
         'FLOWER_URL': f"http://{settings.DOMAIN_NAME}:{settings.FLOWER_PUBLIC_PORT}",
         'ENABLE_SIGN_UP': settings.ENABLE_SIGN_UP,
         'ENABLE_SIGN_IN': settings.ENABLE_SIGN_IN,

--- a/src/utils/worker_utils.py
+++ b/src/utils/worker_utils.py
@@ -16,7 +16,10 @@ def _rabbitmq_auth():
 
 
 def _rabbitmq_base_url():
-    return f"http://{settings.RABBITMQ_HOST}:{settings.RABBITMQ_MANAGEMENT_PORT}/api"
+    return (
+        f"{settings.RABBITMQ_SCHEME}://"
+        f"{settings.RABBITMQ_HOST}:{settings.RABBITMQ_MANAGEMENT_PORT}/api"
+    )
 
 
 def _build_vhost_to_source_map():
@@ -66,8 +69,11 @@ def fetch_compute_workers():
         all_queues = _fetch_all_queues()
         all_channels = _fetch_all_channels()
         all_consumers = _fetch_all_consumers()
-    except Exception:
-        logger.exception("Failed to fetch RabbitMQ data")
+    except Exception as exc:
+        # Do not log the traceback here. requests carries the HTTP basic-auth
+        # tuple in its call locals, and traceback-rich logging can expose the
+        # RabbitMQ password.
+        logger.error("Failed to fetch RabbitMQ data: %s", type(exc).__name__)
         return [], [], []
 
     try:


### PR DESCRIPTION
This PR adds the ability to configure the scheme for the rabbitmq management endpoint. This is needed if you want to use https for example.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

