### PR TITLE
Always upload artifacts in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,10 @@ jobs:
       #     no_output_timeout: 30m
       - store_artifacts:
           path: tests/test-results
+          when: always
       - store_artifacts:
           path: dockerLogs/
+          when: always
 
 workflows:
   build_and_test:


### PR DESCRIPTION
# Description

Change CircleCI config to **always** run the "Uploading artifacts" steps, even if previous steps fail, in order to help with debugging.


# Checklist
- [ ] Code review by me 
- [ ] CircleCi tests are passing
- [ ] Ready to merge

