### PR TITLE
Standardize email plain-text templates and link generation

### DIFF
--- a/src/apps/api/views/competitions.py
+++ b/src/apps/api/views/competitions.py
@@ -362,16 +362,16 @@ class CompetitionViewSet(ModelViewSet):
             participant.status = 'approved'
         elif competition.registration_auto_approve:
             participant.status = 'approved'
-            send_participation_accepted_emails(participant)
+            send_participation_accepted_emails(participant, request)
         else:
             # check if user is in whitelist emails then approve directly
             # Using lower case because some users have used uppercased emails addresses
             if user.email.lower() in list(competition.whitelist_emails.values_list('email', flat=True)):
                 participant.status = 'approved'
-                send_participation_accepted_emails(participant)
+                send_participation_accepted_emails(participant, request)
             else:
                 participant.status = 'pending'
-                send_participation_requested_emails(participant)
+                send_participation_requested_emails(participant, request)
 
         participant.save()
         return Response({'participant_status': participant.status}, status=status.HTTP_201_CREATED)
@@ -1034,7 +1034,7 @@ class CompetitionParticipantViewSet(ModelViewSet):
                 'denied': send_participation_denied_emails,
             }
             if participation_status in emails:
-                emails[participation_status](participant)
+                emails[participation_status](participant, request)
 
         return super().update(request, *args, **kwargs)
 

--- a/src/apps/api/views/profiles.py
+++ b/src/apps/api/views/profiles.py
@@ -21,6 +21,7 @@ from api.serializers.profiles import MyProfileSerializer, UserSerializer, \
 from profiles.helpers import send_mail
 from profiles.models import Organization, Membership
 from profiles.views import send_delete_account_confirmation_mail
+from utils.email import get_link_context
 
 User = get_user_model()
 
@@ -180,6 +181,7 @@ class OrganizationViewSet(mixins.CreateModelMixin,
                         'user': member.user,
                         'invite_url': f'{reverse("profiles:organization_accept_invite")}?token={member.token}',
                         'organization': org.name,
+                        **get_link_context(request),
                     },
                     subject=f'You have been invited to join {org.name}',
                     html_file="profiles/emails/invite.html",

--- a/src/apps/competitions/emails.py
+++ b/src/apps/competitions/emails.py
@@ -1,17 +1,18 @@
-from utils.email import codalab_send_mail, codalab_send_markdown_email
+from utils.email import codalab_send_mail, codalab_send_markdown_email, get_link_context
 
 
 def get_organizer_emails(competition):
     return [user.email for user in competition.all_organizers if not user.is_deleted]
 
 
-def send_participation_requested_emails(participant):
+def send_participation_requested_emails(participant, request):
     if participant.user.is_deleted:
         return
 
     context = {
         'participant': participant,
-        'user': participant.user
+        'user': participant.user,
+        **get_link_context(request),
     }
     # Notify Organizers
     codalab_send_mail(
@@ -32,13 +33,14 @@ def send_participation_requested_emails(participant):
     )
 
 
-def send_participation_accepted_emails(participant):
+def send_participation_accepted_emails(participant, request):
     if participant.user.is_deleted:
         return
 
     context = {
         'participant': participant,
-        'user': participant.user
+        'user': participant.user,
+        **get_link_context(request),
     }
     codalab_send_mail(
         context_data=context,
@@ -57,13 +59,14 @@ def send_participation_accepted_emails(participant):
     )
 
 
