### PR TITLE
Fix organizer username in participation request emails

### DIFF
--- a/src/apps/competitions/emails.py
+++ b/src/apps/competitions/emails.py
@@ -14,13 +14,16 @@ def send_participation_requested_emails(participant):
         'user': participant.user
     }
     # Notify Organizers
-    codalab_send_mail(
-        context_data=context,
-        subject=f'{participant.user.username} applied to your competition',
-        html_file="emails/participation/organizer/participation_requested.html",
-        text_file="emails/participation/organizer/participation_requested.txt",
-        to_email=get_organizer_emails(participant.competition)
-    )
+    for organizer in participant.competition.all_organizers:
+        if organizer.is_deleted:
+            continue
+        codalab_send_mail(
+            context_data={**context, 'user': organizer},
+            subject=f'{participant.user.username} applied to your competition',
+            html_file="emails/participation/organizer/participation_requested.html",
+            text_file="emails/participation/organizer/participation_requested.txt",
+            to_email=organizer.email
+        )
 
     # Notify User
     codalab_send_mail(

--- a/src/apps/competitions/tests/test_emails.py
+++ b/src/apps/competitions/tests/test_emails.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from competitions.emails import send_participation_requested_emails
+
+
+def test_participation_request_uses_each_recipient_as_email_user():
+    participant_user = SimpleNamespace(
+        username='participant', email='participant@example.com', is_deleted=False
+    )
+    organizers = [
+        SimpleNamespace(username='owner', email='owner@example.com', is_deleted=False),
+        SimpleNamespace(username='collaborator', email='collaborator@example.com', is_deleted=False),
+        SimpleNamespace(username='deleted', email='deleted@example.com', is_deleted=True),
+    ]
+    participant = SimpleNamespace(
+        user=participant_user,
+        competition=SimpleNamespace(title='Competition', all_organizers=organizers),
+    )
+
+    with mock.patch('competitions.emails.codalab_send_mail') as send_mail:
+        send_participation_requested_emails(participant)
+
+    assert [call.kwargs['to_email'] for call in send_mail.call_args_list] == [
+        'owner@example.com',
+        'collaborator@example.com',
+        'participant@example.com',
+    ]
+    assert [call.kwargs['context_data']['user'] for call in send_mail.call_args_list] == [
+        organizers[0],
+        organizers[1],
+        participant_user,
+    ]


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.

Participation request emails reused the participant context for organizer recipients, so the base template greeted organizers with the participant username. This sends an individual notification to each active organizer with their own user context while leaving the participant receipt unchanged.

# Issues this PR resolves

Fixes #2445

# A checklist for hand testing
- [ ] Apply to a non-auto-approved competition and verify each active organizer is greeted with their own username.
- [ ] Verify the participant still receives the application confirmation and deleted organizers receive no email.

# Any relevant files for testing
- `src/apps/competitions/tests/test_emails.py`

Tests:
- `.venv\Scripts\python.exe -m pytest src/apps/competitions/tests/test_emails.py -q` with `DOMAIN_NAME=localhost` and `DJANGO_SETTINGS_MODULE=settings.test` (1 passed)
- `.venv\Scripts\python.exe -m flake8 src/` (passed)

The full Docker/PostgreSQL suite was not run locally because Docker is unavailable on this Windows host; CircleCI covers that suite.

# Checklist
- [x] Code review by me
- [ ] Hand tested by me
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge