### PR TITLE
Add pagination to GET /api/competitions and fix participating_in leak

### DIFF
--- a/src/apps/api/tests/test_competitions.py
+++ b/src/apps/api/tests/test_competitions.py
@@ -84,6 +84,61 @@ class CompetitionTests(APITestCase):
         assert not Competition.objects.filter(pk=self.comp.pk).exists()
 
 
+class CompetitionListTests(APITestCase):
+    def setUp(self):
+        self.user = UserFactory(username='user', password='user')
+        self.client.force_authenticate(user=self.user)
+
+    def test_list_endpoint_is_paginated(self):
+        # Create 3 competitions organized by the user
+        for _ in range(3):
+            CompetitionFactory(created_by=self.user)
+
+        url = reverse('competition-list')
+        response = self.client.get(url, {'mine': 'true', 'type': 'any', 'page_size': 2})
+
+        assert response.status_code == 200
+        assert set(response.data.keys()) == {'next', 'previous', 'count', 'page_size', 'results'}
+        assert response.data['count'] == 3
+        assert len(response.data['results']) == 2
+        assert response.data['next'] is not None
+        assert response.data['previous'] is None
+
+    def test_participating_in_excludes_organized_competitions(self):
+        # Competition the user organizes: they're auto-added as an approved participant
+        # under the hood (see Competition.save()), but this should NOT show up as "participating"
+        organized = CompetitionFactory(created_by=self.user)
+
+        # Competition the user genuinely participates in
+        other_creator = UserFactory(username='other_creator', password='other')
+        participated = CompetitionFactory(created_by=other_creator, published=True)
+        CompetitionParticipantFactory(user=self.user, competition=participated, status='approved')
+
+        url = reverse('competition-list')
+        response = self.client.get(url, {'participating_in': 'true'})
+
+        assert response.status_code == 200
+        returned_ids = [c['id'] for c in response.data['results']]
+        assert participated.id in returned_ids
+        assert organized.id not in returned_ids
+
+    def test_mine_returns_organized_competitions(self):
+        # Sanity check that the "organizing" filter is unaffected by the participating_in fix
+        organized = CompetitionFactory(created_by=self.user)
+
+        other_creator = UserFactory(username='other_creator', password='other')
+        participated = CompetitionFactory(created_by=other_creator, published=True)
+        CompetitionParticipantFactory(user=self.user, competition=participated, status='approved')
+
+        url = reverse('competition-list')
+        response = self.client.get(url, {'mine': 'true', 'type': 'any'})
+
+        assert response.status_code == 200
+        returned_ids = [c['id'] for c in response.data['results']]
+        assert organized.id in returned_ids
+        assert participated.id not in returned_ids
+
+
 class PhaseMigrationTests(APITestCase):
     def setUp(self):
         self.creator = UserFactory(username='creator', password='creator')

--- a/src/apps/api/tests/test_public_competitions.py
+++ b/src/apps/api/tests/test_public_competitions.py
@@ -139,6 +139,10 @@ class PublicCompetitionsTests(TestCase):
         # Check that the competition the user is NOT participating in (self.competition1) is excluded
         self.assertNotIn(self.competition3.id, returned_ids)  # Not participating in this
 
+        # Check that a competition the user organizes (as a collaborator) is excluded, even though
+        # collaborators are auto-added as approved participants under the hood
+        self.assertNotIn(self.competition1.id, returned_ids)  # Organizing this, not "participating in" it
+
     def test_filter_by_organizing(self):
         # Send GET request to the public competitions API with the filter: organizing=true
         # This should return competitions where the request user is the creator or a collaborator

--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -42,6 +42,7 @@ from django.conf import settings
 class CompetitionViewSet(ModelViewSet):
     queryset = Competition.objects.all()
     permission_classes = (AllowAny,)
+    pagination_class = LargePagination
 
     def get_queryset(self):
 
@@ -61,7 +62,7 @@ class CompetitionViewSet(ModelViewSet):
         # If user is logged in
         if self.request.user.is_authenticated:
 
-            # `mine` is true when this is called from "Benchmarks I'm Running"
+            # `mine` is true when this is called from "Organizing" tab of benchmark management
             # Filter to only see competitions you own
             mine = self.request.query_params.get('mine', None)
             if mine:
@@ -73,10 +74,16 @@ class CompetitionViewSet(ModelViewSet):
                     (Q(collaborators__in=[self.request.user]))
                 ).distinct()
 
-            # `participating_in` is true when this is called from "Benchmarks I'm in"
+            # `participating_in` is true when this is called from "Participating" tab of benchmark management
             participating_in = self.request.query_params.get('participating_in', None)
             if participating_in:
-                qs = qs.filter(participants__user=self.request.user, participants__status="approved")
+                # Exclude competitions the user organizes: creators/collaborators are auto-added
+                # as approved participants (see Competition.save()), but they belong in "Organizing" tab, not here.
+                qs = qs.filter(
+                    participants__user=self.request.user, participants__status="approved"
+                ).exclude(
+                    Q(created_by=self.request.user) | Q(collaborators=self.request.user)
+                )
 
             participant_status_query = CompetitionParticipant.objects.filter(
                 competition=OuterRef('pk'),
@@ -620,9 +627,13 @@ class CompetitionViewSet(ModelViewSet):
 
         # Filter by participation
         if participating_in:
+            # Exclude competitions the user organizes: creators/collaborators are auto-added
+            # as approved participants (see Competition.save()), but they belong under "organizing", not here.
             participant_comp_ids = CompetitionParticipant.objects.filter(
                 user=request.user,
                 status="approved"
+            ).exclude(
+                Q(competition__created_by=request.user) | Q(competition__collaborators=request.user)
             ).values_list("competition_id", flat=True)
             qs = qs.filter(id__in=participant_comp_ids)
 

--- a/src/static/riot/competitions/competition_list.tag
+++ b/src/static/riot/competitions/competition_list.tag
@@ -4,8 +4,8 @@
             <div class="row">
                 <div class="fourteen wide column">
                     <div class="ui fluid secondary pointing tabular menu">
-                        <a class="active item" data-tab="running">Benchmarks I'm Running</a>
-                        <a class="item" data-tab="participating">Benchmarks I'm In</a>
+                        <a class="active item" data-tab="running">Organizing</a>
+                        <a class="item" data-tab="participating">Participating</a>
                         <div class="right menu">
                             <div class="item">
                                 <help_button href="https://docs.codabench.org/latest/Organizers/Running_a_benchmark/Competition-Management-%26-List/"></help_button>
@@ -25,7 +25,7 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr each="{ competition in running_competitions }" no-reorder>
+                            <tr each="{ competition in organizing_competitions.results }" no-reorder>
                                 <td><a href="{ URLS.COMPETITION_DETAIL(competition.id) }">{ competition.title }</a></td>
                                 <td class="center aligned">{ competition.competition_type }</td>
                                 <td>{ timeSince(Date.parse(competition.created_when)) } ago</td>
@@ -55,6 +55,13 @@
                             <tfoot>
                             </tfoot>
                         </table>
+                        <div class="pagination-nav" if="{organizing_competitions.next || organizing_competitions.previous}">
+                            <button show="{organizing_competitions.previous}" onclick="{change_page.bind(this, 'organizing', -1)}" class="float-left ui inline button active">Back</button>
+                            <button hide="{organizing_competitions.previous}" disabled="disabled" class="float-left ui inline button disabled">Back</button>
+                            { organizing_page } of { Math.ceil(organizing_competitions.count / organizing_competitions.page_size) }
+                            <button show="{organizing_competitions.next}" onclick="{change_page.bind(this, 'organizing', 1)}" class="float-right ui inline button active">Next</button>
+                            <button hide="{organizing_competitions.next}" disabled="disabled" class="float-right ui inline button disabled">Next</button>
+                        </div>
                     </div>
                     <div class="ui tab" data-tab="participating">
                         <table class="ui celled compact table">
@@ -65,7 +72,7 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr each="{ competition in participating_competitions }" style="height: 42px;">
+                            <tr each="{ competition in participating_in_competitions.results }" style="height: 42px;">
                                 <td><a href="{ URLS.COMPETITION_DETAIL(competition.id) }">{ competition.title }</a></td>
                                 <td>{ timeSince(Date.parse(competition.created_when)) } ago</td>
                             </tr>
@@ -73,6 +80,13 @@
                             <tfoot>
                             </tfoot>
                         </table>
+                        <div class="pagination-nav" if="{participating_in_competitions.next || participating_in_competitions.previous}">
+                            <button show="{participating_in_competitions.previous}" onclick="{change_page.bind(this, 'participating', -1)}" class="float-left ui inline button active">Back</button>
+                            <button hide="{participating_in_competitions.previous}" disabled="disabled" class="float-left ui inline button disabled">Back</button>
+                            { participating_page } of { Math.ceil(participating_in_competitions.count / participating_in_competitions.page_size) }
+                            <button show="{participating_in_competitions.next}" onclick="{change_page.bind(this, 'participating', 1)}" class="float-right ui inline button active">Next</button>
+                            <button hide="{participating_in_competitions.next}" disabled="disabled" class="float-right ui inline button disabled">Next</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -81,6 +95,11 @@
     <script>
         var self = this
 
+        self.organizing_competitions = {}
+        self.participating_in_competitions = {}
+        self.organizing_page = 1
+        self.participating_page = 1
+
         self.one("mount", function () {
             self.update_competitions()
             $('.tabular.menu .item').tab();
@@ -88,7 +107,7 @@
 
         self.update_competitions = function () {
             self.get_participating_in_competitions()
-            self.get_running_competitions()
+            self.get_organizing_competitions()
         }
 
         self.get_competitions_wrapper = function (query_params) {
@@ -99,22 +118,33 @@
         }
 
         self.get_participating_in_competitions = function () {
-            self.get_competitions_wrapper({participating_in: true})
+            self.get_competitions_wrapper({participating_in: true, page: self.participating_page})
                 .done(function (data) {
-                    self.participating_competitions = data
+                    self.participating_in_competitions = data
                     self.update()
                 })
         }
 
-        self.get_running_competitions = function () {
+        self.get_organizing_competitions = function () {
             self.get_competitions_wrapper({
                 mine: true,
                 type: 'any',
+                page: self.organizing_page,
             })
                 .done(function (data) {
-                    self.running_competitions = data
+                    self.organizing_competitions = data
                     self.update()
                 })
+        }
+
+        self.change_page = function (tab, direction) {
+            if (tab === 'organizing') {
+                self.organizing_page += direction
+                self.get_organizing_competitions()
+            } else {
+                self.participating_page += direction
+                self.get_participating_in_competitions()
+            }
         }
 
         self.delete_competition = function (competition) {
@@ -135,7 +165,7 @@
                 .done(function (data) {
                     var published_state = data.published ? "published" : "unpublished"
                     toastr.success(`Competition has been ${published_state} successfully`)
-                    self.get_running_competitions()
+                    self.get_organizing_competitions()
                 })
         }
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -341,11 +341,11 @@
             $('#site-wide-competition-search').search({
                 apiSettings: {
                     onResponse: function(codalabResponse) {
-                        _.forEach(codalabResponse, (response) => {
+                        _.forEach(codalabResponse.results, (response) => {
                             response.url = URLS.COMPETITION_DETAIL(response.id)
                         })
                         return {
-                            results: codalabResponse,
+                            results: codalabResponse.results,
                         }
                     },
                     url: `${URLS.API}competitions/?search={query}`


### PR DESCRIPTION
# Description
- Paginate the competition list endpoint (LargePagination), and update the Organizing/Participating tabs in competition_list.tag to consume the new {count, next, previous, results} shape with next/previous buttons (hidden on a single page). 
- Fix the navbar competition search to read response.results instead of assuming a bare array.

- Fix participating_in filter incorrectly including competitions the user organizes: creators/collaborators are auto-added as approved participants (Competition.save()), so they leaked into the Participating tab. 
- Applied the same fix to the public competitions endpoint's participating_in filter and updated its tests. 
- Added coverage for the list endpoint's pagination and participating_in behavior. 
- Minor renames for clarity (change_page, tab labels).



# Issues this PR resolves
- Closes #2481 

# Screenshots

Organizing Tab pagination
<img width="1025" height="316" alt="Screenshot 2026-08-07 at 5 52 41 PM" src="https://github.com/user-attachments/assets/a989793b-5569-44ea-ba06-7d0b63a81828" />

Participating Tab pagination
<img width="1029" height="296" alt="Screenshot 2026-08-07 at 5 52 46 PM" src="https://github.com/user-attachments/assets/2a8eb73c-4c9f-4e09-b78b-fb0f39bd1bfd" />

No pagination when api response has only 1 page
<img width="1032" height="335" alt="Screenshot 2026-08-07 at 5 52 56 PM" src="https://github.com/user-attachments/assets/52ce294b-47da-457d-be65-afd376d33b4c" />






# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