-def send_participation_denied_emails(participant):
+def send_participation_denied_emails(participant, request):
     if participant.user.is_deleted:
         return
 
     context = {
         'participant': participant,
-        'user': participant.user
+        'user': participant.user,
+        **get_link_context(request),
     }
     # Notify Organizers
     codalab_send_mail(

--- a/src/apps/forums/models.py
+++ b/src/apps/forums/models.py
@@ -3,6 +3,8 @@ import datetime
 from django.db import models
 from django.urls import reverse
 
+from utils.email import get_link_context
+
 from .helpers import send_mail
 
 
@@ -63,7 +65,8 @@ class Thread(models.Model):
                 context={
                     'thread': self,
                     'user': user,
-                    'new_post': self.posts.last() if post is None else post
+                    'new_post': self.posts.last() if post is None else post,
+                    **get_link_context(),
                 },
                 subject='New post in %s' % self.title,
                 html_file="forums/emails/new_post.html",

--- a/src/apps/profiles/views.py
+++ b/src/apps/profiles/views.py
@@ -5,8 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.db.models import Q
-from django.contrib.sites.shortcuts import get_current_site
-from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.core.mail import EmailMultiAlternatives
 from django.http import Http404
 from django.shortcuts import render, redirect
 from django.contrib.auth import views as auth_views
@@ -28,7 +27,7 @@ from competitions.models import Competition
 from datasets.models import Data
 from tasks.models import Task
 from forums.models import Post
-from utils.email import codalab_send_mail
+from utils.email import codalab_send_mail, get_link_context
 
 
 class LoginView(auth_views.LoginView):
@@ -108,29 +107,29 @@ def activate(request, uidb64, token):
 
 
 def activateEmail(request, user, to_email):
-    mail_subject = 'Activate your user account.'
-    message = render_to_string('profiles/emails/template_activate_account.html', {
-        'username': user.username,
-        'domain': settings.DOMAIN_NAME,
+    context = {
+        'user': user,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': account_activation_token.make_token(user),
-        'protocol': 'https' if request.is_secure() else 'http'
-    })
-    email = EmailMessage(mail_subject, message, to=[to_email])
-    if email.send():
-        messages.success(request, f'Dear {user.username}, please go to your email {to_email} inbox and click on \
-            the activation link to confirm and complete the registration. *Note: Check your spam folder.')
-    else:
-        messages.error(request, f'Problem sending confirmation email to {to_email}, check if you typed it correctly.')
+        **get_link_context(request),
+    }
+    codalab_send_mail(
+        context_data=context,
+        subject='Activate your user account.',
+        html_file='profiles/emails/template_activate_account.html',
+        text_file='profiles/emails/template_activate_account.txt',
+        to_email=[to_email]
+    )
+    messages.success(request, f'Dear {user.username}, please go to your email {to_email} inbox and click on \
+        the activation link to confirm and complete the registration. *Note: Check your spam folder.')
 
 
 def send_delete_account_confirmation_mail(request, user):
     context = {
         'user': user,
-        'domain': get_current_site(request).domain,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': account_deletion_token.make_token(user),
-        'protocol': 'https' if request.is_secure() else 'http'
+        **get_link_context(request),
     }
     codalab_send_mail(
         context_data=context,
@@ -167,7 +166,7 @@ def send_user_deletion_notice_to_admin(user):
         'tasks': tasks,
         'queues': queues,
         'posts': posts,
-        'domain': settings.DOMAIN_NAME
+        **get_link_context(),
     }
     codalab_send_mail(
         context_data=context,

--- a/src/templates/emails/base_email.txt
+++ b/src/templates/emails/base_email.txt
@@ -6,12 +6,9 @@ Hello{% if user %} {{ user.username }}{% endif %},
 {% if not mass_email %}
 Thanks,
 
-CodaLab Team
+Codabench Team
 {% endif %}
 
-
-Unsubscribe or manage notification settings:
-http://{{ site.domain }}
 
 Privacy policy:
 https://github.com/codalab/codalab-competitions/wiki/Privacy

--- a/src/templates/emails/participation/organizer/participation_accepted.html
+++ b/src/templates/emails/participation/organizer/participation_accepted.html
@@ -3,7 +3,7 @@
 {% block content %}
     <p>
         User <strong>{{ participant.user.username }}</strong> has been accepted into your competition
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
+        <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
         <br>
         You can manage all participants from the admin panel of your competition.
     </p>

--- a/src/templates/emails/participation/organizer/participation_accepted.txt
+++ b/src/templates/emails/participation/organizer/participation_accepted.txt
@@ -1,10 +1,8 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>
-        User <strong>{{ participant.user.username }}</strong> has been accepted into your competition
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
-        <br>
-        You can manage all participants from the admin panel of your competition.
-    </p>
+    User {{ participant.user.username }} has been accepted into your competition {{ participant.competition.title }}.
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
+
+    You can manage all participants from the admin panel of your competition.
 {% endblock %}

--- a/src/templates/emails/participation/organizer/participation_denied.html
+++ b/src/templates/emails/participation/organizer/participation_denied.html
@@ -3,7 +3,7 @@
 {% block content %}
 <p>
     A user <strong>{{ participant.user.username }}</strong> has been denied access to your competition.
-    <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
+    <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
     <br>
     You can manage all participants from the admin panel of your competition.
 </p>

--- a/src/templates/emails/participation/organizer/participation_denied.txt
+++ b/src/templates/emails/participation/organizer/participation_denied.txt
@@ -1,10 +1,8 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-<p>
-    A user <strong>{{ participant.user.username }}</strong> has been denied access to your competition.
-    <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
-    <br>
+    A user {{ participant.user.username }} has been denied access to your competition {{ participant.competition.title }}.
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
+
     You can manage all participants from the admin panel of your competition.
-</p>
 {% endblock %}

--- a/src/templates/emails/participation/organizer/participation_requested.html
+++ b/src/templates/emails/participation/organizer/participation_requested.html
@@ -3,7 +3,7 @@
 {% block content %}
 <p>
     A user <strong>{{ participant.user.username }}</strong> has requested access to your competition
-    <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
+    <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
     <br>
     You can manage all participants from the admin panel of your competition.
 </p>

--- a/src/templates/emails/participation/organizer/participation_requested.txt
+++ b/src/templates/emails/participation/organizer/participation_requested.txt
@@ -1,10 +1,8 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-<p>
-    A user <strong>{{ participant.user.username }}</strong> has requested access to your competition
-    <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>.
-    <br>
+    A user {{ participant.user.username }} has requested access to your competition {{ participant.competition.title }}.
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
+
     You can manage all participants from the admin panel of your competition.
-</p>
 {% endblock %}

--- a/src/templates/emails/participation/participant/participation_accepted.html
+++ b/src/templates/emails/participation/participant/participation_accepted.html
@@ -3,7 +3,7 @@
 {% block content %}
     <p>
         Your application for the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
+        <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
         competition has been <b>accepted</b>. Get ready to showcase your skills and compete with other talented individuals.
     </p>
 {% endblock %}

--- a/src/templates/emails/participation/participant/participation_accepted.txt
+++ b/src/templates/emails/participation/participant/participation_accepted.txt
@@ -1,12 +1,7 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>
-        Your application for the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
-        competition has been <b>accepted</b>. Get ready to showcase your skills and compete with other talented individuals.
-    </p>
+    Your application for the {{ participant.competition.title }} competition has been accepted. Get ready to showcase your skills and compete with other talented individuals.
+
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
 {% endblock %}
-
-
-

--- a/src/templates/emails/participation/participant/participation_denied.html
+++ b/src/templates/emails/participation/participant/participation_denied.html
@@ -3,7 +3,7 @@
 {% block content %}
     <p>
         Your application for the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
+        <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
         competition has been denied. You can reach out to the organizing team for more details.
     </p>
 

--- a/src/templates/emails/participation/participant/participation_denied.txt
+++ b/src/templates/emails/participation/participant/participation_denied.txt
@@ -1,11 +1,7 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>
-        Your application for the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
-        competition has been denied. You can reach out to the organizing team for more details.
-    </p>
+    Your application for the {{ participant.competition.title }} competition has been denied. You can reach out to the organizing team for more details.
+
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
 {% endblock %}
-
-

--- a/src/templates/emails/participation/participant/participation_organizer_direct_email.html
+++ b/src/templates/emails/participation/participant/participation_organizer_direct_email.html
@@ -3,7 +3,7 @@
 {% block title %}
     <p>
         This is a message from the organizer for the competition:
-        <a href="http://{{ site.domain }}{{ competition.get_absolute_url }}">{{ competition }}</a>
+        <a href="{{ protocol }}://{{ domain }}{{ competition.get_absolute_url }}">{{ competition }}</a>
     </p>
     <br><br>
 {% endblock %}

--- a/src/templates/emails/participation/participant/participation_organizer_direct_email.txt
+++ b/src/templates/emails/participation/participant/participation_organizer_direct_email.txt
@@ -1,14 +1,11 @@
 {% extends 'emails/base_email.txt' %}
 
 {% block title %}
-    <p>
-        This is a message from the organizer for the competition:
-        <a href="http://{{ site.domain }}{{ competition.get_absolute_url }}">{{ competition }}</a>
-    </p>
-    <br><br>
+    This is a message from the organizer for the competition: {{ competition }}
+    {{ protocol }}://{{ domain }}{{ competition.get_absolute_url }}
 {% endblock %}
 
 {% block content %}
-    <h3>Message:</h3>
-    <pre>{{ body }}</pre>
+    Message:
+    {{ body }}
 {% endblock %}

--- a/src/templates/emails/participation/participant/participation_requested.html
+++ b/src/templates/emails/participation/participant/participation_requested.html
@@ -3,7 +3,7 @@
 {% block content %}
     <p>
         Thank you for your interest in the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
+        <a href="{{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
         competition. We have received your request to participate.
     </p>
     <p>

--- a/src/templates/emails/participation/participant/participation_requested.txt
+++ b/src/templates/emails/participation/participant/participation_requested.txt
@@ -1,13 +1,9 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>
-        Thank you for your interest in the
-        <a href="http://{{ site.domain }}{{ participant.competition.get_absolute_url }}">{{ participant.competition.title }}</a>
-        competition. We have received your request to participate.
-    </p>
-    <p>
-        We will carefully review your application and notify you by email regarding your participation status (accepted or denied).
-        In the meantime, you can review the competition details and rules to familiarize yourself with the challenge.
-    </p>
+    Thank you for your interest in the {{ participant.competition.title }} competition. We have received your request to participate.
+
+    {{ protocol }}://{{ domain }}{{ participant.competition.get_absolute_url }}
+
+    We will carefully review your application and notify you by email regarding your participation status (accepted or denied). In the meantime, you can review the competition details and rules to familiarize yourself with the challenge.
 {% endblock %}

--- a/src/templates/forums/emails/new_post.html
+++ b/src/templates/forums/emails/new_post.html
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html' %}
 
 {% block content %}
-    <p>There was a new post in <a href="http://{{ site.domain }}{{ thread.get_absolute_url }}">{{ thread.title }}</a>.</p>
+    <p>There was a new post in <a href="{{ protocol }}://{{ domain }}{{ thread.get_absolute_url }}">{{ thread.title }}</a>.</p>
 
     <blockquote>{{ new_post.content|linebreaks }}<p> - {{ new_post.posted_by.username }}</p></blockquote>
 {% endblock %}

--- a/src/templates/forums/emails/new_post.txt
+++ b/src/templates/forums/emails/new_post.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
     There was a new post in "{{ thread.title }}"
-    http://{{ site.domain }}{{ thread.get_absolute_url }}
+    {{ protocol }}://{{ domain }}{{ thread.get_absolute_url }}
 
 
     {{ new_post.content }}

--- a/src/templates/profiles/emails/invite.html
+++ b/src/templates/profiles/emails/invite.html
@@ -2,6 +2,6 @@
 
 {% block content %}
     <p>You have been invited to join {{ organization }}.</p>
-    <p>Click this link to accept or reject your invite. <a href="http://{{ site.domain }}{{ invite_url }}">http://{{ site.domain }}{{ invite_url }}</a></p>
+    <p>Click this link to accept or reject your invite. <a href="{{ protocol }}://{{ domain }}{{ invite_url }}">{{ protocol }}://{{ domain }}{{ invite_url }}</a></p>
 
 {% endblock %}

--- a/src/templates/profiles/emails/invite.txt
+++ b/src/templates/profiles/emails/invite.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
     You have been invited to join {{ organization }}.
-    Copy this URL into your web browser to accept. http://{{ site.domain }}{{ invite_url }}
+    Copy this URL into your web browser to accept. {{ protocol }}://{{ domain }}{{ invite_url }}
 
 
     {{ new_post.content }}

--- a/src/templates/profiles/emails/template_activate_account.html
+++ b/src/templates/profiles/emails/template_activate_account.html
@@ -1,10 +1,6 @@
-{% autoescape off %}
-Hi {{ username }},
+{% extends 'emails/base_email.html' %}
 
-Please click on the link below to confirm your registration:
-
-{{ protocol }}://{{ domain }}{% url 'profiles:activate' uidb64=uid token=token %}
-
-This is an automatic message delivered by Codabench.
-
-{% endautoescape %}
+{% block content %}
+    <p>Please click on the link below to confirm your registration:</p>
+    <p><a href="{{ protocol }}://{{ domain }}{% url 'profiles:activate' uidb64=uid token=token %}">{{ protocol }}://{{ domain }}{% url 'profiles:activate' uidb64=uid token=token %}</a></p>
+{% endblock %}

--- a/src/templates/profiles/emails/template_activate_account.txt
+++ b/src/templates/profiles/emails/template_activate_account.txt
@@ -1,0 +1,6 @@
+{% extends 'emails/base_email.txt' %}
+
+{% block content %}
+    Please click on the link below to confirm your registration:
+    {{ protocol }}://{{ domain }}{% url 'profiles:activate' uidb64=uid token=token %}
+{% endblock %}

--- a/src/templates/profiles/emails/template_delete_account.txt
+++ b/src/templates/profiles/emails/template_delete_account.txt
@@ -1,25 +1,18 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>We have received your request to delete your account.</p>
-    <p>To proceed with the deletion of your account, please confirm your request by clicking the link below:</p>
-    <p><a href="{{ protocol }}://{{ domain }}{% url 'accounts:delete' uidb64=uid token=token %}">{{ protocol }}://{{ domain }}{% url 'accounts:delete' uidb64=uid token=token %}</a></p>
+    We have received your request to delete your account.
 
-    <br>
+    To proceed with the deletion of your account, please confirm your request by clicking the link below:
+    {{ protocol }}://{{ domain }}{% url 'accounts:delete' uidb64=uid token=token %}
 
-    <p><strong>Important Information:</strong></p>
-    <ul>
-        <li>Once confirmed, all your personal data will be permanently deleted or anonymized, except for competitions and submissions retained under our user agreement.</li>
-        <li>After deletion, you will no longer be eligible for any cash prizes in ongoing or future competitions.</li>
-        <li>If you wish to delete any submissions, please do so before confirming your account deletion.</li>
-        <li>You will not be able to re-create an account using the same email address for 30 days.</li>
-    </ul>
+    Important Information:
+    - Once confirmed, all your personal data will be permanently deleted or anonymized, except for competitions and submissions retained under our user agreement.
+    - After deletion, you will no longer be eligible for any cash prizes in ongoing or future competitions.
+    - If you wish to delete any submissions, please do so before confirming your account deletion.
+    - You will not be able to re-create an account using the same email address for 30 days.
 
-    <br>
+    If you did not request this action or have changed your mind, you can safely ignore this email, and your account will remain intact.
 
-    <p>If you did not request this action or have changed your mind, you can safely ignore this email, and your account will remain intact.</p>
-
-    <br>
-
-    <p>Thank you for being part of our community.</p>
+    Thank you for being part of our community.
 {% endblock %}

--- a/src/templates/profiles/emails/template_delete_account_confirmed.txt
+++ b/src/templates/profiles/emails/template_delete_account_confirmed.txt
@@ -1,7 +1,7 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <p>Your account has been successfully removed. Thank you for being part of our community.</p>
-    <br>
-    <p>If you change your mind, you can create a new account at any time. We'd be happy to welcome you back!</p>    
+    Your account has been successfully removed. Thank you for being part of our community.
+
+    If you change your mind, you can create a new account at any time. We'd be happy to welcome you back!
 {% endblock %}

--- a/src/templates/profiles/emails/template_delete_account_notice.html
+++ b/src/templates/profiles/emails/template_delete_account_notice.html
@@ -35,7 +35,7 @@
     <ul>
         {% for organization in organizations.all %}
             <li>
-                <a class="item" href="{{ domain }}{% url 'profiles:organization_profile' pk=organization.id %}">
+                <a class="item" href="{{ protocol }}://{{ domain }}{% url 'profiles:organization_profile' pk=organization.id %}">
                     {{ organization }}
                 </a>
             </li>
@@ -46,7 +46,7 @@
     <ul>
         {% for competition in competitions_organizer.all %}
             <li>
-                <a class="item" href="{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
+                <a class="item" href="{{ protocol }}://{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
                     {{ competition }}
                 </a>
             </li>
@@ -57,7 +57,7 @@
     <ul>
         {% for competition in competitions_participation.all %}
         <li>
-            <a class="item" href="{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
+            <a class="item" href="{{ protocol }}://{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
                 {{ competition }}
             </a>
         </li>
@@ -86,7 +86,7 @@
     <ul>
         {% for task in tasks.all %}
         <li>
-            <a class="item" href="{{ domain }}{% url 'tasks:detail' pk=task.pk %}">
+            <a class="item" href="{{ protocol }}://{{ domain }}{% url 'tasks:detail' pk=task.pk %}">
                 {{ task }}
             </a>
         </li>

--- a/src/templates/profiles/emails/template_delete_account_notice.txt
+++ b/src/templates/profiles/emails/template_delete_account_notice.txt
@@ -1,110 +1,49 @@
-{% extends 'emails/base_email.html' %}
+{% extends 'emails/base_email.txt' %}
 
 {% block content %}
-    <h2>User account deletion notice</h2>
+    User account deletion notice
 
-    <p>You are receiving this notice because your are an administrator of the platform.</p>
+    You are receiving this notice because you are an administrator of the platform.
 
-    <br>
+    The following user has removed their account:
+    - id: {{ deleted_user.id }}
+    - username: {{ deleted_user.username }}
+    - email: {{ deleted_user.email }}
 
-    <p>The following user has removed their account:</p>
-    <ul>
-        <li><strong>id:</strong> {{ deleted_user.id }}</li>
-        <li><strong>username:</strong> {{ deleted_user.username }}</li>
-        <li><strong>email:</strong> {{ deleted_user.email }}</li>
-    </ul>
+    Summary
+    - Organizations: {{ organizations|length }}
+    - Competitions owner: {{ competitions_organizer|length }}
+    - Competitions participation: {{ competitions_participation|length }}
+    - Submissions: {{ submissions|length }}
+    - Data: {{ data|length }}
+    - Tasks: {{ tasks|length }}
+    - Queues: {{ queues|length }}
+    - Posts: {{ posts|length }}
 
-    <br>
+    Details
 
-    <h3>Summary</h3>
-
-    <ul>
-        <li>Organizations: {{ organizations|length }}</li>
-        <li>Competitions owner: {{ competitions_organizer|length }} </li>
-        <li>Competitions participation: {{ competitions_participation|length }}</li>
-        <li>Submissions: {{ submissions|length }}</li>
-        <li>Data: {{ data|length }}</li>
-        <li>Tasks: {{ tasks|length }}</li>
-        <li>Queues: {{ queues|length }}</li>
-        <li>Posts: {{ posts|length }}</li>
-    </ul>
-
-    <h3>Details</h3>
-
-    <h4>Organizations the user is part of:</h4>
-    <ul>
-        {% for organization in organizations.all %}
-            <li>
-                <a class="item" href="{{ domain }}{% url 'profiles:organization_profile' pk=organization.id %}">
-                    {{ organization }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Competitions the user is the owner:</h4>
-    <ul>
-        {% for competition in competitions_organizer.all %}
-            <li>
-                <a class="item" href="{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
-                    {{ competition }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Competitions the user participated in:</h4>
-    <ul>
-        {% for competition in competitions_participation.all %}
-        <li>
-            <a class="item" href="{{ domain }}{% url 'competitions:detail' pk=competition.pk %}">
-                {{ competition }}
-            </a>
-        </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Submissions from the user:</h4>
-    <ul>
-        {% for submission in submissions.all %}
-        <li>
-            {{ submission }}
-        </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Data created by the user</h4>
-    <ul>
-        {% for d in data.all %}
-        <li>
-            {{ d }}
-        </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Tasks created by the user</h4>
-    <ul>
-        {% for task in tasks.all %}
-        <li>
-            <a class="item" href="{{ domain }}{% url 'tasks:detail' pk=task.pk %}">
-                {{ task }}
-            </a>
-        </li>
-        {% endfor %}
-    </ul>
-
-    <h4>Queues created by the user</h4>
-    <ul>
-        {% for queue in queues.all %}
-            <li>{{ queue }}</li>
-        {% endfor %}
-    </ul>
-
-    <h4>Posts posted by the user</h4>
-    <ul>
-        {% for post in posts.all %}
-            <li>{{ post }}</li>
-        {% endfor %}
-    </ul>
-
+    Organizations the user is part of:
+    {% for organization in organizations.all %}    - {{ organization }}: {{ protocol }}://{{ domain }}{% url 'profiles:organization_profile' pk=organization.id %}
+    {% endfor %}
+    Competitions the user is the owner:
+    {% for competition in competitions_organizer.all %}    - {{ competition }}: {{ protocol }}://{{ domain }}{% url 'competitions:detail' pk=competition.pk %}
+    {% endfor %}
+    Competitions the user participated in:
+    {% for competition in competitions_participation.all %}    - {{ competition }}: {{ protocol }}://{{ domain }}{% url 'competitions:detail' pk=competition.pk %}
+    {% endfor %}
+    Submissions from the user:
+    {% for submission in submissions.all %}    - {{ submission }}
+    {% endfor %}
+    Data created by the user:
+    {% for d in data.all %}    - {{ d }}
+    {% endfor %}
+    Tasks created by the user:
+    {% for task in tasks.all %}    - {{ task }}: {{ protocol }}://{{ domain }}{% url 'tasks:detail' pk=task.pk %}
+    {% endfor %}
+    Queues created by the user:
+    {% for queue in queues.all %}    - {{ queue }}
+    {% endfor %}
+    Posts posted by the user:
+    {% for post in posts.all %}    - {{ post }}
+    {% endfor %}
 {% endblock %}

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -6,6 +6,21 @@ from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
 
+def get_link_context(request=None):
+    """
+    Build the {domain, protocol} pair used for absolute links in email templates.
+
+    Pass `request` when one is available so the scheme matches how the user
+    actually connected (relevant behind a reverse proxy terminating TLS).
+    Omit it (e.g. from a model method with no request in scope) and it
+    defaults to 'https', since production is HTTPS-only.
+    """
+    return {
+        'domain': settings.DOMAIN_NAME,
+        'protocol': 'https' if request is None or request.is_secure() else 'http',
+    }
+
+
 def codalab_send_mail(context_data, to_email, html_file, text_file, subject, from_email=None):
     from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
 


### PR DESCRIPTION
# Description

- Add missing plain-text alternative for the account activation email, and send it via EmailMultiAlternatives instead of a plain-text-only EmailMessage.
- Rewrite 9 .txt templates that were literal copies of their .html counterparts (wrong , raw HTML tags) into proper plain text extending emails/base_email.txt.
- Replace hardcoded  + Sites-framework  links with  across participation, forum, invite, and account-deletion-notice emails; fix links in the account-deletion admin notice that had no scheme at all.
- Add get_link_context() in utils/email.py as the single place that builds protocol/domain for email templates, and switch all senders to use it.




# A checklist for email testing
### Account activation
- [ ] Sign up a new user, confirm the activation email arrives
- [ ] View the email's plain-text version — no raw HTML tags visible
- [ ] View the HTML version — renders with Codabench branding/signature/footer
- [ ] Activation link uses the test server's actual domain and scheme (not production)
- [ ] Clicking the link activates the account successfully

### Account deletion request
- [ ] Request account deletion, confirm the email arrives
- [ ] Plain-text version has no raw HTML tags
- [ ] Confirmation link uses the correct test-server domain/scheme
- [ ] Clicking the link completes the deletion flow

### Account deletion — admin notice
- [ ] Delete a user who has organizations, owned competitions, participations, submissions, data, tasks, queues, and posts
- [ ] Admin notice email arrives to superuser/staff accounts
- [ ] Plain-text version has no raw HTML tags
- [ ] Every listed link (organizations, competitions, tasks) resolves correctly with the right domain/scheme

### Account deletion — confirmed
- [ ] Complete a full deletion, confirm the "successfully removed" email arrives
- [ ] Plain-text version has no raw HTML tags

### Competition participation — requested
- [ ] Apply to a competition as a participant (non-auto-approve, non-whitelisted)
- [ ] Participant receives "application sent" email with a working competition link
- [ ] Organizer(s) receive "user applied" email with a working competition link
- [ ] Both plain-text versions have no raw HTML tags

### Competition participation — accepted
- [ ] Approve a pending participant (both manual approval and auto-approve/whitelist paths)
- [ ] Participant receives "accepted" email with a working competition link
- [ ] Organizer receives "accepted" email with a working competition link

### Competition participation — denied
- [ ] Deny a pending participant
- [ ] Participant receives "denied" email with a working competition link
- [ ] Organizer receives "denied" email with a working competition link


### Forum new-post notification
- [ ] Post a new reply in a competition forum thread where another user has forum notifications enabled
- [ ] Notification email arrives with a working thread link (correct domain/scheme)

### Organization invite
- [ ] Invite a user to an organization
- [ ] Invite email arrives with a working accept/reject link (correct domain/scheme)
- [ ] Accepting the invite works end-to-end

### General
- [ ] Confirm links point at the **test server's** domain, not production — verify `DOMAIN_NAME`/`EXTERNAL_DOMAIN_NAME` env vars on the test server are set correctly
- [ ] Spot-check that no email client (or "view plain text" toggle) shows literal `<p>`, `<a>`, `<ul>` etc. in any of the above


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

