### PR TITLE
Document how to link one competition page to another

### DIFF
--- a/documentation/docs/Organizers/Benchmark_Creation/Competition-Creation-Form.md
+++ b/documentation/docs/Organizers/Benchmark_Creation/Competition-Creation-Form.md
@@ -32,6 +32,15 @@ Clicking `Add page` should present you a modal with the following layout:
 - Title: The title of the page you are adding
 - Content: The content of your page formatted as Markdown.
 
+!!! Tip "Linking to another page"
+    You can link from one page's content to another page (or to the Terms page) by adding an anchor tag that triggers a click on the target tab:
+
+    ```html
+    <a onclick="javascript:$('.item[data-tab=_tab_page1]').trigger('click');">Go to Evaluation</a>
+    ```
+
+    Pages are numbered in the order they appear, starting from `_tab_page0`, `_tab_page1`, `_tab_page2`, and so on. The Terms page is the one exception and is always targeted with `_tab_page_term`, regardless of its position.
+
 ## Phases
 The phases section allows you to define your phases and their attached tasks.
 

--- a/documentation/docs/Project_CodaBench_FAQ.md
+++ b/documentation/docs/Project_CodaBench_FAQ.md
@@ -24,6 +24,9 @@ Follow the detailed instruction [here](Organizers/Benchmark_Creation/Public-Task
 ### How to delete my account?
 Click on your account name on the top right of the website, then on `account`
 
+### How to link one competition page to another?
+Follow the detailed instructions [here](Organizers/Benchmark_Creation/Competition-Creation-Form.md#pages) to link from one page's content to another page (or the Terms page) on your competition.
+
 
 
 ***


### PR DESCRIPTION
# Description
Add a tip in the Pages section of Competition-Creation-Form.md showing the anchor/data-tab snippet to link between pages, including the _tab_page0/_tab_page_term numbering rule, and cross-link it from the FAQ.


# Issues this PR resolves
- #2368


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge

