### PR TITLE
Improve CircleCI logs and add env variable `SITE_WORKER_MEMORY_LIMIT`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,10 @@ jobs:
       #     no_output_timeout: 30m
       - store_artifacts:
           path: tests/test-results
+          when: always
       - store_artifacts:
           path: dockerLogs/
+          when: always
 
 workflows:
   build_and_test:

--- a/.env_circleci
+++ b/.env_circleci
@@ -14,6 +14,9 @@ FLOWER_BASIC_AUTH=root:password-you-should-change
 
 DJANGO_SETTINGS_MODULE=settings.test
 
+# Capped below the CI machine's 15 GB to avoid crash
+SITE_WORKER_MEMORY_LIMIT=2g
+
 # Minio local storage example
 MINIO_ACCESS_KEY=testkey
 MINIO_SECRET_KEY=testsecret

--- a/.env_circleci
+++ b/.env_circleci
@@ -14,8 +14,8 @@ FLOWER_BASIC_AUTH=root:password-you-should-change
 
 DJANGO_SETTINGS_MODULE=settings.test
 
-# Capped below the CI machine's 15 GB to avoid crash
-SITE_WORKER_MEMORY_LIMIT=2g
+# Cap memory limit for CircleCI
+SITE_WORKER_MEMORY_LIMIT=256m
 
 # Minio local storage example
 MINIO_ACCESS_KEY=testkey

--- a/.env_circleci
+++ b/.env_circleci
@@ -14,9 +14,6 @@ FLOWER_BASIC_AUTH=root:password-you-should-change
 
 DJANGO_SETTINGS_MODULE=settings.test
 
-# Cap memory limit for CircleCI
-SITE_WORKER_MEMORY_LIMIT=256m
-
 # Minio local storage example
 MINIO_ACCESS_KEY=testkey
 MINIO_SECRET_KEY=testsecret

--- a/.env_sample
+++ b/.env_sample
@@ -13,6 +13,9 @@ ALLOWED_HOSTS=localhost,example.com
 SUBMISSIONS_API_URL=http://django:8000/api
 MAX_EXECUTION_TIME_LIMIT=600 # time limit for the default queue (in seconds)
 
+# Memory limit for the site_worker container. Defaults to 15 GB (default competition quota)
+#SITE_WORKER_MEMORY_LIMIT=15g
+
 # Local domain definition
 DOMAIN_NAME=localhost:80
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 15GB
+          # RAM limit defaults to the default competition quota
+          memory: ${SITE_WORKER_MEMORY_LIMIT:-15g}
 
   compute_worker:
     command: ["celery -A compute_worker worker -l info -Q compute-worker -n compute-worker@%n"]


### PR DESCRIPTION
# Description

- Run **always** the "Uploading artifacts" steps in CircleCI to help with debug.
- New `SITE_WORKER_MEMORY_LIMIT` environment variable, default to 15 GB, to ease up the config.


# Checklist
- [ ] Code review by me 
- [ ] CircleCi tests are passing
- [ ] Ready to merge

