### PR TITLE
Fix organization name not showing on leaderboard for multi-task competitions

### DIFF
--- a/src/apps/competitions/models.py
+++ b/src/apps/competitions/models.py
@@ -165,6 +165,7 @@ class Competition(models.Model):
                 phase=next_phase,
                 owner=submission.owner,
                 data=submission.data,
+                organization=submission.organization,
             )
             new_submission.save(ignore_submission_limit=True)
             new_submission.start()
@@ -656,7 +657,8 @@ class Submission(models.Model):
             'has_children': self.has_children,
             'is_specific_task_re_run': is_specific_task_re_run,
             'fact_sheet_answers': self.fact_sheet_answers,
-            'queue': self.phase.competition.queue
+            'queue': self.phase.competition.queue,
+            'organization': self.organization,
         }
         sub = Submission(**submission_arg_dict)
         sub.save(ignore_submission_limit=True)

--- a/src/apps/competitions/tasks.py
+++ b/src/apps/competitions/tasks.py
@@ -453,6 +453,7 @@ def _run_submission(submission_pk, task_pks=None, is_scoring=False):
                 task=task,
                 fact_sheet_answers=submission.fact_sheet_answers,
                 queue=queue,
+                organization=submission.organization,
             )
             child_sub.save(ignore_submission_limit=True)
             _send_to_compute_worker(child_sub, is_scoring=False)


### PR DESCRIPTION
# Description

Propagate organization when creating chiled submissions during multi-task split, phase migration, and re-run so that leaderboard entries for organization submissions on multi-task competitions show the organization name instead of falling back to the submitter's username.



# Issues this PR resolves
- #1611

# Screenshots after fix:

Already working ok on single task competition:
<img width="1181" height="292" alt="Screenshot 2026-08-10 at 11 56 18 AM" src="https://github.com/user-attachments/assets/3fc80103-8ae3-4166-8489-4e383fdf3d07" />

Fixed the problem for multi-task competition:
<img width="1191" height="290" alt="Screenshot 2026-08-10 at 11 58 06 AM" src="https://github.com/user-attachments/assets/b0b26c0e-edf5-4440-a4f5-59362ce05b8b" />



# A checklist for hand testing
- [x] Submit to single task competition with and without organization and check that on the leaderboard you see the correct submitter
- [x] Do the same for multi task competition



# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

