### PR TITLE
Improvement participant routing UI

### DIFF
--- a/src/apps/api/views/submissions.py
+++ b/src/apps/api/views/submissions.py
@@ -196,6 +196,31 @@ class SubmissionViewSet(ModelViewSet):
                 raise ValidationError('You must be apart of a organization to submit for them')
             if membership.group not in Membership.PARTICIPANT_GROUP:
                 raise ValidationError('You do not have participant permissions for this group')
+
+        submitted_queue_id = request.data.get('queue')
+        if submitted_queue_id is not None:
+            phase_id = request.data.get('phase')
+            if not phase_id:
+                raise ValidationError('Phase is required to validate the queue')
+            phase = get_object_or_404(Phase, pk=phase_id)
+            competition = phase.competition
+
+            try:
+                submitted_queue_id_int = int(submitted_queue_id)
+            except (TypeError, ValueError):
+                raise ValidationError('Invalid queue id')
+
+            allowed_queue_ids = set(
+                competition.participant_groups.filter(user_set=request.user)
+                .exclude(queue__isnull=True)
+                .values_list('queue_id', flat=True)
+            )
+            if competition.queue_id:
+                allowed_queue_ids.add(competition.queue_id)
+
+            if submitted_queue_id_int not in allowed_queue_ids:
+                raise PermissionDenied('You are not allowed to submit to this queue')
+
         return super(SubmissionViewSet, self).create(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):

--- a/src/apps/competitions/urls.py
+++ b/src/apps/competitions/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path('<int:pk>/groups/create/', views.competition_create_group, name='competition_create_group'),
     path('<int:pk>/groups/<int:group_id>/update/', views.competition_update_group),
     path('<int:pk>/groups/<int:group_id>/delete/', views.competition_delete_group),
+    path('<int:pk>/user_groups/', views.competition_user_groups, name='competition_user_groups'),
 ]

--- a/src/apps/competitions/views.py
+++ b/src/apps/competitions/views.py
@@ -2,6 +2,7 @@ import json
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, JsonResponse, HttpResponseForbidden, HttpResponseBadRequest, HttpResponseRedirect
 from django.views.generic import TemplateView, DetailView
+from django.views.decorators.http import require_GET
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Q
 from django.contrib.auth.decorators import login_required
@@ -422,3 +423,22 @@ def _group_display_name(stored_name, competition_pk):
     if stored_name.startswith(prefix):
         return stored_name[len(prefix):]
     return stored_name
+
+@login_required
+@require_GET
+def competition_user_groups(request, pk):
+    competition = get_object_or_404(Competition, pk=pk)
+    user = request.user
+
+    groups = competition.participant_groups.filter(user=user).distinct()
+
+    data = [
+        {
+            'id': g.id,
+            'name': _group_display_name(g.name, competition.pk),
+            'queue': g.queue.pk if g.queue else None,
+        }
+        for g in groups
+    ]
+
+    return JsonResponse(data, safe=False)

--- a/src/static/js/ours/client.js
+++ b/src/static/js/ours/client.js
@@ -347,6 +347,9 @@ CODALAB.api = {
     email_participant: (pk, message) => {
         return CODALAB.api.request('POST', `${URLS.API}participants/${pk}/send_email/`, {message: message})
     },
+    get_user_participant_groups: function (competition_id) {
+        return CODALAB.api.request('GET', `/competitions/${competition_id}/user_groups/`)
+    },
     /*---------------------------------------------------------------------
          Analytics
     ---------------------------------------------------------------------*/

--- a/src/static/riot/competitions/detail/submission_upload.tag
+++ b/src/static/riot/competitions/detail/submission_upload.tag
@@ -52,6 +52,27 @@
                     </div>
                 </div>
 
+                <div class="ui vertical accordion menu" style="width: 36%;" id="select_groups_accordion" if="{available_groups}">
+                    <div class="item">
+                        <a class="title">
+                            <i class="dropdown icon"></i>
+                            Submit to Group
+                        </a>
+                        <div class="content">
+                            <div class="ui form">
+                                <div class="grouped fields">
+                                    <div each="{group, index in available_groups}" class="field">
+                                        <div class="ui radio checkbox">
+                                            <input type="radio" name="selected_group" id="group-{group.id}" value="{group.id}" checked="{index === 0}">
+                                            <label for="group-{group.id}">{group.name}</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="ui six wide field">
                     <label>Submit as:
                     <span class="ui mini circular icon button"
@@ -177,6 +198,8 @@
         self.datasets = {}
         self.organizations = []
 
+        self.available_groups = []
+
         self.one('mount', function () {
             CODALAB.api.get_user_participant_organizations()
                 .done((data) => {
@@ -193,11 +216,17 @@
                 onClose: () => segment.hide(),
             })
 
-            // File upload handler
+            CODALAB.api.get_user_participant_groups(self.opts.competition.id)
+                .done((data) => {
+                    self.available_groups = data
+                    self.update()
+                    $('.ui.radio.checkbox', self.root).checkbox()
+                })
+
             $(self.refs.data_file.refs.file_input).on('change', self.check_can_upload)
             self.setup_autoscroll()
             self.setup_websocket()
-        }) 
+        })
         
         // Function to capture change of `submit as` dropdown
         // Redirect to Add organization if selected option is Add Organizaiton
@@ -460,6 +489,19 @@
             } else if(self.selected_tasks.length === 1){
                 task_ids_to_run = [self.selected_tasks[0].id]
             }
+
+            let queue_to_use = self.opts.competition.queue ? self.opts.competition.queue.id : null
+            if (self.available_groups.length > 0) {
+                let selected_group_id = $('input[name="selected_group"]:checked', self.root).val()
+                // si un seul groupe existe, il n'y a pas de radio visible mais on veut quand même router dessus
+                let effective_group = selected_group_id
+                    ? _.find(self.available_groups, g => String(g.id) === String(selected_group_id))
+                    : self.available_groups[0]
+                if (effective_group && effective_group.queue) {
+                    queue_to_use = effective_group.queue
+                }
+            }
+
             var data_file_metadata = {
                 type: 'submission',
                 competition: self.opts.competition.id
@@ -485,7 +527,7 @@
                         "fact_sheet_answers": self.get_fact_sheet_answers(),
                         "tasks": task_ids_to_run,
                         "organization": organization,
-                        "queue": self.opts.competition.queue ? self.opts.competition.queue.id : null
+                        "queue": queue_to_use
                     })
                         .done(function (data) {
                             CODALAB.events.trigger('new_submission_created', data)


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
UI improvement to display available groups for the participant. If the participant is inside of several groups (done by the organizer), the participant will be able to choose on which group the user wants to submit.  

# Issues this PR resolves
Big problem of UI design that requires a lot of intervention or handling by the organizer. 

<img width="470" height="324" alt="image" src="https://github.com/user-attachments/assets/fe540d1b-eb6c-4927-8eaf-765e8fd047ec" />

<img width="477" height="381" alt="image" src="https://github.com/user-attachments/assets/4e604b3d-fe84-4f95-b5e1-53f9421677e9" />


# A checklist for hand testing
- [ ] Add your self in more than one group.
- [ ] Check if you see the other groups you are not inside of.
- [ ] Choose group and submit

# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge

